### PR TITLE
chore: update skills and docs for subtree terminology

### DIFF
--- a/.claude/skills/coding-rules/SKILL.md
+++ b/.claude/skills/coding-rules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding-rules
-description: "Code style, include order, docs update rules, and submodule policy. MUST consult when: writing or modifying C/C++ files (include order matters), adding/removing/changing ducklake.* SQL functions or procedures (docs/sql_objects.md must be updated), editing third_party/ code, or reviewing code for style."
+description: "Code style, include order, docs update rules, and third-party dependency policy. MUST consult when: writing or modifying C/C++ files (include order matters), adding/removing/changing ducklake.* SQL functions or procedures (docs/sql_objects.md must be updated), editing third_party/ code, or reviewing code for style."
 ---
 
 # Coding Rules
@@ -47,7 +47,7 @@ PostgreSQL and DuckDB headers are conflict-prone. Follow strict include order in
 
 **FATAL macro conflict:** PostgreSQL's `elog.h` defines `#define FATAL 22`, which clobbers DuckDB's `ExceptionType::FATAL` enum member in `duckdb/common/exception.hpp`. Any header that transitively includes both will break. The fix is include order: DuckDB's `exception.hpp` (or any header that pulls it in, e.g., `string_util.hpp`, `error_data.hpp`) must be parsed *before* `postgres.h` defines the macro. Once parsed, C++ include guards prevent re-inclusion. Watch for indirect includes -- `pgduckdb/pgduckdb_contracts.hpp` and `pgducklake/utility/cpp_wrapper.hpp` both include `postgres.h`, so any DuckDB header they transitively need must already be included earlier in the translation unit.
 
-## Third-party Submodules
+## Third-party Dependencies (Subtrees)
 
 Treat `third_party/pg_duckdb` as upstream:
 

--- a/.claude/skills/commit-message-format/SKILL.md
+++ b/.claude/skills/commit-message-format/SKILL.md
@@ -103,9 +103,9 @@ command line tools requirements.
 ### Chore/maintenance
 
 ```
-chore: update pg_duckdb submodule to v0.3.0
+chore: pull pg_duckdb subtree for DuckDB 1.2 compat
 
-Pulls in upstream fixes for DuckDB 1.2 compatibility.
+Pulls in upstream fixes from relytcloud/pg_duckdb.
 ```
 
 ## How to Create the Commit
@@ -133,26 +133,6 @@ git commit -m "$(cat <<'EOF'
 <optional body>
 EOF
 )"
-```
-
-## Submodule Changes
-
-When `third_party/pg_duckdb` (or any submodule) is modified, **commit
-the submodule pointer bump together with the pg_ducklake changes that
-depend on it**. This keeps the change atomic -- the new export and its
-consumer land in one reviewable unit:
-
-```bash
-git add third_party/pg_duckdb <other dependent files>
-git commit -m "<type>: <description>"
-```
-
-If the submodule update is unrelated to any pg_ducklake change (e.g.,
-a pure upstream upgrade), commit it alone:
-
-```bash
-git add third_party/pg_duckdb
-git commit -m "chore: bump pg_duckdb to <version/reason>"
 ```
 
 ## What NOT to Commit

--- a/.claude/skills/fix-ci/SKILL.md
+++ b/.claude/skills/fix-ci/SKILL.md
@@ -21,7 +21,7 @@ git log --oneline -10
 
 ### 2. Craft Commit Message
 
-Use `workflow-commit` skill conventions to create a proper Conventional Commits message.
+Use `commit-message-format` skill conventions to create a proper Conventional Commits message.
 
 ### 3. Commit Changes
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -17,21 +17,9 @@ git status -u                         # uncommitted changes
 git diff origin/main...HEAD --stat    # files changed vs base
 git log --oneline origin/main..HEAD   # commits to include
 git remote -v                         # available remotes
-git submodule status                  # check submodule state
 ```
 
-### 2. Handle submodule changes
-
-If any submodules have modifications (dirty or new commits):
-
-1. For each modified submodule, commit changes inside the submodule first.
-2. **Ask the user** which remote/branch to push each submodule to. Never assume.
-3. Push each submodule before proceeding.
-4. Back in the root project, stage the updated submodule pointers (`git add <submodule-path>`).
-
-**Critical:** The root project must only be pushed AFTER all submodules are pushed. CI clones submodules recursively and will fail if it cannot find the submodule commits.
-
-### 3. Create and push branch
+### 2. Create and push branch
 
 Derive a branch name from the commit subjects (e.g. `feat/snapshot-trigger`). If unsure, ask the user.
 
