### PR TITLE
fix: re-attach DuckLake catalog after DROP + CREATE EXTENSION

### DIFF
--- a/include/pgducklake/pgducklake_defs.hpp
+++ b/include/pgducklake/pgducklake_defs.hpp
@@ -1,3 +1,6 @@
+// PostgreSQL extension name
+#define PGDUCKLAKE_PG_EXTENSION "pg_ducklake"
+
 // Catalog in DuckDB
 #define PGDUCKLAKE_DUCKDB_CATALOG "pgducklake"
 #define PGDUCKLAKE_DUCKDB_CATALOG_QUOTED "'pgducklake'"

--- a/include/pgducklake/pgducklake_duckdb.hpp
+++ b/include/pgducklake/pgducklake_duckdb.hpp
@@ -21,3 +21,13 @@ void ducklake_load_extension(duckdb::DuckDB &db);
 
 /* Returns the DuckDB instance, used by FDW for column inference. */
 duckdb::DuckDB *ducklake_get_duckdb_database();
+
+/* Detach the "pgducklake" DuckLake catalog.  Called by the utility hook
+ * after DROP EXTENSION so that a subsequent CREATE EXTENSION can
+ * attach a fresh catalog. */
+void ducklake_detach_catalog();
+
+/* Attach the "pgducklake" DuckLake catalog.  Called during initial
+ * extension load (ducklake_load_extension) and on re-create
+ * (ducklake_initialize). */
+void ducklake_attach_catalog();

--- a/src/pgducklake_ddl.cpp
+++ b/src/pgducklake_ddl.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "pgducklake/pgducklake_defs.hpp"
+#include "pgducklake/pgducklake_duckdb.hpp"
 #include "pgducklake/pgducklake_duckdb_query.hpp"
 #include "pgducklake/pgducklake_guc.hpp"
 #include "pgducklake/pgducklake_metadata_manager.hpp"
@@ -129,8 +130,26 @@ DECLARE_PG_FUNCTION(ducklake_initialize) {
         (errcode(ERRCODE_DUPLICATE_SCHEMA),
          errmsg("DuckLake reserved schema \"ducklake\" is already in use")));
   }
-  // force creating DuckDB instance
-  pgducklake::ExecuteDuckDBQuery("SELECT 1", NULL);
+
+  // Force DuckDB initialization (no-op if already alive).
+  // On first CREATE: this triggers DuckDBManager::Initialize() which
+  //   calls ducklake_load_extension() -> ducklake_attach_catalog().
+  // On DROP+CREATE: DuckDB is already alive, the catalog was detached
+  //   by the utility hook during DROP, so we re-attach it here.
+  bool duckdb_already_initialized = (ducklake_get_duckdb_database() != nullptr);
+
+  const char *init_errmsg = nullptr;
+  int ret = pgducklake::ExecuteDuckDBQuery("SELECT 1", &init_errmsg);
+  if (ret != 0) {
+    ereport(ERROR,
+            (errcode(ERRCODE_INTERNAL_ERROR),
+             errmsg("failed to initialize DuckDB: %s",
+                    init_errmsg ? init_errmsg : "unknown error")));
+  }
+
+  if (duckdb_already_initialized) {
+    ducklake_attach_catalog();
+  }
 
   PG_RETURN_VOID();
 }

