### PR TITLE
feat: add partitioned tables support

### DIFF
--- a/sql/pg_ducklake--0.1.0.sql
+++ b/sql/pg_ducklake--0.1.0.sql
@@ -151,6 +151,43 @@ CREATE PROCEDURE ducklake.flush_inlined_data(
 AS 'MODULE_PATHNAME', 'ducklake_flush_inlined_data'
 LANGUAGE C;
 
+-- set_partition / reset_partition procedures
+CREATE PROCEDURE ducklake.set_partition(scope regclass, VARIADIC partition_by text[])
+AS 'MODULE_PATHNAME', 'ducklake_set_partition'
+LANGUAGE C;
+
+CREATE PROCEDURE ducklake.reset_partition(scope regclass)
+AS 'MODULE_PATHNAME', 'ducklake_reset_partition'
+LANGUAGE C;
+
+-- get_partition: query partition metadata for a DuckLake table
+CREATE FUNCTION ducklake.get_partition(
+    scope regclass,
+    OUT partition_key_index bigint,
+    OUT column_name varchar,
+    OUT transform varchar
+)
+RETURNS SETOF record
+LANGUAGE SQL STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+SELECT pc.partition_key_index, c.column_name, pc.transform
+FROM ducklake.ducklake_partition_info pi
+JOIN ducklake.ducklake_partition_column pc USING (partition_id)
+JOIN ducklake.ducklake_column c
+  ON pc.column_id = c.column_id AND pc.table_id = c.table_id
+JOIN ducklake.ducklake_table t ON pi.table_id = t.table_id
+JOIN ducklake.ducklake_schema s ON t.schema_id = s.schema_id
+WHERE t.table_name = (SELECT relname FROM pg_class WHERE oid = scope)
+  AND s.schema_name = (SELECT nspname FROM pg_namespace
+                        WHERE oid = (SELECT relnamespace FROM pg_class WHERE oid = scope))
+  AND pi.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL
+  AND t.end_snapshot IS NULL
+  AND s.end_snapshot IS NULL
+ORDER BY pc.partition_key_index
+$$;
+
 -- time_travel by version (DuckDB-only — pg_duckdb routes the query to DuckDB)
 CREATE FUNCTION ducklake.time_travel(table_name text, version bigint)
 RETURNS SETOF duckdb.row

--- a/src/pgducklake_ddl.cpp
+++ b/src/pgducklake_ddl.cpp
@@ -27,7 +27,10 @@
 extern "C" {
 #include "postgres.h"
 
+#include "access/relation.h"
 #include "catalog/namespace.h"
+#include "catalog/pg_am.h"
+#include "commands/defrem.h"
 #include "commands/event_trigger.h"
 #include "commands/extension.h" // creating_extension
 #include "commands/trigger.h"
@@ -521,6 +524,87 @@ DECLARE_PG_FUNCTION(ducklake_set_option) {
                     errmsg("failed to set DuckLake option: %s",
                            error_msg ? error_msg : "unknown error")));
   }
