### PR TITLE
fix: correct UUID byte order in PG-to-DuckDB conversion

### DIFF
--- a/src/pgducklake_pg_types.cpp
+++ b/src/pgducklake_pg_types.cpp
@@ -319,10 +319,19 @@ void ConvertPostgresToDuckValue(Oid attr_type, Datum value, duckdb::Vector &resu
 
   case UUIDOID: {
     pg_uuid_t *pg_uuid = DatumGetUUIDP(value);
-    duckdb::hugeint_t uuid_value;
-    // Copy UUID bytes
-    memcpy(&uuid_value, pg_uuid->data, 16);
-    duckdb::FlatVector::GetData<duckdb::hugeint_t>(result)[offset] = uuid_value;
+    // pg_uuid->data is 16 bytes in big-endian (RFC 4122) byte order.
+    // DuckDB stores UUIDs as hugeint_t with a sign-bit flip for sort order,
+    // so we must read the raw bytes as big-endian and apply FromUHugeint.
+    uint64_t upper = 0, lower = 0;
+    for (int i = 0; i < 8; i++) {
+      upper = (upper << 8) | pg_uuid->data[i];
+      lower = (lower << 8) | pg_uuid->data[i + 8];
+    }
+    duckdb::uhugeint_t raw;
+    raw.upper = upper;
+    raw.lower = lower;
+    duckdb::FlatVector::GetData<duckdb::hugeint_t>(result)[offset] =
+        duckdb::UUID::FromUHugeint(raw);
     break;
   }
 

--- a/test/regression/expected/types.out
+++ b/test/regression/expected/types.out
@@ -35,7 +35,7 @@ INSERT INTO types_native VALUES (
 SELECT * FROM types_native;
  b | i2 | i4 | i8 | f4  | f8  |    t     |      ttz       |       iv        |                  u                   
 ---+----+----+----+-----+-----+----------+----------------+-----------------+--------------------------------------
- t |  1 |  2 |  3 | 1.5 | 2.5 | 12:30:00 | 12:30:00+05:30 | @ 1 day 30 mins | 910a38bd-b96b-6dbb-f84e-0b9c99bceea0
+ t |  1 |  2 |  3 | 1.5 | 2.5 | 12:30:00 | 12:30:00+05:30 | @ 1 day 30 mins | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
 (1 row)
 
 -- Get inlined table name


### PR DESCRIPTION
## Summary
- Fix UUID byte-reversal bug in `ConvertPostgresToDuckValue()`: the previous `memcpy` copied big-endian UUID bytes directly into a little-endian `hugeint_t`, producing reversed UUIDs when read back via DuckLake queries.
- Read `pg_uuid_t->data` bytes as big-endian upper/lower uint64 values and apply `UUID::FromUHugeint()` for the DuckDB sign-bit flip.
- Update `types.out` expected output to match the correct UUID.

## Test plan
- [ ] `make installcheck TEST=types` passes with correct UUID round-trip
- [ ] Verify other native types in the same test are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)