--- a/src/pgducklake_duckdb.cpp
+++ b/src/pgducklake_duckdb.cpp
@@ -1,8 +1,25 @@
 /*
- * pgducklake_duckdb.cpp — DuckDB-facing translation unit
+ * pgducklake_duckdb.cpp -- DuckLake catalog lifecycle in DuckDB
  *
- * This file includes DuckDB and DuckLake headers but NEVER PostgreSQL headers.
- * It provides the DuckLake extension lifecycle functions (init + load).
+ * Manages the "pgducklake" DuckLake catalog attached inside DuckDB.
+ * Two lifecycles exist:
+ *
+ *   First CREATE EXTENSION (DuckDB not yet initialized):
+ *     ducklake_initialize()          -- SQL script entry point
+ *       -> ExecuteDuckDBQuery("SELECT 1")
+ *           -> DuckDBManager::Initialize()
+ *               -> ducklake_load_extension()   [callback from pg_duckdb]
+ *                   -> LoadStaticExtension, Register metadata manager
+ *                   -> ducklake_attach_catalog()
+ *
+ *   DROP + CREATE EXTENSION (DuckDB already alive):
+ *     DROP EXTENSION pg_ducklake
+ *       -> DucklakeUtilityHook        [pgducklake_hooks.cpp]
+ *           -> ducklake_detach_catalog()
+ *     CREATE EXTENSION pg_ducklake
+ *       -> ducklake_initialize()
+ *           -> ExecuteDuckDBQuery("SELECT 1")   (no-op, DuckDB exists)
+ *           -> ducklake_attach_catalog()        (catalog was detached)
  *
  * Query execution against DuckDB is handled via pg_duckdb's raw_query() UDF
  * through PostgreSQL's SPI in the PostgreSQL-facing translation units.
@@ -34,13 +51,17 @@ duckdb::DuckDB *ducklake_get_duckdb_database() {
   return ducklake_duckdb_instance;
 }
 
-void ducklake_load_extension(duckdb::DuckDB &db) {
-  ducklake_duckdb_instance = &db;
-  db.LoadStaticExtension<duckdb::DucklakeExtension>();
-  pgducklake::RegisterTimeTravelFunction(*db.instance);
+void ducklake_detach_catalog() {
+  const char *errmsg;
+  int ret = pgducklake::ExecuteDuckDBQuery(
+      "DETACH DATABASE IF EXISTS " PGDUCKLAKE_DUCKDB_CATALOG, &errmsg);
+  if (ret != 0) {
+    elog(WARNING, "Failed to detach DuckLake catalog: %s",
+         errmsg ? errmsg : "unknown error");
+  }
+}
 
-  duckdb::DuckLakeMetadataManager::Register(
-      PGDUCKLAKE_DUCKDB_CATALOG, pgducklake::PgDuckLakeMetadataManager::Create);
+void ducklake_attach_catalog() {
   duckdb::string query = "ATTACH 'ducklake:" PGDUCKLAKE_DUCKDB_CATALOG
                          ":' AS " PGDUCKLAKE_DUCKDB_CATALOG
                          "(METADATA_SCHEMA " PGDUCKLAKE_PG_SCHEMA_QUOTED;
@@ -65,6 +86,16 @@ void ducklake_load_extension(duckdb::DuckDB &db) {
   int ret = pgducklake::ExecuteDuckDBQuery(query.c_str(), &errmsg);
 
   if (ret != 0) {
-    elog(ERROR, "Failed to execute query, error: %s", errmsg);
+    elog(ERROR, "Failed to attach DuckLake catalog: %s", errmsg);
   }
+}
+
+void ducklake_load_extension(duckdb::DuckDB &db) {
+  ducklake_duckdb_instance = &db;
+  db.LoadStaticExtension<duckdb::DucklakeExtension>();
+  pgducklake::RegisterTimeTravelFunction(*db.instance);
+
+  duckdb::DuckLakeMetadataManager::Register(
+      PGDUCKLAKE_DUCKDB_CATALOG, pgducklake::PgDuckLakeMetadataManager::Create);
+  ducklake_attach_catalog();
 }

--- a/src/pgducklake_hooks.cpp
+++ b/src/pgducklake_hooks.cpp
@@ -8,10 +8,14 @@
  *
  * Utility hook:
  * - catches explicit COMMIT utility statements and commits DuckDB early
+ * - detaches the DuckLake catalog on DROP EXTENSION pg_ducklake so that
+ *   a subsequent CREATE EXTENSION can re-attach a fresh catalog
  */
 
 #include "pgducklake/pgducklake_hooks.hpp"
+#include "pgducklake/pgducklake_defs.hpp"
 #include "pgducklake/pgducklake_direct_insert.hpp"
