### PR TITLE
feat: ducklake_fdw write support and updatable option

### DIFF
--- a/docs/foreign_data_wrapper.md
+++ b/docs/foreign_data_wrapper.md
@@ -51,12 +51,14 @@ CREATE SERVER frozen_snapshot
 | `connection_string` | server | Full libpq connection string (remote connections) |
 | `metadata_schema` | server | Schema holding DuckLake metadata (default: `ducklake`) |
 | `frozen_url` | server | Path or URL to a frozen `.ducklake` file |
+| `updatable` | server, table | Allow INSERT/UPDATE/DELETE (default: `true`; `false` for frozen) |
 | `schema_name` | table | Remote DuckLake schema (default: `public`) |
 | `table_name` | table | Remote table name (default: foreign table name) |
 
 **Mutual exclusivity:** `dbname`, `connection_string`, and `frozen_url`
 are mutually exclusive. `metadata_schema` can be used with `dbname` or
-`connection_string` but not with `frozen_url`.
+`connection_string` but not with `frozen_url`. `frozen_url` and
+`updatable 'true'` are mutually exclusive.
 
 ## Creating foreign tables
 

--- a/src/pgducklake_fdw.cpp
+++ b/src/pgducklake_fdw.cpp
@@ -81,14 +81,15 @@ struct DucklakeFdwOption {
   Oid context;
 };
 
-static const DucklakeFdwOption valid_server_options[] = {{"dbname", ForeignServerRelationId},
-                                                         {"connection_string", ForeignServerRelationId},
-                                                         {"metadata_schema", ForeignServerRelationId},
-                                                         {"frozen_url", ForeignServerRelationId},
-                                                         {nullptr, InvalidOid}};
+static const DucklakeFdwOption valid_server_options[] = {
+    {"dbname", ForeignServerRelationId},          {"connection_string", ForeignServerRelationId},
+    {"metadata_schema", ForeignServerRelationId}, {"frozen_url", ForeignServerRelationId},
+    {"updatable", ForeignServerRelationId},       {nullptr, InvalidOid}};
 
-static const DucklakeFdwOption valid_table_options[] = {
-    {"schema_name", ForeignTableRelationId}, {"table_name", ForeignTableRelationId}, {nullptr, InvalidOid}};
+static const DucklakeFdwOption valid_table_options[] = {{"schema_name", ForeignTableRelationId},
+                                                        {"table_name", ForeignTableRelationId},
+                                                        {"updatable", ForeignTableRelationId},
+                                                        {nullptr, InvalidOid}};
 
 static bool IsValidOption(const char *name, Oid context) {
   for (auto *opt = valid_server_options; opt->optname; opt++) {
@@ -133,6 +134,19 @@ static Oid GetDucklakeFdwOid() {
 
 static bool IsFrozenServer(ForeignServer *server) {
   return GetOptionValue(server->options, "frozen_url") != nullptr;
+}
+
+/* Check whether a foreign table is updatable.  Table-level option
+ * overrides server-level; frozen servers default to false; otherwise
+ * default is true (matching postgres_fdw convention). */
+static bool IsUpdatable(ForeignTable *ft, ForeignServer *server) {
+  const char *table_val = GetOptionValue(ft->options, "updatable");
+  if (table_val)
+    return pg_strcasecmp(table_val, "true") == 0;
+  const char *server_val = GetOptionValue(server->options, "updatable");
+  if (server_val)
+    return pg_strcasecmp(server_val, "true") == 0;
+  return !IsFrozenServer(server);
 }
 
 /* ----------------------------------------------------------------
@@ -274,14 +288,15 @@ void pgducklake::RegisterForeignTablesInQuery(Query *query) {
       pgducklake::RegisterForeignTablesInQuery(castNode(Query, cte->ctequery));
   }
 
-  /* Block DML on frozen FDW tables; regular FDW tables support writes
-   * via DuckDB execution (the planner routes DML through pg_duckdb). */
+  /* Block DML on non-updatable FDW tables.  Regular FDW tables default
+   * to updatable; frozen tables and tables/servers with updatable 'false'
+   * are read-only.  Writable tables are handled by pg_duckdb's planner. */
   if (query->commandType != CMD_SELECT && query->resultRelation > 0) {
     RangeTblEntry *result_rte = list_nth_node(RangeTblEntry, query->rtable, query->resultRelation - 1);
     if (result_rte->relid != InvalidOid && IsDucklakeForeignTable(result_rte->relid)) {
       ForeignTable *ft = GetForeignTable(result_rte->relid);
       ForeignServer *server = GetForeignServer(ft->serverid);
-      if (IsFrozenServer(server)) {
+      if (!IsUpdatable(ft, server)) {
         const char *op = "Unknown";
         switch (query->commandType) {
         case CMD_INSERT:
@@ -296,10 +311,8 @@ void pgducklake::RegisterForeignTablesInQuery(Query *query) {
         default:
           break;
         }
-        ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED), errmsg("frozen ducklake_fdw tables are read-only"),
-                        errhint("%s is not supported on foreign tables "
-                                "backed by a frozen .ducklake snapshot.",
-                                op)));
+        ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED), errmsg("ducklake_fdw foreign table is not updatable"),
+                        errhint("%s is not supported when the \"updatable\" option is false.", op)));
       }
     }
   }
