### PR TITLE
fix: stop hard-coding DATA_PATH on ATTACH and sync default_table_path GUC

### DIFF
--- a/include/pgducklake/pgducklake_duckdb_query.hpp
+++ b/include/pgducklake/pgducklake_duckdb_query.hpp
@@ -17,4 +17,10 @@ namespace pgducklake {
  */
 int ExecuteDuckDBQuery(const char *query, const char **errmsg_out);
 
+/*
+ * Sync the ducklake.default_table_path PG GUC to DuckDB's
+ * ducklake_default_table_path extension option.  No-op when empty.
+ */
+void SyncDefaultTablePathToDuckDB();
+
 } // namespace pgducklake

--- a/src/pgducklake_duckdb.cpp
+++ b/src/pgducklake_duckdb.cpp
@@ -74,17 +74,21 @@ void ducklake_detach_catalog() {
 void ducklake_attach_catalog() {
   duckdb::string query = "ATTACH 'ducklake:" PGDUCKLAKE_DUCKDB_CATALOG ":' AS " PGDUCKLAKE_DUCKDB_CATALOG
                          "(METADATA_SCHEMA " PGDUCKLAKE_PG_SCHEMA_QUOTED;
-  auto data_path = duckdb::StringUtil::Format("%s/pg_ducklake", DataDir);
   if (creating_extension) {
+    /* First-time init: create local data directory and pass it as DATA_PATH
+     * so DuckLake stores it in the catalog metadata. */
+    auto data_path = duckdb::StringUtil::Format("%s/pg_ducklake", DataDir);
     try {
       std::filesystem::create_directory(data_path);
     } catch (const std::filesystem::filesystem_error &e) {
       ereport(ERROR, (errcode(ERRCODE_IO_ERROR),
                       errmsg("failed to create DuckLake data directory \"%s\": %s", data_path.c_str(), e.what())));
     }
+    query += ", DATA_PATH '" + data_path + "'";
   }
-
-  query += ", DATA_PATH '" + data_path + "'";
+  /* On subsequent ATTACHes, omit DATA_PATH so DuckLake reads it from its
+   * stored catalog metadata. This avoids mismatch errors when the data_path
+   * has been changed (e.g. to an S3 bucket via ducklake.set_option). */
   query += ")";
 
   elog(DEBUG1, "Executing query: %s", query.c_str());

--- a/src/pgducklake_duckdb_query.cpp
+++ b/src/pgducklake_duckdb_query.cpp
@@ -12,6 +12,7 @@
 #include <duckdb/parser/keyword_helper.hpp>
 
 #include "pgducklake/pgducklake_duckdb_query.hpp"
+#include "pgducklake/pgducklake_guc.hpp"
 
 #include <string>
 
@@ -85,6 +86,17 @@ int ExecuteDuckDBQuery(const char *query, const char **errmsg_out) {
   AtEOXact_GUC(false, save_nestlevel);
 
   return result;
+}
+
+void SyncDefaultTablePathToDuckDB() {
+  if (default_table_path && default_table_path[0] != '\0') {
+    std::string set_query =
+        "SET ducklake_default_table_path = " + duckdb::KeywordHelper::WriteQuoted(std::string(default_table_path));
+    const char *errmsg = nullptr;
+    if (ExecuteDuckDBQuery(set_query.c_str(), &errmsg) != 0) {
+      elog(WARNING, "failed to sync ducklake.default_table_path to DuckDB: %s", errmsg ? errmsg : "unknown");
+    }
+  }
 }
 
 } // namespace pgducklake

--- a/src/pgducklake_table.cpp
+++ b/src/pgducklake_table.cpp
@@ -595,6 +595,10 @@ DECLARE_PG_FUNCTION(ducklake_create_table_trigger) {
   AtEOXact_GUC(false, save_nestlevel);
   SPI_finish();
 
+  // Sync ducklake.default_table_path GUC to DuckDB extension option so
+  // DuckLake's CreateTable uses the custom path for data files.
+  pgducklake::SyncDefaultTablePathToDuckDB();
+
   // Generate CREATE TABLE DDL for DuckDB
   std::string create_table_ddl(pgduckdb_get_tabledef(relid));
   elog(DEBUG1, "Creating DuckLake table: %s", create_table_ddl.c_str());

--- a/test/regression/expected/default_table_path.out
+++ b/test/regression/expected/default_table_path.out
@@ -1,0 +1,30 @@
+-- Test ducklake.default_table_path end-to-end:
+-- set a custom path, create a table, insert data, flush, verify file location.
+-- Disable data inlining so inserts write parquet files immediately
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+-- Use a custom directory as the default table path (simulates s3:// bucket)
+SET ducklake.default_table_path = '/tmp/ducklake_test_custom_path';
+CREATE TABLE dtp_test (id int, val text) USING ducklake;
+INSERT INTO dtp_test VALUES (1, 'one'), (2, 'two');
+-- Verify data is readable
+SELECT * FROM dtp_test ORDER BY id;
+ id | val 
+----+-----
+  1 | one
+  2 | two
+(2 rows)
+
+-- Verify files are under the custom path
+SELECT * FROM duckdb.query($$
+  SELECT bool_and(starts_with(data_file, '/tmp/ducklake_test_custom_path/')) AS path_ok
+  FROM ducklake_list_files('pgducklake', 'dtp_test', schema => 'public')
+$$);
+ path_ok 
+---------
+ t
+(1 row)
+
+-- Cleanup
+RESET ducklake.default_table_path;
+DROP TABLE dtp_test;
+CALL ducklake.set_option('data_inlining_row_limit', 0);

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -9,6 +9,7 @@ test: temp_table
 test: insert_unnest
 test: ctas
 test: gucs
+test: default_table_path
 test: options
 test: data_inlining_row_limit
 test: inlined_data_schema_change

--- a/test/regression/sql/default_table_path.sql
+++ b/test/regression/sql/default_table_path.sql
@@ -1,0 +1,25 @@
+-- Test ducklake.default_table_path end-to-end:
+-- set a custom path, create a table, insert data, flush, verify file location.
+
+-- Disable data inlining so inserts write parquet files immediately
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+
+-- Use a custom directory as the default table path (simulates s3:// bucket)
+SET ducklake.default_table_path = '/tmp/ducklake_test_custom_path';
+
+CREATE TABLE dtp_test (id int, val text) USING ducklake;
+INSERT INTO dtp_test VALUES (1, 'one'), (2, 'two');
+
+-- Verify data is readable
+SELECT * FROM dtp_test ORDER BY id;
+
+-- Verify files are under the custom path
+SELECT * FROM duckdb.query($$
+  SELECT bool_and(starts_with(data_file, '/tmp/ducklake_test_custom_path/')) AS path_ok
+  FROM ducklake_list_files('pgducklake', 'dtp_test', schema => 'public')
+$$);
+
+-- Cleanup
+RESET ducklake.default_table_path;
+DROP TABLE dtp_test;
+CALL ducklake.set_option('data_inlining_row_limit', 0);


### PR DESCRIPTION
## Summary

- **Stop hard-coding `DATA_PATH` on every ATTACH**: `ducklake_attach_catalog()` now only passes `DATA_PATH` during `CREATE EXTENSION` (first-time init). On subsequent backend connections, DuckLake reads the data path from its own catalog metadata. This fixes mismatch errors when the path has been changed (e.g. to an S3 bucket via `ducklake.set_option`).
- **Sync `ducklake.default_table_path` GUC to DuckDB**: Added `SyncDefaultTablePathToDuckDB()` which propagates the PG GUC to DuckDB's `ducklake_default_table_path` extension option before `CREATE TABLE` DDL. Previously the GUC existed but was never wired through to DuckDB.
- **Regression test**: Full user story -- set custom path, create ducklake table, insert data, verify files land under the custom path via `ducklake_list_files`.

## Test plan

- [x] `make installcheck` -- all 37 regression + 3 isolation tests pass
- [ ] Manual test with S3 bucket (requires credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)