@@ -42,7 +30,7 @@ git push -u origin <branch-name>
 
 If already on a non-main branch, just push.
 
-### 4. Open the PR
+### 3. Open the PR
 
 Use `gh pr create`. Write a concise title (<70 chars) and a body with a Summary section. Only include a Test plan section if the PR adds or changes tests. Use a HEREDOC for the body:
 
@@ -58,7 +46,7 @@ EOF
 )"
 ```
 
-### 5. Report
+### 4. Report
 
 Print the PR URL so the user can see it.
 
@@ -68,4 +56,3 @@ Print the PR URL so the user can see it.
 - Prefer specific `git add` over `git add -A`.
 - If there are uncommitted changes, ask the user whether to commit them first.
 - If `Closes #N` applies, include it in the body.
-- Always push submodules before the root project -- CI will break otherwise.

--- a/.claude/skills/setup-dev/SKILL.md
+++ b/.claude/skills/setup-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-dev
-description: "Dev environment setup: build tools, PostgreSQL, submodules, worktrees. Always import on EnterWorktree/ExitWorktree."
+description: "Dev environment setup: build tools, PostgreSQL, subtrees, submodule, worktrees. Always import on EnterWorktree/ExitWorktree."
 user-invocable: true
 ---
 
@@ -14,8 +14,8 @@ already done, and present options to the user via `AskUserQuestion`.
 - **Global build cache**: ccache in `~/.ccache`, shared across all worktrees.
 - **Single clone per repo**: one clone each for pg_ducklake and postgres; use
   git worktrees for parallel work.
-- **Submodule sharing**: `git worktree add` on each submodule's git repo
-  to share the same object store across worktrees.
+- **Submodule worktree sharing**: the only submodule (`duckdb`) uses
+  `git worktree add` to share the same object store across worktrees.
 
 ---
 
@@ -27,7 +27,8 @@ Run these checks silently to understand what is already set up:
 command -v ccache                          # compiler cache
 ls pg-*/bin/pg_config 2>/dev/null          # local PG installs in workdir
 ls ~/.dev/pg-*/configure 2>/dev/null       # PG source worktrees
-ls third_party/pg_duckdb/Makefile 2>/dev/null  # submodules initialized?
+ls third_party/pg_duckdb/Makefile 2>/dev/null  # subtrees present? (committed directly)
+ls third_party/pg_duckdb/third_party/duckdb/Makefile 2>/dev/null  # duckdb submodule initialized?
 git worktree list                          # current worktree situation
 ```
 
@@ -136,7 +137,7 @@ grep -qF 'pg-*/' "$exclude_file" 2>/dev/null || echo 'pg-*/' >> "$exclude_file"
 
 ---
 
-## Step 4: Submodules and subtrees
+## Step 4: Subtrees and submodule
 
 ### pg_duckdb (subtree) and duckdb (submodule)
 
@@ -247,9 +248,9 @@ and the SQL files into the PG extension directory.
 - `echo $CMAKE_C_COMPILER_LAUNCHER` is `ccache`
 - cmake is picking it up: check build logs for `ccache` in compiler command
 
-**Wrong submodule commit** -- reset to what the branch expects:
+**Wrong duckdb submodule commit** -- reset to what the branch expects:
 ```bash
-git submodule update third_party/pg_duckdb
+git submodule update third_party/pg_duckdb/third_party/duckdb
 ```
 
 **PG configure fails** -- missing build deps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ SQL is parsed and converted to DuckDB SQL by `DuckdbPlannerHook`, then passed to
 
 ## Build and Test Commands
 
-See `setup-dev` skill for full dev environment setup (ccache, PostgreSQL from source, submodules, worktrees). See `commit-message-format`, `pr`, and `fix-ci` skills for git/CI workflows.
+See `setup-dev` skill for full dev environment setup (ccache, PostgreSQL from source, subtrees, worktrees). See `commit-message-format`, `pr`, and `fix-ci` skills for git/CI workflows.
 
 Supported PostgreSQL versions: 14, 15, 16, 17, 18.
 


### PR DESCRIPTION
## Summary
- Updated `setup-dev`, `coding-rules`, `commit-message-format`, `pr`, and `fix-ci` skills to use correct subtree terminology after the submodule-to-subtree migration
- Removed unnecessary "Handle submodule/subtree changes" sections from `pr` and `commit-message-format` skills since `third_party/*` changes are ordinary commits
- Fixed stale `workflow-commit` skill reference in `fix-ci` (renamed to `commit-message-format`)