### PR TITLE
feat: COMMENT ON trigger and schema evolution DDL tests

### DIFF
--- a/sql/pg_ducklake--0.1.0.sql
+++ b/sql/pg_ducklake--0.1.0.sql
@@ -104,6 +104,16 @@ CREATE EVENT TRIGGER ducklake_alter_table_trigger ON ddl_command_end
     WHEN tag IN ('ALTER TABLE')
     EXECUTE FUNCTION ducklake._alter_table_trigger();
 
+CREATE FUNCTION ducklake._comment_trigger()
+    RETURNS event_trigger
+    SET search_path = pg_catalog, pg_temp
+    AS 'MODULE_PATHNAME', 'ducklake_comment_trigger'
+    LANGUAGE C;
+
+CREATE EVENT TRIGGER ducklake_comment_trigger ON ddl_command_end
+    WHEN tag IN ('COMMENT')
+    EXECUTE FUNCTION ducklake._comment_trigger();
+
 -- Metadata sync trigger function: DuckDB->PG catalog sync.
 -- When an external DuckDB client creates/drops tables (writing directly to
 -- ducklake metadata tables), this trigger creates/drops corresponding

--- a/src/pgducklake_table.cpp
+++ b/src/pgducklake_table.cpp
@@ -3,7 +3,7 @@
  *
  * @scope extension: ducklake table AM handler, DDL event triggers
  *   (ducklake_create_table_trigger, ducklake_drop_table_trigger,
- *   ducklake_alter_table_trigger), EnsureDuckLakeTable
+ *   ducklake_alter_table_trigger, ducklake_comment_trigger), EnsureDuckLakeTable
  * @scope duckdb-instance: SyncNewTables, SyncDroppedTables (snapshot sync)
  *
  * Provides the PostgreSQL TableAM implementation for DuckLake tables and
@@ -846,6 +846,94 @@ DECLARE_PG_FUNCTION(ducklake_alter_table_trigger) {
   if (result != 0) {
     ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
                     errmsg("failed to alter DuckLake table: %s", error_msg ? error_msg : "unknown error")));
+  }
+
+  PG_RETURN_NULL();
+}
+
+DECLARE_PG_FUNCTION(ducklake_comment_trigger) {
+  if (pgducklake::syncing_from_metadata)
+    PG_RETURN_NULL();
+
+  if (!CALLED_AS_EVENT_TRIGGER(fcinfo))
+    elog(ERROR, "not fired by event trigger manager");
+
+  EventTriggerData *trigger_data = (EventTriggerData *)fcinfo->context;
+  Node *parsetree = trigger_data->parsetree;
+
+  if (!IsA(parsetree, CommentStmt))
+    PG_RETURN_NULL();
+
+  CommentStmt *comment_stmt = (CommentStmt *)parsetree;
+
+  /* Only handle table and column comments */
+  if (comment_stmt->objtype != OBJECT_TABLE && comment_stmt->objtype != OBJECT_COLUMN)
+    PG_RETURN_NULL();
+
+  SPI_connect();
+
+  auto save_nestlevel = NewGUCNestLevel();
+  SetConfigOption("search_path", "pg_catalog, pg_temp", PGC_USERSET, PGC_S_SESSION);
+  SetConfigOption("duckdb.force_execution", "false", PGC_USERSET, PGC_S_SESSION);
+
+  int ret = SPI_exec(R"(
+		SELECT DISTINCT cmds.objid AS relid, cmds.objsubid
+		FROM pg_catalog.pg_event_trigger_ddl_commands() cmds
+		JOIN pg_catalog.pg_class
+		ON cmds.objid = pg_class.oid
+		WHERE cmds.object_type IN ('table', 'table column')
+		AND pg_class.relam = (SELECT oid FROM pg_am WHERE amname = 'ducklake')
+		)",
+                     0);
+
+  if (ret != SPI_OK_SELECT)
+    elog(ERROR, "SPI_exec failed: error code %s", SPI_result_code_string(ret));
+
+  if (SPI_processed == 0) {
+    AtEOXact_GUC(false, save_nestlevel);
+    SPI_finish();
+    PG_RETURN_NULL();
+  }
+
+  HeapTuple tuple = SPI_tuptable->vals[0];
+  bool isnull;
+  Datum relid_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 1, &isnull);
+  if (isnull)
+    elog(ERROR, "Expected relid to be returned, but found NULL");
+
+  Oid relid = DatumGetObjectId(relid_datum);
+
+  Datum subid_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 2, &isnull);
+  int32 objsubid = isnull ? 0 : DatumGetInt32(subid_datum);
+
+  AtEOXact_GUC(false, save_nestlevel);
+  SPI_finish();
+
+  /* Build DuckDB COMMENT SQL */
+  std::string comment_ddl;
+  std::string rel_name(pgduckdb_relation_name(relid));
+
+  if (objsubid > 0) {
+    char *col_name = get_attname(relid, (AttrNumber)objsubid, false);
+    comment_ddl =
+        "COMMENT ON COLUMN " + rel_name + "." + duckdb::KeywordHelper::WriteOptionallyQuoted(col_name) + " IS ";
+  } else {
+    comment_ddl = "COMMENT ON TABLE " + rel_name + " IS ";
+  }
+
+  if (comment_stmt->comment != nullptr) {
+    comment_ddl += quote_literal_cstr(comment_stmt->comment);
+  } else {
+    comment_ddl += "NULL";
+  }
+
+  elog(DEBUG1, "COMMENT DDL for DuckLake: %s", comment_ddl.c_str());
+
+  const char *error_msg = nullptr;
+  int result = pgducklake::ExecuteDuckDBQuery(comment_ddl.c_str(), &error_msg);
+  if (result != 0) {
+    ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+                    errmsg("failed to set DuckLake comment: %s", error_msg ? error_msg : "unknown error")));
   }
 
   PG_RETURN_NULL();

