### PR TITLE
fix: move PGXS include before format targets to fix Docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,11 @@ ifeq ($(shell uname -s), Darwin)
 endif
 
 # ---------------------------------------------------------------------------
+# PGXS (must come before any target rules so PGXS's "all" is the default)
+# ---------------------------------------------------------------------------
+include Makefile.global
+
+# ---------------------------------------------------------------------------
 # Code formatting (project files only, not third_party/)
 # ---------------------------------------------------------------------------
 FORMAT_FILES = $(shell find src/ include/ -name '*.cpp' -o -name '*.hpp' -o -name '*.h')
@@ -82,11 +87,6 @@ format:
 
 check-format:
 	clang-format --dry-run -Werror $(FORMAT_FILES)
-
-# ---------------------------------------------------------------------------
-# PGXS
-# ---------------------------------------------------------------------------
-include Makefile.global
 
 # install-pg_duckdb is pulled in via $(shlib) dependency
 


### PR DESCRIPTION
## Summary

- The `format:` rule was the first target rule in the Makefile, making it GNU Make's default target
- Docker build runs `make -j$(nproc)` without an explicit target, so it tried to run `clang-format` (not installed in the image) instead of PGXS's `all` target
- Moved `include Makefile.global` above the formatting rules so `all` becomes the default

Fixes the "Build Docker" CI failure introduced in #110.

## Test plan

- [x] `make -n` dry-run confirms default target is now compilation, not `format`
- [ ] Docker build CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)