### PR TITLE
test: add regression test for INSERT INTO with chained CTEs

### DIFF
--- a/test/regression/expected/insert_cte.out
+++ b/test/regression/expected/insert_cte.out
@@ -1,0 +1,42 @@
+-- Test INSERT INTO with CTEs (WITH ... SELECT) -- issue #148
+CREATE TABLE cte_src (id int, name text, amount numeric(12,2), ts timestamp) USING ducklake;
+CREATE TABLE cte_dst (id int, name text, total numeric(12,2), category text, processed_at timestamp) USING ducklake;
+INSERT INTO cte_src VALUES
+    (1, 'alice', 100.50, '2024-01-01 10:00:00'),
+    (2, 'bob',   200.75, '2024-01-02 11:00:00'),
+    (3, 'alice', 50.25,  '2024-01-03 12:00:00'),
+    (4, 'carol', 300.00, '2024-01-04 13:00:00'),
+    (5, 'bob',   150.00, '2024-01-05 14:00:00');
+-- Complex chained CTE ETL pattern
+INSERT INTO cte_dst
+WITH t1 AS (
+    SELECT id, name, amount, ts,
+           CASE WHEN amount > 200 THEN 'high'
+                WHEN amount > 100 THEN 'medium'
+                ELSE 'low' END AS category
+    FROM cte_src
+    WHERE ts >= '2024-01-01'::timestamp
+),
+t2 AS (
+    SELECT name, SUM(amount) AS total, category, MAX(ts) AS last_ts
+    FROM t1
+    GROUP BY name, category
+),
+t3 AS (
+    SELECT ROW_NUMBER() OVER (ORDER BY total DESC) AS id,
+           name, total, category, last_ts AS processed_at
+    FROM t2
+)
+SELECT * FROM t3;
+SELECT * FROM cte_dst ORDER BY id;
+ id | name  | total  | category |       processed_at       
+----+-------+--------+----------+--------------------------
+  1 | carol | 300.00 | high     | Thu Jan 04 13:00:00 2024
+  2 | bob   | 200.75 | high     | Tue Jan 02 11:00:00 2024
+  3 | bob   | 150.00 | medium   | Fri Jan 05 14:00:00 2024
+  4 | alice | 100.50 | medium   | Mon Jan 01 10:00:00 2024
+  5 | alice |  50.25 | low      | Wed Jan 03 12:00:00 2024
+(5 rows)
+
+DROP TABLE cte_dst;
+DROP TABLE cte_src;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -8,6 +8,7 @@ test: transaction
 test: non_ducklake_commit
 test: temp_table
 test: insert_unnest
+test: insert_cte
 test: ctas
 test: gucs
 test: default_table_path

--- a/test/regression/sql/insert_cte.sql
+++ b/test/regression/sql/insert_cte.sql
@@ -1,0 +1,38 @@
+-- Test INSERT INTO with CTEs (WITH ... SELECT) -- issue #148
+
+CREATE TABLE cte_src (id int, name text, amount numeric(12,2), ts timestamp) USING ducklake;
+CREATE TABLE cte_dst (id int, name text, total numeric(12,2), category text, processed_at timestamp) USING ducklake;
+
+INSERT INTO cte_src VALUES
+    (1, 'alice', 100.50, '2024-01-01 10:00:00'),
+    (2, 'bob',   200.75, '2024-01-02 11:00:00'),
+    (3, 'alice', 50.25,  '2024-01-03 12:00:00'),
+    (4, 'carol', 300.00, '2024-01-04 13:00:00'),
+    (5, 'bob',   150.00, '2024-01-05 14:00:00');
+
+-- Complex chained CTE ETL pattern
+INSERT INTO cte_dst
+WITH t1 AS (
+    SELECT id, name, amount, ts,
+           CASE WHEN amount > 200 THEN 'high'
+                WHEN amount > 100 THEN 'medium'
+                ELSE 'low' END AS category
+    FROM cte_src
+    WHERE ts >= '2024-01-01'::timestamp
+),
+t2 AS (
+    SELECT name, SUM(amount) AS total, category, MAX(ts) AS last_ts
+    FROM t1
+    GROUP BY name, category
+),
+t3 AS (
+    SELECT ROW_NUMBER() OVER (ORDER BY total DESC) AS id,
+           name, total, category, last_ts AS processed_at
+    FROM t2
+)
+SELECT * FROM t3;
+
+SELECT * FROM cte_dst ORDER BY id;
+
+DROP TABLE cte_dst;
+DROP TABLE cte_src;


### PR DESCRIPTION
## Summary
- Add regression test covering complex ETL-style `INSERT INTO ... WITH` chained CTEs (CASE, aggregation, window functions)
- Attempted to reproduce #148 but could not on PG 17 or PG 18 -- adding the test for coverage

Relates to #148

## Test plan
- `insert_cte` regression test: chained CTEs (t1 -> t2 -> t3) with CASE expressions, SUM/MAX aggregation, and ROW_NUMBER() window function inserted into a ducklake target table