### PR TITLE
feat(docker): add gdb to debug tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ USER root
 
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
-    procps vim-tiny less curl net-tools iputils-ping htop lsof strace && \
+    procps vim-tiny less curl net-tools iputils-ping htop lsof strace gdb && \
     ln -sf /usr/bin/vim.tiny /usr/bin/vim && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Add GDB to the full Docker image's debug toolset for crash analysis and core dump inspection of PostgreSQL/DuckDB processes

## Test plan
- [ ] Verify Docker image builds successfully
- [ ] Verify `gdb` is available in the full image (`docker run --rm pgducklake/pgducklake gdb --version`)
- [ ] Verify the slim image is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)