### PR TITLE
fix: survive initdb when pg_ducklake is in shared_preload_libraries

### DIFF
--- a/src/pgducklake_direct_insert.cpp
+++ b/src/pgducklake_direct_insert.cpp
@@ -294,7 +294,9 @@ static bool TryDetectDirectInsertPattern(Query *parse,
   // Check 4: Target table must use ducklake access method
   static Oid ducklake_am_oid = InvalidOid;
   if (!OidIsValid(ducklake_am_oid))
-    ducklake_am_oid = get_am_oid("ducklake", false);
+    ducklake_am_oid = get_am_oid("ducklake", true);
+  if (!OidIsValid(ducklake_am_oid))
+    return false;
   Relation target_rel = relation_open(target_oid, AccessShareLock);
   Oid am_oid = target_rel->rd_rel->relam;
 


### PR DESCRIPTION
## Summary

- `initdb` crashes with `FATAL: access method "ducklake" does not exist` when `shared_preload_libraries = 'pg_duckdb,pg_ducklake'`
- Root cause: `TryDetectDirectInsertPattern()` calls `get_am_oid("ducklake", false)` on every INSERT query via the planner hook -- during initdb's post-bootstrap `INSERT INTO pg_description`, the ducklake AM doesn't exist yet
- Fix: use `missing_ok=true` and return false when the AM is absent; the static cache re-checks until the OID becomes valid after `CREATE EXTENSION`

## Test plan

- [x] Reproduced: `initdb` fails without the fix
- [x] Verified: `initdb` succeeds with the fix
- [x] All 29 regression tests pass
- [x] All 3 isolation tests pass
- [x] No side effects: static OID cache re-lookups until AM exists, then caches normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)