### PR TITLE
fix: use archive basename for --exclude-libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ ifeq ($(shell uname -s), Darwin)
 	SHLIB_LINK += -Wl,-force_load,$(DUCKLAKE_STATIC_LIB)
 else
 	SHLIB_LINK += -Wl,--whole-archive $(DUCKLAKE_STATIC_LIB) -Wl,--no-whole-archive
-	SHLIB_LINK += -Wl,--exclude-libs,$(DUCKLAKE_STATIC_LIB)
+	SHLIB_LINK += -Wl,--exclude-libs,$(notdir $(DUCKLAKE_STATIC_LIB))
 endif
 
 # Link against libduckdb from PG_LIB (installed by pg_duckdb)


### PR DESCRIPTION
Follow-up to #90. GNU ld's `--exclude-libs` matches by archive **filename**, not full path. The previous `--exclude-libs,$(DUCKLAKE_STATIC_LIB)` passed an absolute path which ld couldn't match, so no symbols were actually hidden.

Use `$(notdir ...)` to extract just `libducklake_extension.a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)