### PR TITLE
fix: convert expire_snapshots to wrapper macro pattern

### DIFF
--- a/include/pgducklake/pgducklake_functions.hpp
+++ b/include/pgducklake/pgducklake_functions.hpp
@@ -21,7 +21,6 @@ void RegisterScalarMacros(duckdb::DatabaseInstance &db);
 void RegisterCleanupFunction(duckdb::DatabaseInstance &db);
 void RegisterCleanupOrphanedFilesFunction(duckdb::DatabaseInstance &db);
 void RegisterCompactionFunctions(duckdb::DatabaseInstance &db);
-void RegisterExpireSnapshotsFunction(duckdb::DatabaseInstance &db);
 void RegisterFlushInlinedDataFunction(duckdb::DatabaseInstance &db);
 
 } // namespace pgducklake

--- a/src/pgducklake_duckdb.cpp
+++ b/src/pgducklake_duckdb.cpp
@@ -115,7 +115,6 @@ void ducklake_load_extension(duckdb::DuckDB &db) {
   pgducklake::RegisterCleanupFunction(*db.instance);
   pgducklake::RegisterCleanupOrphanedFilesFunction(*db.instance);
   pgducklake::RegisterCompactionFunctions(*db.instance);
-  pgducklake::RegisterExpireSnapshotsFunction(*db.instance);
   pgducklake::RegisterFlushInlinedDataFunction(*db.instance);
 
   ducklake_attach_catalog();

--- a/src/pgducklake_functions.cpp
+++ b/src/pgducklake_functions.cpp
@@ -118,6 +118,9 @@ static const DefaultTableMacro pg_ducklake_wrapper_macros[] = {
    "FROM ducklake_table_info('" PGDUCKLAKE_DUCKDB_CATALOG "')"},
   {DEFAULT_SCHEMA, "options", {nullptr}, {{nullptr, nullptr}},
    "FROM ducklake_options('" PGDUCKLAKE_DUCKDB_CATALOG "')"},
+  // maintenance functions (no args)
+  {DEFAULT_SCHEMA, "expire_snapshots", {nullptr}, {{nullptr, nullptr}},
+   "FROM ducklake_expire_snapshots('" PGDUCKLAKE_DUCKDB_CATALOG "')"},
   // table-scoped functions
   {DEFAULT_SCHEMA, "list_files", {"schema_name", "table_name", nullptr}, {{nullptr, nullptr}},
    "FROM ducklake_list_files('" PGDUCKLAKE_DUCKDB_CATALOG "', table_name, schema => schema_name)"},
@@ -359,27 +362,6 @@ static void RegisterOneCompactionFunction(DatabaseInstance &db, const string &pg
 void RegisterCompactionFunctions(DatabaseInstance &db) {
   RegisterOneCompactionFunction(db, "merge_adjacent_files", MergeNoArgsBind, MergeTableArgsBind);
   RegisterOneCompactionFunction(db, "rewrite_data_files", RewriteNoArgsBind, RewriteTableArgsBind);
-}
-
-/*
- * expire_snapshots(): no-args only. Interval overload omitted because
- * pg_duckdb deparses PG intervals in @ format which DuckDB cannot parse.
- */
-static unique_ptr<FunctionData> ExpireNoArgsBind(ClientContext &context, TableFunctionBindInput &input,
-                                                 vector<LogicalType> &return_types, vector<string> &names) {
-  input.inputs.clear();
-  input.inputs.push_back(duckdb::Value(PGDUCKLAKE_DUCKDB_CATALOG));
-  input.named_parameters.clear();
-
-  auto func = LookupUpstreamFunction(context, "ducklake_expire_snapshots");
-  input.table_function = func;
-  return func.bind(context, input, return_types, names);
-}
-
-void RegisterExpireSnapshotsFunction(DatabaseInstance &db) {
-  TableFunctionSet set("expire_snapshots");
-  set.AddFunction(TableFunction({}, UnreachableExecute, ExpireNoArgsBind, UnreachableInit));
-  RegisterTableFunctionSet(db, set);
 }
 
 /*


### PR DESCRIPTION
## Summary

- Replace the bind-pattern `TableFunctionSet` for `expire_snapshots` with a wrapper table macro, matching the proven pattern used by `snapshots`, `options`, `table_info`, etc.
- Remove `ExpireNoArgsBind`, `RegisterExpireSnapshotsFunction`, and the associated registration call

The bind pattern was fragile -- it relied on `input.table_function` copy-assignment during bind and broke when DuckDB-only function routing failed to rewrite `ducklake.expire_snapshots()` to `system.main.expire_snapshots()`.

Closes #168

## Test plan

- [x] `make check-regression TEST=maintenance` passes (expire_snapshots test case)
- [x] Full `make installcheck` passes (40 regression + 3 isolation tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)