--- a/test/regression/expected/ddl.out
+++ b/test/regression/expected/ddl.out
@@ -28,15 +28,22 @@ SELECT * FROM test_ddl_renamed ORDER BY id;
 
 -- RENAME COLUMN
 ALTER TABLE test_ddl_renamed RENAME COLUMN name TO full_name;
-SELECT * FROM test_ddl_renamed ORDER BY id;
- id | full_name | age 
-----+-----------+-----
-  1 | Alice     |  20
-  2 | Bob       |  30
-(2 rows)
-
 -- ALTER COLUMN TYPE
 ALTER TABLE test_ddl_renamed ALTER COLUMN id TYPE BIGINT;
+-- Verify RENAME TABLE, RENAME COLUMN, ALTER COLUMN TYPE, ADD COLUMN in metadata
+SELECT c.column_name, c.column_type, c.nulls_allowed, c.default_value
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 'test_ddl_renamed' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL
+ORDER BY c.column_order;
+ column_name | column_type | nulls_allowed | default_value 
+-------------+-------------+---------------+---------------
+ id          | int64       | t             | NULL
+ full_name   | varchar     | t             | NULL
+ age         | int32       | t             | 20
+(3 rows)
+
 SELECT * FROM test_ddl_renamed ORDER BY id;
  id | full_name | age 
 ----+-----------+-----
@@ -44,5 +51,156 @@ SELECT * FROM test_ddl_renamed ORDER BY id;
   2 | Bob       |  30
 (2 rows)
 
