### PR TITLE
fix: cherry-pick DuckLake DELETE visibility fix

### DIFF
--- a/third_party/ducklake/src/include/storage/ducklake_transaction.hpp
+++ b/third_party/ducklake/src/include/storage/ducklake_transaction.hpp
@@ -74,6 +74,7 @@ public:
 	void AddNewInlinedFileDeletes(TableIndex table_id, idx_t file_id, set<idx_t> new_deletes);
 	void AddCompaction(TableIndex table_id, DuckLakeCompactionEntry entry);
 	bool HasLocalDeletes(TableIndex table_id) const;
+	bool HasLocalDeleteForFile(TableIndex table_id, const string &path) const;
 	bool HasAnyLocalChanges(TableIndex table_id) const;
 
 	void GetLocalDeleteForFile(TableIndex table_id, const string &path, DuckLakeFileData &result) const;
@@ -234,6 +235,7 @@ public:
 	string GetDefaultSchemaName();
 
 	bool HasLocalDeletes(TableIndex table_id) const;
+	bool HasLocalDeleteForFile(TableIndex table_id, const string &path) const;
 	void GetLocalDeleteForFile(TableIndex table_id, const string &path, DuckLakeFileData &delete_file) const;
 	void TransactionLocalDelete(TableIndex table_id, const string &data_path, DuckLakeDeleteFile delete_file);
 

--- a/third_party/ducklake/src/storage/ducklake_multi_file_reader.cpp
+++ b/third_party/ducklake/src/storage/ducklake_multi_file_reader.cpp
@@ -266,8 +266,13 @@ ReaderInitializeType DuckLakeMultiFileReader::InitializeReader(MultiFileReaderDa
 			if (file_entry.max_row_count.IsValid()) {
 				delete_filter->SetMaxRowCount(file_entry.max_row_count.GetIndex());
 			}
-			// set the snapshot id so we know what to skip from deletion files
-			delete_filter->SetSnapshotFilter(read_info.snapshot.snapshot_id);
+			auto txn = read_info.GetTransaction();
+			bool has_local_delete = txn && txn->HasLocalDeleteForFile(read_info.table_id, reader.GetFileName());
+			if (!has_local_delete) {
+				// We only set snapshot filter if this file is not a current running transaction
+				// OW, we are guaranteed to be on the latest valid snapshot
+				delete_filter->SetSnapshotFilter(read_info.snapshot.snapshot_id);
+			}
 			reader.deletion_filter = std::move(delete_filter);
 		}
 	} else {

--- a/third_party/ducklake/src/storage/ducklake_transaction.cpp
+++ b/third_party/ducklake/src/storage/ducklake_transaction.cpp
@@ -469,6 +469,17 @@ bool LocalTableChanges::HasAnyLocalChanges(TableIndex table_id) const {
 	return false;
 }
 
+bool LocalTableChanges::HasLocalDeleteForFile(TableIndex table_id, const string &path) const {
+	lock_guard<mutex> guard(lock);
+	auto entry = changes.find(table_id);
+	if (entry == changes.end()) {
+		return false;
+	}
+	auto &table_changes = entry->second;
+	auto file_entry = table_changes.new_delete_files.find(path);
+	return file_entry != table_changes.new_delete_files.end() && !file_entry->second.empty();
+}
+
 void LocalTableChanges::GetLocalDeleteForFile(TableIndex table_id, const string &path, DuckLakeFileData &result) const {
 	lock_guard<mutex> guard(lock);
 	auto entry = changes.find(table_id);
@@ -2703,6 +2714,10 @@ void DuckLakeTransaction::AddCompaction(TableIndex table_id, DuckLakeCompactionE
 
 bool DuckLakeTransaction::HasLocalDeletes(TableIndex table_id) const {
 	return local_changes.HasLocalDeletes(table_id);
+}
+
+bool DuckLakeTransaction::HasLocalDeleteForFile(TableIndex table_id, const string &path) const {
+	return local_changes.HasLocalDeleteForFile(table_id, path);
 }
 
 bool DuckLakeTransaction::HasAnyLocalChanges(TableIndex table_id) const {

--- a/third_party/ducklake/test/sql/data_inlining/data_inlining_txn_delete_visibility.test
+++ b/third_party/ducklake/test/sql/data_inlining/data_inlining_txn_delete_visibility.test
@@ -1,0 +1,51 @@
+# name: test/sql/data_inlining/data_inlining_txn_delete_visibility.test
+# description: DELETE inside transaction not visible to subsequent reads when file has existing delete file
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS lake (DATA_PATH '${DATA_PATH}/txn_delete_vis', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+CREATE TABLE lake.test (id INTEGER, val INTEGER)
+
+statement ok
+INSERT INTO lake.test VALUES (1, 10), (2, 20), (3, 30)
+
+# Create a committed delete file on the parquet file
+statement ok
+DELETE FROM lake.test WHERE id = 1
+
+# Verify id=1 is gone
+query II
+SELECT * FROM lake.test ORDER BY id
+----
+2	20
+3	30
+
+# DELETE inside a transaction  id=2 should not be visible after DELETE
+statement ok
+BEGIN
+
+statement ok
+DELETE FROM lake.test WHERE id = 2
+
+query II
+SELECT * FROM lake.test ORDER BY id
+----
+3	30
+
+statement ok
+COMMIT
+
+query II
+SELECT * FROM lake.test ORDER BY id
+----
+3	30


### PR DESCRIPTION
Cherry-pick upstream duckdb/ducklake#922 (commits b227e159, 2ad4a50) into the ducklake subtree. Fixes DELETE silently failing for rows with existing delete files in the same transaction.

The fix adds HasLocalDeleteForFile() and conditionally skips the snapshot filter when the file has a local (uncommitted) delete, so the delete is visible to subsequent reads within the transaction.

Closes #145