+
+  PG_RETURN_VOID();
+}
+
+static void EnsureDuckLakeTable(Oid relid) {
+  static Oid ducklake_am_oid = InvalidOid;
+  if (!OidIsValid(ducklake_am_oid))
+    ducklake_am_oid = get_am_oid("ducklake", false);
+
+  Relation rel = relation_open(relid, AccessShareLock);
+  Oid am_oid = rel->rd_rel->relam;
+  relation_close(rel, AccessShareLock);
+
+  if (am_oid != ducklake_am_oid)
+    ereport(ERROR, (errcode(ERRCODE_WRONG_OBJECT_TYPE),
+                    errmsg("table \"%s\" is not a DuckLake table",
+                           get_rel_name(relid))));
+}
+
+DECLARE_PG_FUNCTION(ducklake_set_partition) {
+  if (PG_ARGISNULL(0))
+    elog(ERROR, "table cannot be NULL");
+  if (PG_ARGISNULL(1))
+    elog(ERROR, "partition_by cannot be NULL");
+
+  Oid relid = PG_GETARG_OID(0);
+  EnsureDuckLakeTable(relid);
+
+  ArrayType *arr = PG_GETARG_ARRAYTYPE_P(1);
+  if (ARR_NDIM(arr) == 0)
+    elog(ERROR, "partition_by cannot be empty");
+
+  int nelems;
+  Datum *elems;
+  bool *nulls;
+  deconstruct_array(arr, TEXTOID, -1, false, TYPALIGN_INT, &elems, &nulls,
+                    &nelems);
+
+  if (nelems == 0)
+    elog(ERROR, "partition_by cannot be empty");
+
+  std::string spec;
+  for (int i = 0; i < nelems; i++) {
+    if (nulls[i])
+      elog(ERROR, "partition key cannot be NULL");
+    if (i > 0)
+      spec += ", ";
+    spec += text_to_cstring(DatumGetTextPP(elems[i]));
+  }
+
+  std::string query = std::string("ALTER TABLE ") +
+                       pgduckdb_relation_name(relid) +
+                       " SET PARTITIONED BY (" + spec + ")";
+
+  const char *error_msg = nullptr;
+  int result = pgducklake::ExecuteDuckDBQuery(query.c_str(), &error_msg);
+  if (result != 0)
+    ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+                    errmsg("failed to set partition: %s",
+                           error_msg ? error_msg : "unknown error")));
+
+  PG_RETURN_VOID();
+}
+
+DECLARE_PG_FUNCTION(ducklake_reset_partition) {
+  if (PG_ARGISNULL(0))
+    elog(ERROR, "table cannot be NULL");
+
+  Oid relid = PG_GETARG_OID(0);
+  EnsureDuckLakeTable(relid);
+
+  std::string query = std::string("ALTER TABLE ") +
+                       pgduckdb_relation_name(relid) +
+                       " RESET PARTITIONED BY";
+
+  const char *error_msg = nullptr;
+  int result = pgducklake::ExecuteDuckDBQuery(query.c_str(), &error_msg);
+  if (result != 0)
+    ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+                    errmsg("failed to reset partition: %s",
+                           error_msg ? error_msg : "unknown error")));
 
   PG_RETURN_VOID();
 }

