### PR TITLE
fix: skip snapshot sync trigger during DuckDB commit

### DIFF
--- a/include/pgducklake/pgducklake_guc.hpp
+++ b/include/pgducklake/pgducklake_guc.hpp
@@ -7,6 +7,8 @@ extern double vacuum_delete_threshold;
 extern bool enable_direct_insert;
 extern bool ctas_skip_data;
 
+extern bool enable_metadata_sync;
+
 extern char *superuser_role;
 extern char *writer_role;
 extern char *reader_role;

--- a/include/pgducklake/pgducklake_sync.hpp
+++ b/include/pgducklake/pgducklake_sync.hpp
@@ -12,10 +12,24 @@ namespace pgducklake {
  * ducklake_sorted indexes during sync. */
 extern bool syncing_from_metadata;
 
-/* When true the snapshot trigger skips all sync handlers.  Set by the
- * direct insert path which only inserts inlined data rows -- no DDL
- * or sort-key changes that need reverse-syncing to pg_class. */
+/* When true the snapshot trigger skips all sync handlers.  Managed
+ * exclusively via SkipSnapshotSyncGuard -- do not set directly. */
 extern bool skip_snapshot_sync;
+
+/* RAII guard: sets skip_snapshot_sync = true on construction, resets
+ * on destruction.  Use in any code path that inserts into
+ * ducklake_snapshot but has no DDL changes to reverse-sync (direct
+ * insert, ExecuteCommit). */
+struct SkipSnapshotSyncGuard {
+  SkipSnapshotSyncGuard() {
+    skip_snapshot_sync = true;
+  }
+  ~SkipSnapshotSyncGuard() {
+    skip_snapshot_sync = false;
+  }
+  SkipSnapshotSyncGuard(const SkipSnapshotSyncGuard &) = delete;
+  SkipSnapshotSyncGuard &operator=(const SkipSnapshotSyncGuard &) = delete;
+};
 
 /* Signature for per-object-type sync handlers.
  * Called by ducklake_snapshot_trigger for each new snapshot,

--- a/src/pgducklake_direct_insert.cpp
+++ b/src/pgducklake_direct_insert.cpp
@@ -727,9 +727,9 @@ static TupleTableSlot *DirectInsert_ExecCustomScan(CustomScanState *node) {
 
   // Create the snapshot record immediately while we still have an active
   // PostgreSQL snapshot. This makes the inserted rows visible to subsequent
-  // DuckLake queries.  Tell the snapshot trigger to skip sync handlers --
-  // direct insert only adds inlined data rows, no DDL changes to reverse-sync.
-  pgducklake::skip_snapshot_sync = true;
+  // DuckLake queries.  Guard skips the sync trigger -- direct insert only
+  // adds inlined data rows, no DDL changes to reverse-sync.
+  pgducklake::SkipSnapshotSyncGuard sync_guard;
   pgducklake::CreateSnapshotForDirectInsert(state->begin_snapshot, state->schema_version, state->table_id,
                                             state->rows_inserted);
 

--- a/src/pgducklake_guc.cpp
+++ b/src/pgducklake_guc.cpp
@@ -22,6 +22,8 @@ double vacuum_delete_threshold = 0.1;
 bool enable_direct_insert = true;
 bool ctas_skip_data = false;
 
+bool enable_metadata_sync = true;
+
 char *superuser_role = strdup("ducklake_superuser");
 char *writer_role = strdup("ducklake_writer");
 char *reader_role = strdup("ducklake_reader");
@@ -41,6 +43,15 @@ void RegisterGUCs() {
                            "Enable direct insert optimization for INSERT ... "
                            "SELECT UNNEST($n) statements.",
                            NULL, &enable_direct_insert, true, PGC_USERSET, 0, NULL, NULL, NULL);
+
+  DefineCustomBoolVariable("ducklake.enable_metadata_sync",
+                           "Enable reverse metadata sync from DuckDB to PostgreSQL. "
+                           "When enabled (default), a snapshot trigger detects tables "
+                           "created or dropped by external DuckDB clients and syncs "
+                           "the corresponding pg_class entries. Disable this when all "
+                           "DDL and DML goes through PostgreSQL, to avoid the per-commit "
+                           "trigger overhead.",
+                           NULL, &enable_metadata_sync, true, PGC_USERSET, 0, NULL, NULL, NULL);
 
   DefineCustomStringVariable("ducklake.superuser_role",
                              "Role with full DDL + DML access to DuckLake tables. "

--- a/src/pgducklake_metadata_manager.cpp
+++ b/src/pgducklake_metadata_manager.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "pgducklake/pgducklake_metadata_manager.hpp"
+#include "pgducklake/pgducklake_sync.hpp"
 
 // DuckDB headers first
 #include "duckdb/common/allocator.hpp"
@@ -439,6 +440,12 @@ duckdb::unique_ptr<duckdb::QueryResult> PgDuckLakeMetadataManager::ExecuteCommit
                                                                                  duckdb::string query) {
   DuckLakeMetadataManager::FillSnapshotArgs(query, snapshot);
   SubstituteCatalogPlaceholders(query);
+  /* Skip the snapshot sync trigger during commit.  The trigger exists
+   * for external DuckDB clients that write directly to the ducklake
+   * metadata tables; pg_ducklake's own commits have nothing to
+   * reverse-sync.  Running the trigger on a DuckDB worker thread
+   * crashes because PG's InterruptHoldoffCount is not thread-safe. */
+  SkipSnapshotSyncGuard sync_guard;
   return CreateSPIExecuteInSubtransaction(query);
 }
 

