### PR TITLE
docs: add CONTRIBUTING.md and MIT LICENSE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to pg_ducklake
+
+Thanks for your interest in pg_ducklake! All types of contributions are welcome.
+
+## You don't have to write code to help
+
+We develop in a **vibe coding style** -- AI coding assistants help us ship code fast. What we can't generate is *your* perspective as a user. The contributions that help us most are often:
+
+- **Bug reports** -- a short description with steps to reproduce is perfect.
+- **Feature requests** -- tell us what you wish pg_ducklake could do.
+- **Questions and discussions** -- confused by something? Others probably are too.
+- **Docs and examples** -- spotted something unclear? A small fix can save the next person a lot of time.
+
+Don't underestimate these -- a good bug report or feature idea can shape the project more than a pull request.
+
+## Code contributions are welcome too
+
+Bug fixes, new features, tests -- we're happy to review them. For anything non-trivial, please open an issue first so we can discuss the approach.
+
+## Reporting a bug
+
+Open an [issue](https://github.com/relytcloud/pg_ducklake/issues) with:
+
+1. What you did (SQL statements, configuration, environment)
+2. What you expected
+3. What actually happened (error messages, logs)
+
+## Suggesting a feature
+
+Open an issue describing:
+
+1. The problem you're trying to solve
+2. How you'd like it to work
+
+A few sentences is plenty. We'll figure out the details together.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pg_ducklake contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -143,9 +143,7 @@ GROUP BY "Pclass", "Sex";
 
 ## Contributing
 
-We welcome contributions! Please see:
-
-- [Issues](https://github.com/relytcloud/pg_ducklake/issues) for bug reports
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for how to get involved.
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` explaining that non-code contributions (bug reports, feature requests, discussions, docs) are especially valued since maintainers develop in vibe coding style
- Add MIT `LICENSE` file at project root
- Update `README.md` Contributing section to link to `CONTRIBUTING.md`

## Test plan
- [ ] Verify CONTRIBUTING.md renders correctly on GitHub
- [ ] Verify LICENSE is recognized by GitHub as MIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)