@@ -626,6 +639,20 @@ DECLARE_PG_FUNCTION(ducklake_fdw_validator) {
     if (has_connstr && has_dbname)
       ereport(ERROR, (errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
                       errmsg("\"connection_string\" and \"dbname\" are mutually exclusive")));
+
+    const char *updatable_val = GetOptionValue(options, "updatable");
+    if (updatable_val && pg_strcasecmp(updatable_val, "true") != 0 && pg_strcasecmp(updatable_val, "false") != 0)
+      ereport(ERROR, (errcode(ERRCODE_FDW_INVALID_OPTION_NAME), errmsg("\"updatable\" must be \"true\" or \"false\"")));
+    if (has_frozen && updatable_val && pg_strcasecmp(updatable_val, "true") == 0)
+      ereport(ERROR, (errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+                      errmsg("\"frozen_url\" and \"updatable 'true'\" are mutually exclusive")));
+  }
+
+  /* Validate table-level updatable option */
+  if (catalog == ForeignTableRelationId) {
+    const char *updatable_val = GetOptionValue(options, "updatable");
+    if (updatable_val && pg_strcasecmp(updatable_val, "true") != 0 && pg_strcasecmp(updatable_val, "false") != 0)
+      ereport(ERROR, (errcode(ERRCODE_FDW_INVALID_OPTION_NAME), errmsg("\"updatable\" must be \"true\" or \"false\"")));
   }
 
   PG_RETURN_VOID();

--- a/test/regression/expected/fdw.out
+++ b/test/regression/expected/fdw.out
@@ -116,6 +116,47 @@ SELECT * FROM fdw_source ORDER BY id;
   5 | Eve     |    77
 (4 rows)
 
