### PR TITLE
feat: support write operations on ducklake_fdw foreign tables

### DIFF
--- a/docs/foreign_data_wrapper.md
+++ b/docs/foreign_data_wrapper.md
@@ -1,9 +1,11 @@
 # Foreign Data Wrapper
 
-`ducklake_fdw` provides read-only access to DuckLake tables stored in a
-remote PostgreSQL catalog or a frozen `.ducklake` snapshot file. Queries
-on foreign tables are routed through DuckDB -- the FDW handles catalog
-registration, not scan execution.
+`ducklake_fdw` provides access to DuckLake tables stored in a remote
+PostgreSQL catalog or a frozen `.ducklake` snapshot file. Foreign tables
+backed by a remote catalog support full DML (INSERT/UPDATE/DELETE);
+frozen snapshots are read-only. Queries on foreign tables are routed
+through DuckDB -- the FDW handles catalog registration, not scan
+execution.
 
 ## Connection modes
 
@@ -111,20 +113,24 @@ IMPORT FOREIGN SCHEMA public EXCEPT (internal_logs)
 `IMPORT FOREIGN SCHEMA` works with both remote PostgreSQL catalogs and
 frozen snapshots.
 
-## Querying foreign tables
+## Querying and modifying foreign tables
 
-Foreign tables are read-only. SELECT, JOIN, and aggregation work
-normally -- queries are routed to DuckDB for execution:
+Foreign tables backed by a remote PostgreSQL catalog support full SQL
+including SELECT, INSERT, UPDATE, and DELETE -- queries and writes are
+routed to DuckDB for execution:
 
 ```sql
 SELECT * FROM analytics.orders WHERE amount > 100 ORDER BY created_at;
 
-SELECT o.id, c.name, o.amount
-FROM analytics.orders o
-JOIN analytics.customers c ON o.customer_id = c.id;
+INSERT INTO analytics.orders (id, amount) VALUES (42, 199.99);
+
+UPDATE analytics.orders SET amount = 249.99 WHERE id = 42;
+
+DELETE FROM analytics.orders WHERE id = 42;
 ```
 
-INSERT, UPDATE, and DELETE are not supported and raise an error.
+Foreign tables backed by a **frozen snapshot** (`frozen_url`) are
+read-only. INSERT, UPDATE, and DELETE raise an error.
 
 ## Handling remote schema changes
 

--- a/src/pgducklake_fdw.cpp
+++ b/src/pgducklake_fdw.cpp
@@ -6,8 +6,9 @@
  *   FDW utility hook; cached FDW OID
  * @scope duckdb-instance: attach DuckLake databases for FDW queries
  *
- * Implements a PostgreSQL FDW that provides read-only access to DuckLake
- * tables.  Supports two modes:
+ * Implements a PostgreSQL FDW that provides access to DuckLake tables.
+ * Regular FDW tables (PostgreSQL-backed) support full DML; frozen
+ * snapshots remain read-only.  Supports two modes:
  *
  *   1. Regular FDW — references a DuckLake catalog backed by a PostgreSQL
  *      metadata database (options: dbname, metadata_schema).
@@ -273,28 +274,33 @@ void pgducklake::RegisterForeignTablesInQuery(Query *query) {
       pgducklake::RegisterForeignTablesInQuery(castNode(Query, cte->ctequery));
   }
 
-  /* Block DML on FDW tables */
+  /* Block DML on frozen FDW tables; regular FDW tables support writes
+   * via DuckDB execution (the planner routes DML through pg_duckdb). */
   if (query->commandType != CMD_SELECT && query->resultRelation > 0) {
     RangeTblEntry *result_rte = list_nth_node(RangeTblEntry, query->rtable, query->resultRelation - 1);
     if (result_rte->relid != InvalidOid && IsDucklakeForeignTable(result_rte->relid)) {
-      const char *op = "Unknown";
-      switch (query->commandType) {
-      case CMD_INSERT:
-        op = "INSERT";
-        break;
-      case CMD_UPDATE:
-        op = "UPDATE";
-        break;
-      case CMD_DELETE:
-        op = "DELETE";
-        break;
-      default:
-        break;
+      ForeignTable *ft = GetForeignTable(result_rte->relid);
+      ForeignServer *server = GetForeignServer(ft->serverid);
+      if (IsFrozenServer(server)) {
+        const char *op = "Unknown";
+        switch (query->commandType) {
+        case CMD_INSERT:
+          op = "INSERT";
+          break;
+        case CMD_UPDATE:
+          op = "UPDATE";
+          break;
+        case CMD_DELETE:
+          op = "DELETE";
+          break;
+        default:
+          break;
+        }
+        ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED), errmsg("frozen ducklake_fdw tables are read-only"),
+                        errhint("%s is not supported on foreign tables "
+                                "backed by a frozen .ducklake snapshot.",
+                                op)));
       }
-      ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED), errmsg("ducklake_fdw tables are read-only"),
-                      errhint("%s is not supported on foreign tables "
-                              "created with ducklake_fdw.",
-                              op)));
     }
   }
 }

--- a/test/regression/expected/fdw.out
+++ b/test/regression/expected/fdw.out
@@ -78,16 +78,44 @@ ORDER BY a.name;
  Charlie |  92.1
 (2 rows)
 
--- READ-ONLY enforcement
+-- DML on regular FDW tables
 INSERT INTO fdw_t VALUES (4, 'Dave', 88.0);