--- a/test/regression/expected/partition.out
+++ b/test/regression/expected/partition.out
@@ -1,0 +1,128 @@
+-- Test ducklake.set_partition() and ducklake.reset_partition()
+-- Disable data inlining so inserts create actual parquet files
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+-- 1. Basic column partition + metadata verification
+CREATE TABLE part_basic (id int, category text, val int) USING ducklake;
+CALL ducklake.set_partition('part_basic'::regclass, 'category');
+SELECT * FROM ducklake.get_partition('part_basic'::regclass);
+ partition_key_index | column_name | transform 
+---------------------+-------------+-----------
+                   0 | category    | identity
+(1 row)
+
+INSERT INTO part_basic VALUES (1, 'a', 10), (2, 'b', 20), (3, 'a', 30);
+SELECT * FROM part_basic ORDER BY id;
+ id | category | val 
+----+----------+-----
+  1 | a        |  10
+  2 | b        |  20
+  3 | a        |  30
+(3 rows)
+
+-- Verify file partition values
+SELECT fpv.partition_key_index, fpv.partition_value
+FROM ducklake.ducklake_file_partition_value fpv
+JOIN ducklake.ducklake_table t ON fpv.table_id = t.table_id
+WHERE t.table_name = 'part_basic'
+ORDER BY fpv.partition_key_index, fpv.partition_value;
+ partition_key_index | partition_value 
+---------------------+-----------------
+                   0 | a
+                   0 | b
+(2 rows)
+
+-- 2. Transform partition (year, month) + metadata verification
+CREATE TABLE part_ts (id int, ts timestamp, val int) USING ducklake;
+CALL ducklake.set_partition('part_ts'::regclass, 'year(ts)', 'month(ts)');
+SELECT * FROM ducklake.get_partition('part_ts'::regclass);
+ partition_key_index | column_name | transform 
+---------------------+-------------+-----------
+                   0 | ts          | year
+                   1 | ts          | month
+(2 rows)
+
+INSERT INTO part_ts VALUES (1, '2024-01-15', 10), (2, '2024-06-20', 20);
+SELECT * FROM part_ts ORDER BY id;
+ id |            ts            | val 
+----+--------------------------+-----
+  1 | Mon Jan 15 00:00:00 2024 |  10
+  2 | Thu Jun 20 00:00:00 2024 |  20
+(2 rows)
+
+-- 3. Multi-key partition
+CREATE TABLE part_multi (a text, b text, c int) USING ducklake;
+CALL ducklake.set_partition('part_multi'::regclass, 'a', 'b');
+SELECT * FROM ducklake.get_partition('part_multi'::regclass);
+ partition_key_index | column_name | transform 
+---------------------+-------------+-----------
+                   0 | a           | identity
+                   1 | b           | identity
+(2 rows)
+
+INSERT INTO part_multi VALUES ('x', 'y', 1), ('x', 'z', 2);
+SELECT * FROM part_multi ORDER BY c;
+ a | b | c 
+---+---+---
+ x | y | 1
+ x | z | 2
+(2 rows)
+
+-- 4. Set partition on table with existing data
+CREATE TABLE part_existing (id int, grp text, val int) USING ducklake;
+INSERT INTO part_existing VALUES (1, 'a', 10), (2, 'b', 20);
+SELECT * FROM part_existing ORDER BY id;
+ id | grp | val 
+----+-----+-----
+  1 | a   |  10
+  2 | b   |  20
+(2 rows)
+
+-- Set partition after data already exists
+CALL ducklake.set_partition('part_existing'::regclass, 'grp');
+-- Existing data should still be queryable
+SELECT * FROM part_existing ORDER BY id;
+ id | grp | val 
+----+-----+-----
+  1 | a   |  10
+  2 | b   |  20
+(2 rows)
+
+-- New inserts go into partitioned files
+INSERT INTO part_existing VALUES (3, 'a', 30), (4, 'c', 40);
+SELECT * FROM part_existing ORDER BY id;
+ id | grp | val 
+----+-----+-----
+  1 | a   |  10
+  2 | b   |  20
+  3 | a   |  30
+  4 | c   |  40
+(4 rows)
+
+-- 5. Reset partition + metadata verification
+CALL ducklake.reset_partition('part_basic'::regclass);
+-- Verify no active partition columns remain
+SELECT * FROM ducklake.get_partition('part_basic'::regclass);
+ partition_key_index | column_name | transform 
+---------------------+-------------+-----------
+(0 rows)
+
+INSERT INTO part_basic VALUES (4, 'c', 40);
+SELECT * FROM part_basic ORDER BY id;
+ id | category | val 
+----+----------+-----
+  1 | a        |  10
+  2 | b        |  20
+  3 | a        |  30
+  4 | c        |  40
+(4 rows)
+
+-- 6. Error: non-ducklake table
+CREATE TABLE heap_table (id int);
+CALL ducklake.set_partition('heap_table'::regclass, 'id');
+ERROR:  table "heap_table" is not a DuckLake table
+DROP TABLE heap_table;
+-- Cleanup (must happen before any error-inducing DuckDB queries)
+DROP TABLE part_basic;
+DROP TABLE part_ts;
+DROP TABLE part_multi;
+DROP TABLE part_existing;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -12,6 +12,7 @@ test: data_inlining_row_limit
 test: readme_examples
 test: ddl
 test: vacuum
+test: partition
 test: hybrid_scan
 test: time_travel
 test: freeze