+-- updatable option: table-level override
+CREATE FOREIGN TABLE fdw_readonly ()
+    SERVER ducklake_test_server
+    OPTIONS (table_name 'fdw_source', updatable 'false');
+INSERT INTO fdw_readonly VALUES (6, 'Frank', 60.0);
+ERROR:  ducklake_fdw foreign table is not updatable
+HINT:  INSERT is not supported when the "updatable" option is false.
+SELECT * FROM fdw_readonly ORDER BY id;
+ id |  name   | score 
+----+---------+-------
+  1 | Alice   |  95.5
+  2 | Bob     |  87.3
+  3 | Charlie |  92.1
+  5 | Eve     |    77
+(4 rows)
+
+DROP FOREIGN TABLE fdw_readonly;
+-- updatable option: server-level
+CREATE SERVER ducklake_readonly_server
+    FOREIGN DATA WRAPPER ducklake_fdw
+    OPTIONS (metadata_schema 'ducklake', updatable 'false');
+CREATE FOREIGN TABLE fdw_srv_ro ()
+    SERVER ducklake_readonly_server
+    OPTIONS (table_name 'fdw_source');
+INSERT INTO fdw_srv_ro VALUES (6, 'Frank', 60.0);
+ERROR:  ducklake_fdw foreign table is not updatable
+HINT:  INSERT is not supported when the "updatable" option is false.
+-- table-level updatable 'true' overrides server-level 'false'
+CREATE FOREIGN TABLE fdw_srv_override ()
+    SERVER ducklake_readonly_server
+    OPTIONS (table_name 'fdw_source', updatable 'true');
+INSERT INTO fdw_srv_override VALUES (6, 'Frank', 60.0);
+DELETE FROM fdw_srv_override WHERE id = 6;
+DROP FOREIGN TABLE fdw_srv_override;
+DROP FOREIGN TABLE fdw_srv_ro;
+DROP SERVER ducklake_readonly_server;
+-- updatable validation: invalid value
+CREATE SERVER ducklake_bad_updatable
+    FOREIGN DATA WRAPPER ducklake_fdw
+    OPTIONS (metadata_schema 'ducklake', updatable 'yes');
+ERROR:  "updatable" must be "true" or "false"
 -- Error: non-existent table
 CREATE FOREIGN TABLE fdw_nonexistent ()
     SERVER ducklake_test_server

--- a/test/regression/expected/frozen_fdw.out
+++ b/test/regression/expected/frozen_fdw.out
@@ -9,6 +9,11 @@ CREATE SERVER frozen_bad_2
     FOREIGN DATA WRAPPER ducklake_fdw
     OPTIONS (frozen_url 'https://example.com/test.ducklake', metadata_schema 'myschema');
 ERROR:  "frozen_url" and "metadata_schema" are mutually exclusive
+-- Validation: frozen_url + updatable 'true' -> error
+CREATE SERVER frozen_bad_3
+    FOREIGN DATA WRAPPER ducklake_fdw
+    OPTIONS (frozen_url 'https://example.com/test.ducklake', updatable 'true');
+ERROR:  "frozen_url" and "updatable 'true'" are mutually exclusive
 -- Setup: create and freeze our own test data
 CALL ducklake.set_option('data_inlining_row_limit', 0);
 CREATE TABLE frozen_src (id int, name text, score numeric(5,2)) USING ducklake;
@@ -59,14 +64,14 @@ SELECT count(*) FROM frozen_src_fdw;
 
 -- READ-ONLY enforcement
 INSERT INTO frozen_src_fdw VALUES (6, 'Frank', 80.00);
-ERROR:  frozen ducklake_fdw tables are read-only
-HINT:  INSERT is not supported on foreign tables backed by a frozen .ducklake snapshot.
+ERROR:  ducklake_fdw foreign table is not updatable
+HINT:  INSERT is not supported when the "updatable" option is false.
 UPDATE frozen_src_fdw SET name = 'test' WHERE id = 1;
-ERROR:  frozen ducklake_fdw tables are read-only
-HINT:  UPDATE is not supported on foreign tables backed by a frozen .ducklake snapshot.
+ERROR:  ducklake_fdw foreign table is not updatable
+HINT:  UPDATE is not supported when the "updatable" option is false.
 DELETE FROM frozen_src_fdw WHERE id = 1;
-ERROR:  frozen ducklake_fdw tables are read-only
-HINT:  DELETE is not supported on foreign tables backed by a frozen .ducklake snapshot.
+ERROR:  ducklake_fdw foreign table is not updatable
+HINT:  DELETE is not supported when the "updatable" option is false.
 -- IMPORT FOREIGN SCHEMA from frozen server
 CREATE SCHEMA frozen_import;
 IMPORT FOREIGN SCHEMA public FROM SERVER frozen_test INTO frozen_import;