-ERROR:  ducklake_fdw tables are read-only
-HINT:  INSERT is not supported on foreign tables created with ducklake_fdw.
-UPDATE fdw_t SET score = 100 WHERE id = 1;
-ERROR:  ducklake_fdw tables are read-only
-HINT:  UPDATE is not supported on foreign tables created with ducklake_fdw.
-DELETE FROM fdw_t WHERE id = 1;
-ERROR:  ducklake_fdw tables are read-only
-HINT:  DELETE is not supported on foreign tables created with ducklake_fdw.
+SELECT * FROM fdw_t ORDER BY id;
+ id |  name   | score 
+----+---------+-------
+  1 | Alice   |  95.5
+  2 | Bob     |  87.3
+  3 | Charlie |  92.1
+  4 | Dave    |    88
+(4 rows)
+
+UPDATE fdw_t SET score = 99.9 WHERE id = 4;
+SELECT id, score FROM fdw_t WHERE id = 4;
+ id | score 
+----+-------
+  4 |  99.9
+(1 row)
+
+DELETE FROM fdw_t WHERE id = 4;
+SELECT * FROM fdw_t ORDER BY id;
+ id |  name   | score 
+----+---------+-------
+  1 | Alice   |  95.5
+  2 | Bob     |  87.3
+  3 | Charlie |  92.1
+(3 rows)
+
+-- Cross-check: writes through FDW are visible on the base table
+INSERT INTO fdw_t VALUES (5, 'Eve', 77.0);
+SELECT * FROM fdw_source ORDER BY id;
+ id |  name   | score 
+----+---------+-------
+  1 | Alice   |  95.5
+  2 | Bob     |  87.3
+  3 | Charlie |  92.1
+  5 | Eve     |    77
+(4 rows)
+
 -- Error: non-existent table
 CREATE FOREIGN TABLE fdw_nonexistent ()
     SERVER ducklake_test_server

--- a/test/regression/expected/frozen_fdw.out
+++ b/test/regression/expected/frozen_fdw.out
@@ -59,14 +59,14 @@ SELECT count(*) FROM frozen_src_fdw;
 
 -- READ-ONLY enforcement
 INSERT INTO frozen_src_fdw VALUES (6, 'Frank', 80.00);
-ERROR:  ducklake_fdw tables are read-only
-HINT:  INSERT is not supported on foreign tables created with ducklake_fdw.
+ERROR:  frozen ducklake_fdw tables are read-only
+HINT:  INSERT is not supported on foreign tables backed by a frozen .ducklake snapshot.
 UPDATE frozen_src_fdw SET name = 'test' WHERE id = 1;
-ERROR:  ducklake_fdw tables are read-only
-HINT:  UPDATE is not supported on foreign tables created with ducklake_fdw.
+ERROR:  frozen ducklake_fdw tables are read-only
+HINT:  UPDATE is not supported on foreign tables backed by a frozen .ducklake snapshot.
 DELETE FROM frozen_src_fdw WHERE id = 1;
-ERROR:  ducklake_fdw tables are read-only
-HINT:  DELETE is not supported on foreign tables created with ducklake_fdw.
+ERROR:  frozen ducklake_fdw tables are read-only
+HINT:  DELETE is not supported on foreign tables backed by a frozen .ducklake snapshot.
 -- IMPORT FOREIGN SCHEMA from frozen server
 CREATE SCHEMA frozen_import;
 IMPORT FOREIGN SCHEMA public FROM SERVER frozen_test INTO frozen_import;

--- a/test/regression/sql/fdw.sql
+++ b/test/regression/sql/fdw.sql
@@ -52,10 +52,19 @@ JOIN fdw_t2 b ON a.id = b.id
 WHERE b.score > 90
 ORDER BY a.name;
 
--- READ-ONLY enforcement
+-- DML on regular FDW tables
 INSERT INTO fdw_t VALUES (4, 'Dave', 88.0);
-UPDATE fdw_t SET score = 100 WHERE id = 1;
-DELETE FROM fdw_t WHERE id = 1;
+SELECT * FROM fdw_t ORDER BY id;
+
+UPDATE fdw_t SET score = 99.9 WHERE id = 4;
+SELECT id, score FROM fdw_t WHERE id = 4;
+
+DELETE FROM fdw_t WHERE id = 4;
+SELECT * FROM fdw_t ORDER BY id;
+
+-- Cross-check: writes through FDW are visible on the base table
+INSERT INTO fdw_t VALUES (5, 'Eve', 77.0);
+SELECT * FROM fdw_source ORDER BY id;
 
 -- Error: non-existent table
 CREATE FOREIGN TABLE fdw_nonexistent ()


### PR DESCRIPTION
## Summary

- Lift the blanket DML block on `ducklake_fdw` foreign tables so that regular (PostgreSQL-backed) FDW tables support INSERT, UPDATE, and DELETE through DuckDB execution
- Frozen snapshot tables remain read-only with a specific error message
- The existing pg_duckdb hook infrastructure already routes DML on external tables to DuckDB, so this is purely removing the guard for non-frozen tables

## Test plan

- Updated `fdw.sql` regression test: INSERT, UPDATE, DELETE on regular FDW tables, plus cross-check that writes are visible on the base table
- Updated `frozen_fdw.out`: frozen tables still block DML with a frozen-specific error message
- Both `fdw` and `frozen_fdw` regression tests pass

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)