### PR TITLE
test: add regression test for force_execution deadlock

### DIFF
--- a/test/regression/expected/force_execution.out
+++ b/test/regression/expected/force_execution.out
@@ -1,0 +1,30 @@
+-- Regression: force_execution must not deadlock on first query (#76).
+-- DuckDB initialization runs ATTACH which holds the ClientContext mutex;
+-- SPI metadata reads must bypass the planner hook to avoid re-locking it.
+SET duckdb.force_execution TO true;
+CREATE TABLE fe_t (a int, b int) USING ducklake;
+INSERT INTO fe_t VALUES (1, 10), (2, 20);
+-- The original reproducer was EXPLAIN, but its output is volatile (DuckDB plan
+-- formatting changes across versions).  A plain SELECT exercises the same
+-- DuckDB initialization path that triggered the deadlock.
+SELECT * FROM fe_t ORDER BY a;
+ a | b  
+---+----
+ 1 | 10
+ 2 | 20
+(2 rows)
+
+-- Hybrid scan (heap + ducklake) under force_execution.
+CREATE TABLE fe_heap (id int);
+INSERT INTO fe_heap VALUES (1);
+SELECT (SELECT count(*) FROM fe_heap) AS heap_count,
+       (SELECT count(*) FROM fe_t)    AS lake_count;
+ heap_count | lake_count 
+------------+------------
+          1 |          2
+(1 row)
+
+-- Reset before cleanup to avoid noisy DuckDB warnings on event triggers.
+RESET duckdb.force_execution;
+DROP TABLE fe_heap;
+DROP TABLE fe_t;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -19,6 +19,7 @@ test: vacuum
 test: partition
 test: sorted_table
 test: hybrid_scan
+test: force_execution
 test: time_travel
 test: snapshots
 test: data_change_feed

--- a/test/regression/sql/force_execution.sql
+++ b/test/regression/sql/force_execution.sql
@@ -1,0 +1,24 @@
+-- Regression: force_execution must not deadlock on first query (#76).
+-- DuckDB initialization runs ATTACH which holds the ClientContext mutex;
+-- SPI metadata reads must bypass the planner hook to avoid re-locking it.
+SET duckdb.force_execution TO true;
+
+CREATE TABLE fe_t (a int, b int) USING ducklake;
+INSERT INTO fe_t VALUES (1, 10), (2, 20);
+
+-- The original reproducer was EXPLAIN, but its output is volatile (DuckDB plan
+-- formatting changes across versions).  A plain SELECT exercises the same
+-- DuckDB initialization path that triggered the deadlock.
+SELECT * FROM fe_t ORDER BY a;
+
+-- Hybrid scan (heap + ducklake) under force_execution.
+CREATE TABLE fe_heap (id int);
+INSERT INTO fe_heap VALUES (1);
+SELECT (SELECT count(*) FROM fe_heap) AS heap_count,
+       (SELECT count(*) FROM fe_t)    AS lake_count;
+
+-- Reset before cleanup to avoid noisy DuckDB warnings on event triggers.
+RESET duckdb.force_execution;
+
+DROP TABLE fe_heap;
+DROP TABLE fe_t;


### PR DESCRIPTION
## Summary
- Adds regression test exercising `duckdb.force_execution = true` as the first DuckDB-triggering query in a session
- Previously this deadlocked because SPI metadata reads during DuckDB initialization were re-routed through `DuckdbPlannerHook`, which tried to lock the `ClientContext` mutex already held by the ATTACH path
- `ForceExecutionGuard` (introduced in a99855b) already prevents this; this test ensures the guard is not accidentally removed

Closes #76

## Test plan
- `force_execution` regression test: SET force_execution, CREATE/INSERT/SELECT on a ducklake table, hybrid scan (heap + ducklake), then cleanup
- Full suite: all 31 regression + 3 isolation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)