### PR TITLE
fix: avoid unconditional FORCE rebuild for submodule targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,10 @@ PG_DUCKDB_HEAD = .git/modules/third_party/pg_duckdb/HEAD
 DUCKDB_HEAD = .git/modules/third_party/pg_duckdb/modules/third_party/duckdb/HEAD
 DUCKLAKE_HEAD = .git/modules/third_party/ducklake/HEAD
 
+# Force rebuild only when the submodule working tree is dirty
+PG_DUCKDB_DIRTY := $(shell git -C $(PG_DUCKDB_DIR) diff-index --quiet HEAD 2>/dev/null || echo FORCE)
+DUCKLAKE_DIRTY  := $(shell git -C $(DUCKLAKE_DIR) diff-index --quiet HEAD 2>/dev/null || echo FORCE)
+
 $(PG_DUCKDB_HEAD):
 	git submodule update --init --recursive third_party/pg_duckdb
 
@@ -114,7 +118,7 @@ PG_DUCKDB_TARGET = $(PG_DUCKDB_DIR)/pg_duckdb$(DLSUFFIX)
 
 pg_duckdb: $(PG_DUCKDB_TARGET)
 
-$(PG_DUCKDB_TARGET): $(PG_DUCKDB_HEAD) FORCE
+$(PG_DUCKDB_TARGET): $(PG_DUCKDB_HEAD) $(PG_DUCKDB_DIRTY)
 	DUCKDB_BUILD_TYPE=$(DUCKDB_BUILD_TYPE) \
 	$(MAKE) -C $(PG_DUCKDB_DIR)
 
@@ -129,7 +133,7 @@ clean-pg_duckdb:
 # ---------------------------------------------------------------------------
 ducklake: $(DUCKLAKE_STATIC_LIB)
 
-$(DUCKLAKE_STATIC_LIB): $(DUCKLAKE_HEAD) $(DUCKDB_HEAD) FORCE
+$(DUCKLAKE_STATIC_LIB): $(DUCKLAKE_HEAD) $(DUCKDB_HEAD) $(DUCKLAKE_DIRTY)
 	DUCKDB_SRCDIR=$(DUCKDB_SRC_DIR) \
 	CMAKE_VARS="-DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0" \
 	DISABLE_SANITIZER=1 \


### PR DESCRIPTION
## Summary
- Replace the blanket `FORCE` prerequisite on `pg_duckdb` and `ducklake` build targets with a dirty-check using `git diff-index --quiet HEAD`
- Clean submodules now depend solely on the git HEAD file, eliminating false-positive rebuilds that re-entered the submodule build every time
- Dirty submodules (uncommitted changes) still trigger a rebuild via the `FORCE` phony target

## Test plan
- [ ] `make` on a clean checkout — should skip submodule rebuilds when HEAD hasn't changed
- [ ] Edit a file inside `third_party/ducklake/` → `make` — should trigger ducklake rebuild
- [ ] `git checkout` a different submodule commit → `make` — should trigger rebuild via HEAD change

🤖 Generated with [Claude Code](https://claude.com/claude-code)