+-- SET DEFAULT
+ALTER TABLE test_ddl_renamed ALTER COLUMN age SET DEFAULT 99;
+-- Verify default_value in metadata
+SELECT c.column_name, c.default_value
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 'test_ddl_renamed' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL AND c.column_name = 'age';
+ column_name | default_value 
+-------------+---------------
+ age         | 99
+(1 row)
+
+INSERT INTO test_ddl_renamed (id, full_name) VALUES (3, 'Charlie');
+SELECT * FROM test_ddl_renamed ORDER BY id;
+ id | full_name | age 
+----+-----------+-----
+  1 | Alice     |  20
+  2 | Bob       |  30
+  3 | Charlie   |  99
+(3 rows)
+
+-- DROP DEFAULT
+ALTER TABLE test_ddl_renamed ALTER COLUMN age DROP DEFAULT;
+-- Verify default_value cleared in metadata
+SELECT c.column_name, c.default_value
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 'test_ddl_renamed' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL AND c.column_name = 'age';
+ column_name | default_value 
+-------------+---------------
+ age         | NULL
+(1 row)
+
+INSERT INTO test_ddl_renamed (id, full_name) VALUES (4, 'Dave');
+SELECT * FROM test_ddl_renamed ORDER BY id;
+ id | full_name | age 
+----+-----------+-----
+  1 | Alice     |  20
+  2 | Bob       |  30
+  3 | Charlie   |  99
+  4 | Dave      |    
+(4 rows)
+
+-- SET NOT NULL
+ALTER TABLE test_ddl_renamed ALTER COLUMN full_name SET NOT NULL;
+-- Verify nulls_allowed in metadata
+SELECT c.column_name, c.nulls_allowed
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 'test_ddl_renamed' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL AND c.column_name = 'full_name';
+ column_name | nulls_allowed 
+-------------+---------------
+ full_name   | f
+(1 row)
+
+-- verify NOT NULL constraint is enforced
+INSERT INTO test_ddl_renamed (id) VALUES (5);
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Constraint Error: NOT NULL constraint failed: test_ddl_renamed.full_name
+-- DROP NOT NULL
+ALTER TABLE test_ddl_renamed ALTER COLUMN full_name DROP NOT NULL;
+-- Verify nulls_allowed restored in metadata
+SELECT c.column_name, c.nulls_allowed
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 'test_ddl_renamed' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL AND c.column_name = 'full_name';
+ column_name | nulls_allowed 
+-------------+---------------
+ full_name   | t
+(1 row)
+
+INSERT INTO test_ddl_renamed (id) VALUES (5);
+SELECT * FROM test_ddl_renamed ORDER BY id;
+ id | full_name | age 
+----+-----------+-----
+  1 | Alice     |  20
+  2 | Bob       |  30
+  3 | Charlie   |  99
+  4 | Dave      |    
+  5 |           |    
+(5 rows)
+
+-- DROP COLUMN
+ALTER TABLE test_ddl_renamed DROP COLUMN age;
+-- Verify dropped column no longer in current metadata
+SELECT c.column_name
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 'test_ddl_renamed' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL
+ORDER BY c.column_order;
+ column_name 
+-------------
+ id
+ full_name
+(2 rows)
+
+SELECT * FROM test_ddl_renamed ORDER BY id;
+ id | full_name 
+----+-----------
+  1 | Alice
+  2 | Bob
+  3 | Charlie
+  4 | Dave
+  5 | 
+(5 rows)
+
+-- COMMENT ON TABLE
+COMMENT ON TABLE test_ddl_renamed IS 'A test table for DDL operations';
+SELECT obj_description('test_ddl_renamed'::regclass, 'pg_class');
+         obj_description         
+---------------------------------
+ A test table for DDL operations
+(1 row)
+
+-- COMMENT ON COLUMN
+COMMENT ON COLUMN test_ddl_renamed.id IS 'The primary identifier';
+SELECT col_description('test_ddl_renamed'::regclass, 1);
+    col_description     
+------------------------
+ The primary identifier
+(1 row)
+
+-- Remove table comment
+COMMENT ON TABLE test_ddl_renamed IS NULL;
+SELECT obj_description('test_ddl_renamed'::regclass, 'pg_class');
+ obj_description 
+-----------------
+ 
+(1 row)
+
+-- Remove column comment
+COMMENT ON COLUMN test_ddl_renamed.id IS NULL;
+SELECT col_description('test_ddl_renamed'::regclass, 1);
+ col_description 
+-----------------
+ 
+(1 row)
+
+-- COMMENT with special characters
+COMMENT ON TABLE test_ddl_renamed IS 'it''s a "quoted" value & more';
+SELECT obj_description('test_ddl_renamed'::regclass, 'pg_class');
+       obj_description        
+------------------------------
+ it's a "quoted" value & more
+(1 row)
+
+COMMENT ON TABLE test_ddl_renamed IS NULL;
 -- DROP TABLE
 DROP TABLE test_ddl_renamed;

--- a/test/regression/expected/ddl_triggers.out
+++ b/test/regression/expected/ddl_triggers.out
@@ -4,9 +4,10 @@ SELECT evtname FROM pg_event_trigger WHERE evtname LIKE 'ducklake%' ORDER BY evt
             evtname            
 -------------------------------
  ducklake_alter_table_trigger
+ ducklake_comment_trigger
  ducklake_create_table_trigger
  ducklake_drop_table_trigger