+#include "pgducklake/pgducklake_duckdb.hpp"
 #include "pgducklake/pgducklake_duckdb_query.hpp"
 #include "pgducklake/pgducklake_fdw.hpp"
 #include "pgducklake/pgducklake_guc.hpp"
@@ -67,6 +71,26 @@ void ForceDuckDBCommitOnExplicitCommit() {
                          duckdb_errmsg ? duckdb_errmsg : "unknown error")));
 }
 
+/*
+ * Check whether the statement is DROP EXTENSION pg_ducklake.
+ */
+bool IsDropDucklakeExtensionStmt(PlannedStmt *pstmt) {
+  if (!pstmt || !pstmt->utilityStmt || !IsA(pstmt->utilityStmt, DropStmt))
+    return false;
+
+  auto *drop = castNode(DropStmt, pstmt->utilityStmt);
+  if (drop->removeType != OBJECT_EXTENSION)
+    return false;
+
+  ListCell *lc;
+  foreach (lc, drop->objects) {
+    char *extname = strVal(lfirst(lc));
+    if (strcmp(extname, PGDUCKLAKE_PG_EXTENSION) == 0)
+      return true;
+  }
+  return false;
+}
+
 void DucklakeUtilityHook(PlannedStmt *pstmt, const char *query_string,
                          bool read_only_tree, ProcessUtilityContext context,
                          ParamListInfo params,
@@ -77,8 +101,15 @@ void DucklakeUtilityHook(PlannedStmt *pstmt, const char *query_string,
     ForceDuckDBCommitOnExplicitCommit();
   }
 
+  bool dropping_extension = IsDropDucklakeExtensionStmt(pstmt);
+
   prev_process_utility_hook(pstmt, query_string, read_only_tree, context,
                             params, query_env, dest, qc);
+
+  // After DROP EXTENSION completes, detach the DuckLake catalog from DuckDB
+  // so that a subsequent CREATE EXTENSION can attach a fresh one.
+  if (dropping_extension)
+    ducklake_detach_catalog();
 }
 
 } // namespace

--- a/test/regression/expected/initialization.out
+++ b/test/regression/expected/initialization.out
@@ -30,3 +30,14 @@ SELECT oid FROM pg_namespace WHERE nspname = 'ducklake';
 (0 rows)
 
 CREATE EXTENSION pg_ducklake;
+-- Verify catalog works after DROP+CREATE in same backend
+CREATE TABLE t2 (a int, b text) USING ducklake;
+INSERT INTO t2 VALUES (1, 'hello'), (2, 'world');
+SELECT * FROM t2;
+ a |   b   
+---+-------
+ 1 | hello
+ 2 | world
+(2 rows)
+
+DROP TABLE t2;

--- a/test/regression/sql/initialization.sql
+++ b/test/regression/sql/initialization.sql
@@ -17,3 +17,9 @@ DROP EXTENSION pg_ducklake;
 SELECT oid FROM pg_namespace WHERE nspname = 'ducklake';
 
 CREATE EXTENSION pg_ducklake;
+
+-- Verify catalog works after DROP+CREATE in same backend
+CREATE TABLE t2 (a int, b text) USING ducklake;
+INSERT INTO t2 VALUES (1, 'hello'), (2, 'world');
+SELECT * FROM t2;
+DROP TABLE t2;


### PR DESCRIPTION
## Summary
- After `DROP EXTENSION pg_ducklake` + `CREATE EXTENSION pg_ducklake` in the same backend, creating DuckLake tables failed with `Catalog "pgducklake" does not exist!` because the catalog was never re-attached
- Fix: detect `DROP EXTENSION pg_ducklake` in `ProcessUtility_hook` to detach the catalog, then re-attach it in `ducklake_initialize()` when DuckDB was already alive
- Extract `ducklake_attach_catalog()` / `ducklake_detach_catalog()` from `ducklake_load_extension()` for reuse across both lifecycle paths

## Test plan
- [x] All 20 regression tests pass (`make installcheck`)
- [x] All 2 isolation tests pass
- [x] New test case in `initialization.sql` verifies table creation works after DROP+CREATE cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)