--- a/test/regression/sql/fdw.sql
+++ b/test/regression/sql/fdw.sql
@@ -66,6 +66,44 @@ SELECT * FROM fdw_t ORDER BY id;
 INSERT INTO fdw_t VALUES (5, 'Eve', 77.0);
 SELECT * FROM fdw_source ORDER BY id;
 
+-- updatable option: table-level override
+CREATE FOREIGN TABLE fdw_readonly ()
+    SERVER ducklake_test_server
+    OPTIONS (table_name 'fdw_source', updatable 'false');
+
+INSERT INTO fdw_readonly VALUES (6, 'Frank', 60.0);
+SELECT * FROM fdw_readonly ORDER BY id;
+
+DROP FOREIGN TABLE fdw_readonly;
+
+-- updatable option: server-level
+CREATE SERVER ducklake_readonly_server
+    FOREIGN DATA WRAPPER ducklake_fdw
+    OPTIONS (metadata_schema 'ducklake', updatable 'false');
+
+CREATE FOREIGN TABLE fdw_srv_ro ()
+    SERVER ducklake_readonly_server
+    OPTIONS (table_name 'fdw_source');
+
+INSERT INTO fdw_srv_ro VALUES (6, 'Frank', 60.0);
+
+-- table-level updatable 'true' overrides server-level 'false'
+CREATE FOREIGN TABLE fdw_srv_override ()
+    SERVER ducklake_readonly_server
+    OPTIONS (table_name 'fdw_source', updatable 'true');
+
+INSERT INTO fdw_srv_override VALUES (6, 'Frank', 60.0);
+DELETE FROM fdw_srv_override WHERE id = 6;
+
+DROP FOREIGN TABLE fdw_srv_override;
+DROP FOREIGN TABLE fdw_srv_ro;
+DROP SERVER ducklake_readonly_server;
+
+-- updatable validation: invalid value
+CREATE SERVER ducklake_bad_updatable
+    FOREIGN DATA WRAPPER ducklake_fdw
+    OPTIONS (metadata_schema 'ducklake', updatable 'yes');
+
 -- Error: non-existent table
 CREATE FOREIGN TABLE fdw_nonexistent ()
     SERVER ducklake_test_server

--- a/test/regression/sql/frozen_fdw.sql
+++ b/test/regression/sql/frozen_fdw.sql
@@ -10,6 +10,11 @@ CREATE SERVER frozen_bad_2
     FOREIGN DATA WRAPPER ducklake_fdw
     OPTIONS (frozen_url 'https://example.com/test.ducklake', metadata_schema 'myschema');
 
+-- Validation: frozen_url + updatable 'true' -> error
+CREATE SERVER frozen_bad_3
+    FOREIGN DATA WRAPPER ducklake_fdw
+    OPTIONS (frozen_url 'https://example.com/test.ducklake', updatable 'true');
+
 -- Setup: create and freeze our own test data
 CALL ducklake.set_option('data_inlining_row_limit', 0);
 


### PR DESCRIPTION
## Summary

- Lift the blanket DML block on `ducklake_fdw` foreign tables so that regular (PostgreSQL-backed) FDW tables support INSERT, UPDATE, and DELETE through DuckDB execution
- Add `updatable` option (server and table level) to control whether DML is allowed, matching `postgres_fdw` convention
- Table-level overrides server-level; frozen servers default to `false`; regular servers default to `true`
- Validator rejects invalid values and `frozen_url` + `updatable 'true'` combination

## Test plan

- `fdw.sql`: INSERT/UPDATE/DELETE on regular FDW tables; cross-check writes visible on base table; table-level `updatable 'false'` blocks DML; server-level `updatable 'false'` blocks DML; table-level override of server; invalid value rejected
- `frozen_fdw.sql`: `frozen_url` + `updatable 'true'` rejected; frozen DML blocked with updatable-aware error message

Closes #137
Supersedes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)