### PR TITLE
fix: preserve decimal precision in DuckDB SQL deparse

### DIFF
--- a/test/regression/expected/decimal_precision.out
+++ b/test/regression/expected/decimal_precision.out
@@ -1,0 +1,68 @@
+-- Test DECIMAL/NUMERIC precision is preserved through DuckDB (#171)
+-- Wide precision: DECIMAL(31,3) -- exceeds DuckDB's default DECIMAL(18,3)
+CREATE TABLE t_decimal_wide (usd decimal(31, 3)) USING ducklake;
+-- Insert a large value that overflows DECIMAL(18,3) but fits DECIMAL(31,3)
+INSERT INTO t_decimal_wide VALUES (1.7820000000000002e+16);
+-- Insert normal values
+INSERT INTO t_decimal_wide VALUES (12345.678);
+INSERT INTO t_decimal_wide VALUES (0.001);
+INSERT INTO t_decimal_wide VALUES (-99999999999999.999);
+SELECT * FROM t_decimal_wide ORDER BY usd;
+          usd          
+-----------------------
+   -99999999999999.999
+                 0.001
+             12345.678
+ 17820000000000002.000
+(4 rows)
+
+-- Max precision: DECIMAL(38,10)
+CREATE TABLE t_decimal_max (val decimal(38, 10)) USING ducklake;
+INSERT INTO t_decimal_max VALUES (12345678901234567890.1234567890);
+INSERT INTO t_decimal_max VALUES (-12345678901234567890.1234567890);
+SELECT * FROM t_decimal_max ORDER BY val;
+               val                
+----------------------------------
+ -12345678901234567890.1234567890
+  12345678901234567890.1234567890
+(2 rows)
+
+-- Verify PG column types are preserved
+\d+ t_decimal_wide
+                                 Table "public.t_decimal_wide"
+ Column |     Type      | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------------+-----------+----------+---------+---------+--------------+-------------
+ usd    | numeric(31,3) |           |          |         | main    |              | 
+
+\d+ t_decimal_max
+                                  Table "public.t_decimal_max"
+ Column |      Type      | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+----------------+-----------+----------+---------+---------+--------------+-------------
+ val    | numeric(38,10) |           |          |         | main    |              | 
+
+-- Verify DuckDB-side column types in ducklake metadata
+SELECT c.column_name, c.column_type
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 't_decimal_wide' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL
+ORDER BY c.column_order;
+ column_name |  column_type  
+-------------+---------------
+ usd         | decimal(31,3)
+(1 row)
+
+SELECT c.column_name, c.column_type
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 't_decimal_max' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL
+ORDER BY c.column_order;
+ column_name |  column_type   
+-------------+----------------
+ val         | decimal(38,10)
+(1 row)
+
+-- Cleanup
+DROP TABLE t_decimal_wide;
+DROP TABLE t_decimal_max;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -17,6 +17,7 @@ test: options
 test: data_inlining_row_limit
 test: inlined_data_schema_change
 test: types
+test: decimal_precision
 test: variant
 test: readme_examples
 test: ddl

--- a/test/regression/sql/decimal_precision.sql
+++ b/test/regression/sql/decimal_precision.sql
@@ -1,0 +1,43 @@
+-- Test DECIMAL/NUMERIC precision is preserved through DuckDB (#171)
+
+-- Wide precision: DECIMAL(31,3) -- exceeds DuckDB's default DECIMAL(18,3)
+CREATE TABLE t_decimal_wide (usd decimal(31, 3)) USING ducklake;
+
+-- Insert a large value that overflows DECIMAL(18,3) but fits DECIMAL(31,3)
+INSERT INTO t_decimal_wide VALUES (1.7820000000000002e+16);
+
+-- Insert normal values
+INSERT INTO t_decimal_wide VALUES (12345.678);
+INSERT INTO t_decimal_wide VALUES (0.001);
+INSERT INTO t_decimal_wide VALUES (-99999999999999.999);
+
+SELECT * FROM t_decimal_wide ORDER BY usd;
+
+-- Max precision: DECIMAL(38,10)
+CREATE TABLE t_decimal_max (val decimal(38, 10)) USING ducklake;
+INSERT INTO t_decimal_max VALUES (12345678901234567890.1234567890);
+INSERT INTO t_decimal_max VALUES (-12345678901234567890.1234567890);
+SELECT * FROM t_decimal_max ORDER BY val;
+
+-- Verify PG column types are preserved
+\d+ t_decimal_wide
+\d+ t_decimal_max
+
+-- Verify DuckDB-side column types in ducklake metadata
+SELECT c.column_name, c.column_type
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 't_decimal_wide' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL
+ORDER BY c.column_order;
+
+SELECT c.column_name, c.column_type
+FROM ducklake.ducklake_column c
+JOIN ducklake.ducklake_table t ON c.table_id = t.table_id
+WHERE t.table_name = 't_decimal_max' AND t.end_snapshot IS NULL
+  AND c.end_snapshot IS NULL
+ORDER BY c.column_order;
+
+-- Cleanup
+DROP TABLE t_decimal_wide;
+DROP TABLE t_decimal_max;

--- a/third_party/pg_duckdb/src/pgduckdb_ruleutils.cpp
+++ b/third_party/pg_duckdb/src/pgduckdb_ruleutils.cpp
@@ -381,6 +381,17 @@ pgduckdb_show_type(Const *constval, int original_showtype) {
 	if (pgduckdb_is_fake_type(constval->consttype)) {
 		return -1;
 	}
+	/*
+	 * Suppress "::numeric" for unqualified NUMERIC constants (typmod == -1).
+	 * PG's unqualified NUMERIC is arbitrary precision, but DuckDB interprets
+	 * "::numeric" as DECIMAL(18,3).  Dropping the cast lets DuckDB infer the
+	 * type from context (e.g. target column type for INSERT).  Qualified casts
+	 * like "::numeric(31,3)" are preserved because format_type_with_typemod
+	 * produces the precision/scale that DuckDB can parse.
+	 */
+	if (constval->consttype == NUMERICOID && constval->consttypmod == -1) {
+		return -1;
+	}
 	return original_showtype;
 }
 
@@ -714,8 +725,8 @@ pgduckdb_get_tabledef(Oid relation_oid) {
 		pgduckdb::GetPostgresDuckDBType(duck_type, true);
 
 		const char *passthrough_name = pgduckdb::GetPassthroughTypeName(column->atttypid);
-		const char *column_type_name = passthrough_name ? passthrough_name
-		                                                : format_type_with_typemod(column->atttypid, column->atttypmod);
+		const char *column_type_name =
+		    passthrough_name ? passthrough_name : format_type_with_typemod(column->atttypid, column->atttypmod);
 
 		if (first_column_printed) {
 			appendStringInfoString(&buffer, ", ");
@@ -991,8 +1002,8 @@ pgduckdb_get_alter_tabledef(Oid relation_oid, AlterTableStmt *alter_stmt) {
 			TupleDesc tupdesc = BuildDescForRelation(list_make1(col));
 			Form_pg_attribute attribute = TupleDescAttr(tupdesc, 0);
 			const char *add_passthrough = pgduckdb::GetPassthroughTypeName(attribute->atttypid);
-			const char *column_fq_type = add_passthrough ? add_passthrough
-			                                             : format_type_with_typemod(attribute->atttypid, attribute->atttypmod);
+			const char *column_fq_type =
+			    add_passthrough ? add_passthrough : format_type_with_typemod(attribute->atttypid, attribute->atttypmod);
 
 			appendStringInfo(&buffer, "ADD COLUMN %s %s", quote_identifier(col->colname), column_fq_type);
 			foreach_node(Constraint, constraint, col->constraints) {
@@ -1051,8 +1062,9 @@ pgduckdb_get_alter_tabledef(Oid relation_oid, AlterTableStmt *alter_stmt) {
 			TupleDesc tupdesc = BuildDescForRelation(list_make1(col));
 			Form_pg_attribute attribute = TupleDescAttr(tupdesc, 0);
 			const char *alter_passthrough = pgduckdb::GetPassthroughTypeName(attribute->atttypid);
-			const char *column_fq_type = alter_passthrough ? alter_passthrough
-			                                               : format_type_with_typemod(attribute->atttypid, attribute->atttypmod);
+			const char *column_fq_type = alter_passthrough
+			                                 ? alter_passthrough
+			                                 : format_type_with_typemod(attribute->atttypid, attribute->atttypmod);
 			/* TODO: Disallow after SET DEFAULT/ADD CHECK CONSTRAINTin the same ALTER command */
 
 			appendStringInfo(&buffer, "ALTER COLUMN %s TYPE %s; ", quote_identifier(column_name), column_fq_type);


### PR DESCRIPTION
## Summary

- Suppress `::numeric` type cast for unqualified NUMERIC constants (typmod == -1) in pg_duckdb's SQL deparse
- DuckDB interprets `::numeric` as `DECIMAL(18,3)`, which overflows for large values that PG's arbitrary-precision NUMERIC handles fine
- Dropping the cast lets DuckDB infer the type from context (e.g. target column type for INSERT); qualified casts like `::numeric(31,3)` are preserved

Closes #171

## Test plan

- [x] New `decimal_precision` regression test verifies:
  - INSERT of values exceeding DECIMAL(18,3) into DECIMAL(31,3) and DECIMAL(38,10) columns
  - PG catalog shows correct `numeric(p,s)` types via `\d+`
  - DuckDB metadata (`ducklake.ducklake_column.column_type`) shows correct `decimal(p,s)` types
- [x] All 41 regression + 3 isolation tests pass (PG 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)