### PR TITLE
chore: add open-pr Claude Code skill

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -16,9 +16,21 @@ git status -u                         # uncommitted changes
 git diff origin/main...HEAD --stat    # files changed vs base
 git log --oneline origin/main..HEAD   # commits to include
 git remote -v                         # available remotes
+git submodule status                  # check submodule state
 ```
 
-### 2. Create and push branch
+### 2. Handle submodule changes
+
+If any submodules have modifications (dirty or new commits):
+
+1. For each modified submodule, commit changes inside the submodule first.
+2. **Ask the user** which remote/branch to push each submodule to. Never assume.
+3. Push each submodule before proceeding.
+4. Back in the root project, stage the updated submodule pointers (`git add <submodule-path>`).
+
+**Critical:** The root project must only be pushed AFTER all submodules are pushed. CI clones submodules recursively and will fail if it cannot find the submodule commits.
+
+### 3. Create and push branch
 
 Derive a branch name from the commit subjects (e.g. `feat/snapshot-trigger`). If unsure, ask the user.
 
@@ -29,7 +41,7 @@ git push -u origin <branch-name>
 
 If already on a non-main branch, just push.
 
-### 3. Open the PR
+### 4. Open the PR
 
 Use `gh pr create`. Write a concise title (<70 chars) and a body with Summary + Test plan sections. Use a HEREDOC for the body:
 
@@ -46,7 +58,7 @@ EOF
 )"
 ```
 
-### 4. Report
+### 5. Report
 
 Print the PR URL so the user can see it.
 
@@ -56,3 +68,4 @@ Print the PR URL so the user can see it.
 - Prefer specific `git add` over `git add -A`.
 - If there are uncommitted changes, ask the user whether to commit them first.
 - If `Closes #N` applies, include it in the body.
+- Always push submodules before the root project -- CI will break otherwise.


### PR DESCRIPTION
## Summary
- Add a Claude Code skill for opening GitHub PRs, providing a standardized workflow for branch creation, push, and PR opening

## Test plan
- [x] Skill file is valid YAML frontmatter + markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)