### PR TITLE
docs: add work-on-issue skill and clean up build instructions

### DIFF
--- a/.claude/skills/work-on-issue/SKILL.md
+++ b/.claude/skills/work-on-issue/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: work-on-issue
+description: "End-to-end workflow for working on a GitHub issue: create a worktree, fetch the issue, plan, implement, simplify, and open a PR. Use this skill whenever the user says '/work-on-issue' followed by a GitHub issue number. Also trigger when the user says things like 'work on issue #N', 'pick up issue N', 'start issue #N', or 'implement #N'."
+user-invocable: true
+---
+
+# Work on Issue
+
+End-to-end workflow that takes a GitHub issue from triage to pull request.
+Accepts a GitHub issue number as argument (e.g., `#42` or `42`).
+
+## Workflow
+
+Execute these phases in order. Each phase has a clear checkpoint --
+do not skip ahead without completing the current phase.
+
+### Phase 1: Worktree and environment
+
+1. Parse the issue number from the argument (strip leading `#` if present).
+2. Create an isolated worktree via `EnterWorktree` (name: `issue-<number>`).
+3. Run `/setup-dev` inside the new worktree.
+
+### Phase 2: Understand the issue
+
+```bash
+gh issue view <number>
+gh issue view <number> --comments
+```
+
+Summarize the issue to the user in 2-3 sentences for confirmation.
+
+### Phase 3: Plan
+
+Use `EnterPlanMode` to design the implementation. Explore code paths,
+write a concrete plan (files to change, how to test), then
+`ExitPlanMode` for user approval.
+
+Do not write code until the user approves the plan.
+
+### Phase 4: Implement
+
+Code the solution following the approved plan. Build and run tests
+per CLAUDE.md. Stop after 3 failed attempts and ask the user.
+
+### Phase 5: Simplify
+
+Run `/simplify` and apply any fixes it surfaces.
+
+### Phase 6: User review
+
+Present a change summary (files changed, design decisions, test
+results). Wait for the user to confirm or request adjustments.
+
+### Phase 7: Open PR
+
+Run `/pr`. Include `Closes #<issue-number>` in the PR body.
+
+## Notes
+
+- If any phase fails, stop gracefully -- the worktree remains for
+  manual follow-up.
+- This workflow pauses for user confirmation at the plan (phase 3)
+  and review (phase 6) checkpoints. Do not auto-proceed past those.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,11 @@ Supported PostgreSQL versions: 14, 15, 16, 17, 18.
 `PG_CONFIG` is required. Usually a local pg is installed under workdir, e.g. `PG_CONFIG=$(pwd)/pg-18/bin/pg_config`, to avoid conflicts with other worktrees. If neither local pg nor global pg is found, stop and ask user.
 
 ```bash
-git submodule update --init --recursive
-PG_CONFIG=<pg_config> make install
+# macOS add:
+# LIBRARY_PATH="$(brew --prefix)/lib:$LIBRARY_PATH"
+
+NCPU=$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+PG_CONFIG=<pg_config> make -j"$NCPU" && make install
 PG_CONFIG=<pg_config> make installcheck # build, install, and runs both regression + isolation
 
 # Run single regression test
@@ -100,9 +103,6 @@ PG_CONFIG=<pg_config> make check-regression TEST=basic
 
 # Run single isolation test
 PG_CONFIG=<pg_config> make check-isolation TEST=concurrent_writes
-
-# macOS: if linker errors, add:
-# LIBRARY_PATH="$(brew --prefix)/lib:$LIBRARY_PATH"
 ```
 
 Tests live in `test/regression/` (SQL regression) and `test/isolation/` (concurrency specs). Use regression and isolation tests to verify functionality as possible.


### PR DESCRIPTION
## Summary
- Add `.claude/skills/work-on-issue/SKILL.md` -- a 7-phase workflow skill that orchestrates issue-to-PR: worktree creation, issue fetch, plan mode, implementation, `/simplify`, user review, and `/pr`
- Clean up `CLAUDE.md` build section: use parallel `make -j`, move macOS `LIBRARY_PATH` note to the top, remove redundant `git submodule` step (handled by Makefile)