--- a/test/regression/sql/partition.sql
+++ b/test/regression/sql/partition.sql
@@ -1,0 +1,76 @@
+-- Test ducklake.set_partition() and ducklake.reset_partition()
+
+-- Disable data inlining so inserts create actual parquet files
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+
+-- 1. Basic column partition + metadata verification
+CREATE TABLE part_basic (id int, category text, val int) USING ducklake;
+
+CALL ducklake.set_partition('part_basic'::regclass, 'category');
+
+SELECT * FROM ducklake.get_partition('part_basic'::regclass);
+
+INSERT INTO part_basic VALUES (1, 'a', 10), (2, 'b', 20), (3, 'a', 30);
+SELECT * FROM part_basic ORDER BY id;
+
+-- Verify file partition values
+SELECT fpv.partition_key_index, fpv.partition_value
+FROM ducklake.ducklake_file_partition_value fpv
+JOIN ducklake.ducklake_table t ON fpv.table_id = t.table_id
+WHERE t.table_name = 'part_basic'
+ORDER BY fpv.partition_key_index, fpv.partition_value;
+
+-- 2. Transform partition (year, month) + metadata verification
+CREATE TABLE part_ts (id int, ts timestamp, val int) USING ducklake;
+
+CALL ducklake.set_partition('part_ts'::regclass, 'year(ts)', 'month(ts)');
+
+SELECT * FROM ducklake.get_partition('part_ts'::regclass);
+
+INSERT INTO part_ts VALUES (1, '2024-01-15', 10), (2, '2024-06-20', 20);
+SELECT * FROM part_ts ORDER BY id;
+
+-- 3. Multi-key partition
+CREATE TABLE part_multi (a text, b text, c int) USING ducklake;
+
+CALL ducklake.set_partition('part_multi'::regclass, 'a', 'b');
+
+SELECT * FROM ducklake.get_partition('part_multi'::regclass);
+
+INSERT INTO part_multi VALUES ('x', 'y', 1), ('x', 'z', 2);
+SELECT * FROM part_multi ORDER BY c;
+
+-- 4. Set partition on table with existing data
+CREATE TABLE part_existing (id int, grp text, val int) USING ducklake;
+INSERT INTO part_existing VALUES (1, 'a', 10), (2, 'b', 20);
+SELECT * FROM part_existing ORDER BY id;
+
+-- Set partition after data already exists
+CALL ducklake.set_partition('part_existing'::regclass, 'grp');
+
+-- Existing data should still be queryable
+SELECT * FROM part_existing ORDER BY id;
+
+-- New inserts go into partitioned files
+INSERT INTO part_existing VALUES (3, 'a', 30), (4, 'c', 40);
+SELECT * FROM part_existing ORDER BY id;
+
+-- 5. Reset partition + metadata verification
+CALL ducklake.reset_partition('part_basic'::regclass);
+
+-- Verify no active partition columns remain
+SELECT * FROM ducklake.get_partition('part_basic'::regclass);
+
+INSERT INTO part_basic VALUES (4, 'c', 40);
+SELECT * FROM part_basic ORDER BY id;
+
+-- 6. Error: non-ducklake table
+CREATE TABLE heap_table (id int);
+CALL ducklake.set_partition('heap_table'::regclass, 'id');
+DROP TABLE heap_table;
+
+-- Cleanup (must happen before any error-inducing DuckDB queries)
+DROP TABLE part_basic;
+DROP TABLE part_ts;
+DROP TABLE part_multi;
+DROP TABLE part_existing;


### PR DESCRIPTION
## Summary
- Add `ducklake.set_partition(regclass, VARIADIC text[])` to set file-level partitioning with transform support (`year`, `month`, `day`, `hour`)
- Add `ducklake.reset_partition(regclass)` to remove partitioning
- Add `ducklake.get_partition(regclass)` SQL function to query partition metadata
- New regression test covering column/transform/multi-key partitions, existing-data behavior, reset, and error cases

## Test plan
- [x] `make installcheck TEST=partition` passes
- [x] Full regression suite (22/22 tests pass)
- [ ] Verify on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)