### PR TITLE
fix: survive duckdb.recycle_ddb() without metadata manager error

### DIFF
--- a/src/pgducklake_duckdb.cpp
+++ b/src/pgducklake_duckdb.cpp
@@ -21,6 +21,15 @@
  *           -> ExecuteDuckDBQuery("SELECT 1")   (no-op, DuckDB exists)
  *           -> ducklake_attach_catalog()        (catalog was detached)
  *
+ *   duckdb.recycle_ddb() (DuckDB instance destroyed and recreated):
+ *     recycle_ddb()
+ *       -> DuckDBManager::Reset()               [destroys DuckDB instance]
+ *     next query
+ *       -> DuckDBManager::Initialize()
+ *           -> ducklake_load_extension()         [callback from pg_duckdb]
+ *               -> LoadStaticExtension, skip metadata manager (already registered)
+ *               -> ducklake_attach_catalog()
+ *
  * Query execution against DuckDB is handled via pg_duckdb's raw_query() UDF
  * through PostgreSQL's SPI in the PostgreSQL-facing translation units.
  */
@@ -99,7 +108,15 @@ void ducklake_load_extension(duckdb::DuckDB &db) {
   pgducklake::RegisterCleanupFunction(*db.instance);
   pgducklake::RegisterFlushInlinedDataFunction(*db.instance);
 
-  duckdb::DuckLakeMetadataManager::Register(
-      PGDUCKLAKE_DUCKDB_CATALOG, pgducklake::PgDuckLakeMetadataManager::Create);
+  /* The metadata manager registry is a process-global static map that
+   * survives DuckDB instance destruction (e.g. duckdb.recycle_ddb()).
+   * Register only once per backend lifetime. */
+  static bool metadata_manager_registered = false;
+  if (!metadata_manager_registered) {
+    duckdb::DuckLakeMetadataManager::Register(
+        PGDUCKLAKE_DUCKDB_CATALOG,
+        pgducklake::PgDuckLakeMetadataManager::Create);
+    metadata_manager_registered = true;
+  }
   ducklake_attach_catalog();
 }

--- a/test/regression/expected/recycle_ddb.out
+++ b/test/regression/expected/recycle_ddb.out
@@ -1,0 +1,28 @@
+-- Verify DuckLake works after duckdb.recycle_ddb() destroys and
+-- recreates the DuckDB instance (GitHub issue #81).
+CREATE TABLE t (a int, b text) USING ducklake;
+INSERT INTO t VALUES (1, 'before');
+SELECT * FROM t;
+ a |   b    
+---+--------
+ 1 | before
+(1 row)
+
+CALL duckdb.recycle_ddb();
+-- The metadata manager factory is registered in a process-global static
+-- map, so it survives the recycle. The catalog must be re-attached.
+SELECT * FROM t;
+ a |   b    
+---+--------
+ 1 | before
+(1 row)
+
+INSERT INTO t VALUES (2, 'after');
+SELECT * FROM t ORDER BY a;
+ a |   b    
+---+--------
+ 1 | before
+ 2 | after
+(2 rows)
+
+DROP TABLE t;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -1,4 +1,5 @@
 test: initialization
+test: recycle_ddb
 test: ddl_triggers
 test: basic
 test: transaction

--- a/test/regression/sql/recycle_ddb.sql
+++ b/test/regression/sql/recycle_ddb.sql
@@ -1,0 +1,16 @@
+-- Verify DuckLake works after duckdb.recycle_ddb() destroys and
+-- recreates the DuckDB instance (GitHub issue #81).
+
+CREATE TABLE t (a int, b text) USING ducklake;
+INSERT INTO t VALUES (1, 'before');
+SELECT * FROM t;
+
+CALL duckdb.recycle_ddb();
+
+-- The metadata manager factory is registered in a process-global static
+-- map, so it survives the recycle. The catalog must be re-attached.
+SELECT * FROM t;
+INSERT INTO t VALUES (2, 'after');
+SELECT * FROM t ORDER BY a;
+
+DROP TABLE t;


### PR DESCRIPTION
## Summary

- Guard `DuckLakeMetadataManager::Register()` with a static flag so it only runs once per backend lifetime, fixing the "Metadata manager with name 'pgducklake' already exists!" error after `duckdb.recycle_ddb()`
- The registry is a process-global static map that survives DuckDB instance destruction -- re-registration on reinit is redundant and throws
- Added `recycle_ddb` regression test covering insert/select across a recycle cycle

Closes #81

## Test plan

- [x] New `recycle_ddb` regression test passes
- [x] Full regression suite (28 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)