--- a/src/pgducklake_sync.cpp
+++ b/src/pgducklake_sync.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "pgducklake/pgducklake_defs.hpp"
+#include "pgducklake/pgducklake_guc.hpp"
 #include "pgducklake/pgducklake_sync.hpp"
 
 #include <duckdb/common/error_data.hpp> /* must precede postgres.h (FATAL macro) */
@@ -72,10 +73,14 @@ DECLARE_PG_FUNCTION(ducklake_snapshot_trigger) {
 
   TriggerData *trigdata = (TriggerData *)fcinfo->context;
 
-  /* Direct insert path sets skip_snapshot_sync -- no DDL or sort-key
-   * changes to reverse-sync, so skip the expensive SPI queries. */
-  if (pgducklake::skip_snapshot_sync) {
-    pgducklake::skip_snapshot_sync = false;
+  /* Skip sync when:
+   *  - skip_snapshot_sync is set (direct insert / ExecuteCommit paths
+   *    have no DDL changes to reverse-sync; running sync handlers on
+   *    a DuckDB worker thread would also crash because PG's
+   *    InterruptHoldoffCount is not thread-safe), or
+   *  - enable_metadata_sync GUC is off (user opts out of the
+   *    per-commit sync overhead when all DDL goes through PG). */
+  if (pgducklake::skip_snapshot_sync || !pgducklake::enable_metadata_sync) {
     return PointerGetDatum(trigdata->tg_trigtuple);
   }
 

--- a/test/regression/expected/gucs.out
+++ b/test/regression/expected/gucs.out
@@ -48,3 +48,27 @@ SHOW ducklake.enable_direct_insert;
 (1 row)
 
 RESET ducklake.enable_direct_insert;
+SHOW ducklake.enable_metadata_sync;
+ ducklake.enable_metadata_sync 
+-------------------------------
+ on
+(1 row)
+
+SET ducklake.enable_metadata_sync = false;
+SHOW ducklake.enable_metadata_sync;
+ ducklake.enable_metadata_sync 
+-------------------------------
+ off
+(1 row)
+
+-- DML should still work with metadata sync disabled
+CREATE TABLE guc_sync_test (id int, val text) USING ducklake;
+INSERT INTO guc_sync_test VALUES (1, 'hello');
+SELECT * FROM guc_sync_test;
+ id |  val  
+----+-------
+  1 | hello
+(1 row)
+
+DROP TABLE guc_sync_test;
+RESET ducklake.enable_metadata_sync;

--- a/test/regression/sql/gucs.sql
+++ b/test/regression/sql/gucs.sql
@@ -16,3 +16,15 @@ RESET ducklake.vacuum_delete_threshold;
 SET ducklake.enable_direct_insert = false;
 SHOW ducklake.enable_direct_insert;
 RESET ducklake.enable_direct_insert;
+
+SHOW ducklake.enable_metadata_sync;
+SET ducklake.enable_metadata_sync = false;
+SHOW ducklake.enable_metadata_sync;
+
+-- DML should still work with metadata sync disabled
+CREATE TABLE guc_sync_test (id int, val text) USING ducklake;
+INSERT INTO guc_sync_test VALUES (1, 'hello');
+SELECT * FROM guc_sync_test;
+DROP TABLE guc_sync_test;
+
+RESET ducklake.enable_metadata_sync;


### PR DESCRIPTION
## Summary

- Fix server crash (assertion `InterruptHoldoffCount > 0` in `lwlock.c`) during DuckDB commit on worker threads by setting `skip_snapshot_sync = true` in `ExecuteCommit`
- Add `ducklake.enable_metadata_sync` GUC (default `on`) to let users disable the per-commit snapshot sync trigger entirely when all DDL/DML goes through PostgreSQL

**Root cause:** DuckDB commits run on a worker thread (`TaskScheduler::ExecuteForever`). The metadata manager's `ExecuteCommit` inserts into `ducklake_snapshot`, firing the sync trigger which does nested SPI. PG's `InterruptHoldoffCount` is process-global and not thread-safe, causing the assertion failure.

**Fix:** pg_ducklake's own commits have nothing to reverse-sync -- DDL goes through PG event triggers, DML only adds data. Skip the trigger, matching the existing direct insert path pattern.

**GUC:** `ducklake.enable_metadata_sync = off` disables the trigger for all commits, eliminating the per-commit overhead for deployments where no external DuckDB clients write to the metadata tables.

Closes #167

## Test plan

- [x] All 40 regression tests pass
- [x] All 3 isolation tests pass
- [x] New GUC test: SHOW/SET/DML-with-sync-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)