-(3 rows)
+(4 rows)
 
 -- Create a simple ducklake table
 CREATE TABLE products (

--- a/test/regression/sql/ddl.sql
+++ b/test/regression/sql/ddl.sql
@@ -16,11 +16,105 @@ SELECT * FROM test_ddl_renamed ORDER BY id;
 
 -- RENAME COLUMN
 ALTER TABLE test_ddl_renamed RENAME COLUMN name TO full_name;
-SELECT * FROM test_ddl_renamed ORDER BY id;
 
 -- ALTER COLUMN TYPE
 ALTER TABLE test_ddl_renamed ALTER COLUMN id TYPE BIGINT;
+
+-- Verify RENAME TABLE, RENAME COLUMN, ALTER COLUMN TYPE, ADD COLUMN in metadata
+SELECT c.column_name, c.column_type, c.nulls_allowed, c.default_value
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 'test_ddl_renamed' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL
+ORDER BY c.column_order;
+
 SELECT * FROM test_ddl_renamed ORDER BY id;
+
+-- SET DEFAULT
+ALTER TABLE test_ddl_renamed ALTER COLUMN age SET DEFAULT 99;
+
+-- Verify default_value in metadata
+SELECT c.column_name, c.default_value
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 'test_ddl_renamed' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL AND c.column_name = 'age';
+
+INSERT INTO test_ddl_renamed (id, full_name) VALUES (3, 'Charlie');
+SELECT * FROM test_ddl_renamed ORDER BY id;
+
+-- DROP DEFAULT
+ALTER TABLE test_ddl_renamed ALTER COLUMN age DROP DEFAULT;
+
+-- Verify default_value cleared in metadata
+SELECT c.column_name, c.default_value
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 'test_ddl_renamed' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL AND c.column_name = 'age';
+
+INSERT INTO test_ddl_renamed (id, full_name) VALUES (4, 'Dave');
+SELECT * FROM test_ddl_renamed ORDER BY id;
+
+-- SET NOT NULL
+ALTER TABLE test_ddl_renamed ALTER COLUMN full_name SET NOT NULL;
+
+-- Verify nulls_allowed in metadata
+SELECT c.column_name, c.nulls_allowed
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 'test_ddl_renamed' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL AND c.column_name = 'full_name';
+
+-- verify NOT NULL constraint is enforced
+INSERT INTO test_ddl_renamed (id) VALUES (5);
+
+-- DROP NOT NULL
+ALTER TABLE test_ddl_renamed ALTER COLUMN full_name DROP NOT NULL;
+
+-- Verify nulls_allowed restored in metadata
+SELECT c.column_name, c.nulls_allowed
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 'test_ddl_renamed' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL AND c.column_name = 'full_name';
+
+INSERT INTO test_ddl_renamed (id) VALUES (5);
+SELECT * FROM test_ddl_renamed ORDER BY id;
+
+-- DROP COLUMN
+ALTER TABLE test_ddl_renamed DROP COLUMN age;
+
+-- Verify dropped column no longer in current metadata
+SELECT c.column_name
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 'test_ddl_renamed' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL
+ORDER BY c.column_order;
+
+SELECT * FROM test_ddl_renamed ORDER BY id;
+
+-- COMMENT ON TABLE
+COMMENT ON TABLE test_ddl_renamed IS 'A test table for DDL operations';
+SELECT obj_description('test_ddl_renamed'::regclass, 'pg_class');
+
+-- COMMENT ON COLUMN
+COMMENT ON COLUMN test_ddl_renamed.id IS 'The primary identifier';
+SELECT col_description('test_ddl_renamed'::regclass, 1);
+
+-- Remove table comment
+COMMENT ON TABLE test_ddl_renamed IS NULL;
+SELECT obj_description('test_ddl_renamed'::regclass, 'pg_class');
+
+-- Remove column comment
+COMMENT ON COLUMN test_ddl_renamed.id IS NULL;
+SELECT col_description('test_ddl_renamed'::regclass, 1);
+
+-- COMMENT with special characters
+COMMENT ON TABLE test_ddl_renamed IS 'it''s a "quoted" value & more';
+SELECT obj_description('test_ddl_renamed'::regclass, 'pg_class');
+COMMENT ON TABLE test_ddl_renamed IS NULL;
 
 -- DROP TABLE
 DROP TABLE test_ddl_renamed;


### PR DESCRIPTION
## Summary
- Add `ducklake_comment_trigger` event trigger that intercepts `COMMENT ON TABLE` and `COMMENT ON COLUMN` for ducklake tables and forwards them to DuckDB's ducklake catalog
- Extend DDL test coverage for ALTER TABLE operations that already worked but lacked tests: SET/DROP DEFAULT, SET/DROP NOT NULL, DROP COLUMN
- Tests include comment removal (`IS NULL`) and special characters (quotes, ampersand)

Closes #125

## Test plan
- `make check-regression TEST=ddl` -- verifies all schema evolution DDL operations including COMMENT
- `make check-regression TEST=ddl_triggers` -- verifies the new comment trigger is registered
- `make installcheck` -- full regression + isolation suite (32 + 3 tests pass)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>