### PR TITLE
fix: add missing wrapper macro for ducklake.options()

### DIFF
--- a/src/pgducklake_functions.cpp
+++ b/src/pgducklake_functions.cpp
@@ -110,6 +110,8 @@ static const DefaultTableMacro pg_ducklake_wrapper_macros[] = {
    "FROM ducklake_last_committed_snapshot('" PGDUCKLAKE_DUCKDB_CATALOG "')"},
   {DEFAULT_SCHEMA, "table_info", {nullptr}, {{nullptr, nullptr}},
    "FROM ducklake_table_info('" PGDUCKLAKE_DUCKDB_CATALOG "')"},
+  {DEFAULT_SCHEMA, "options", {nullptr}, {{nullptr, nullptr}},
+   "FROM ducklake_options('" PGDUCKLAKE_DUCKDB_CATALOG "')"},
   // table-scoped functions
   {DEFAULT_SCHEMA, "list_files", {"schema_name", "table_name", nullptr}, {{nullptr, nullptr}},
    "FROM ducklake_list_files('" PGDUCKLAKE_DUCKDB_CATALOG "', table_name, schema => schema_name)"},

--- a/test/regression/expected/options.out
+++ b/test/regression/expected/options.out
@@ -1,4 +1,11 @@
--- Test ducklake.set_option() procedure
+-- Test ducklake.options() and ducklake.set_option()
+-- 0. options() should return rows without crashing (issue #136)
+SELECT count(*) > 0 AS has_options FROM ducklake.options();
+ has_options 
+-------------
+ t
+(1 row)
+
 -- 1. Set a global option
 CALL ducklake.set_option('data_inlining_row_limit', 100);
 -- 2. Set a table-scoped option

--- a/test/regression/sql/options.sql
+++ b/test/regression/sql/options.sql
@@ -1,4 +1,7 @@
--- Test ducklake.set_option() procedure
+-- Test ducklake.options() and ducklake.set_option()
+
+-- 0. options() should return rows without crashing (issue #136)
+SELECT count(*) > 0 AS has_options FROM ducklake.options();
 
 -- 1. Set a global option
 CALL ducklake.set_option('data_inlining_row_limit', 100);


### PR DESCRIPTION
## Summary

- `ducklake.options()` crashed the server because it was registered as a DuckDB-only function but had no wrapper macro to bridge `system.main.options()` to `ducklake_options('pgducklake')`
- Added a wrapper table macro (same pattern as `snapshots`, `table_info`, etc.)
- Audited all 20 DuckDB-only functions -- `options()` was the only one missing a handler

Closes #136

## Test plan

- Added `SELECT count(*) > 0 FROM ducklake.options()` to the `options` regression test