### PR TITLE
fix: use per-table schema version check for direct insert guard

### DIFF
--- a/src/pgducklake_metadata_manager.cpp
+++ b/src/pgducklake_metadata_manager.cpp
@@ -622,14 +622,32 @@ bool GetTableInliningInfo(Oid table_oid, uint64_t *table_id_out, uint64_t *schem
   char *schema_name = NameStr(nstup->nspname);
   ReleaseSysCache(ntp);
 
+  /* Single SPI query that returns all the information we need:
+   *   col 0: table_id          -- from ducklake_table
+   *   col 1: inlined schema_version -- from ducklake_inlined_data_tables
+   *   col 2: data_inlining_row_limit -- from ducklake_metadata (NULL if unset)
+   *   col 3: max per-table schema_version -- from ducklake_schema_versions
+   *
+   * Returns 0 rows when the table doesn't exist or has no inlined
+   * data entry.  A NULL in col 2 means the limit was not explicitly
+   * set; a NULL in col 3 means no ALTER has ever been performed on
+   * this table (safe to proceed). */
   StringInfoData query;
   initStringInfo(&query);
   appendStringInfo(&query,
-                   "SELECT dt.table_id, idt.schema_version "
+                   "SELECT dt.table_id, "
+                   "       idt.schema_version, "
+                   "       (SELECT m.value::bigint "
+                   "        FROM ducklake.ducklake_metadata m "
+                   "        WHERE m.key = 'data_inlining_row_limit' "
+                   "        AND m.scope IS NULL), "
+                   "       (SELECT MAX(sv.schema_version) "
+                   "        FROM ducklake.ducklake_schema_versions sv "
+                   "        WHERE sv.table_id = dt.table_id) "
                    "FROM ducklake.ducklake_table dt "
                    "JOIN ducklake.ducklake_schema ds ON dt.schema_id = ds.schema_id "
-                   "LEFT JOIN ducklake.ducklake_inlined_data_tables idt ON idt.table_id = "
-                   "dt.table_id "
+                   "LEFT JOIN ducklake.ducklake_inlined_data_tables idt "
+                   "  ON idt.table_id = dt.table_id "
                    "WHERE dt.table_name = '%s' "
                    "AND ds.schema_name = '%s' "
                    "AND dt.end_snapshot IS NULL "
@@ -642,75 +660,41 @@ bool GetTableInliningInfo(Oid table_oid, uint64_t *table_id_out, uint64_t *schem
     HeapTuple tuple = SPI_tuptable->vals[0];
     bool isnull;
 
+    /* col 0: table_id */
     Datum table_id_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 1, &isnull);
-    if (!isnull) {
-      uint64_t table_id = DatumGetInt64(table_id_datum);
+    if (isnull)
+      goto done;
+    uint64_t table_id = DatumGetInt64(table_id_datum);
 
-      Datum schema_version_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 2, &isnull);
-      if (!isnull) {
-        uint64_t schema_version = DatumGetInt64(schema_version_datum);
-        *table_id_out = table_id;
-        *schema_version_out = schema_version;
-        result = true;
-      }
-    }
+    /* col 1: inlined schema_version (NULL if not inlined) */
+    Datum sv_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 2, &isnull);
+    if (isnull)
+      goto done;
+    uint64_t schema_version = DatumGetInt64(sv_datum);
+
+    /* col 2: data_inlining_row_limit must be explicitly set > 0 */
+    Datum limit_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 3, &isnull);
+    if (isnull || DatumGetInt64(limit_datum) <= 0)
+      goto done;
+
+    /* col 3: per-table schema version check.
+     * NULL means no ALTER has been performed -- safe to proceed.
+     * Non-NULL must match the inlined table's schema_version.
+     *
+     * Previously this compared against the global schema_version in
+     * ducklake_snapshot, which caused false negatives: a DDL on any
+     * other table would bump the global version and block direct
+     * insert for all unrelated tables. */
+    Datum max_sv_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 4, &isnull);
+    if (!isnull && (uint64_t)DatumGetInt64(max_sv_datum) != schema_version)
+      goto done;
+
+    *table_id_out = table_id;
+    *schema_version_out = schema_version;
+    result = true;
   }
 
-  /* Only allow direct insert when data_inlining_row_limit was
-   * explicitly set to a positive value.  The default (10) triggers
-   * auto-inlining by DuckDB, but DuckDB manages those tables'
-   * schema evolution internally; direct insert bypasses that and
-   * causes crashes after ALTER TABLE ADD/DROP COLUMN.
-   *
-   * First check if ducklake_metadata exists (safe pg_class query),
-   * then query the actual limit. */
-  if (result) {
-    bool limit_explicitly_set = false;
-    ret = SPI_execute("SELECT 1 FROM pg_class c "
-                      "JOIN pg_namespace n ON c.relnamespace = n.oid "
-                      "WHERE n.nspname = 'ducklake' "
-                      "AND c.relname = 'ducklake_metadata'",
-                      true, 1);
-    if (ret == SPI_OK_SELECT && SPI_processed > 0) {
-      ret = SPI_execute("SELECT value::bigint "
-                        "FROM ducklake.ducklake_metadata "
-                        "WHERE key = 'data_inlining_row_limit' "
-                        "AND scope IS NULL",
-                        true, 1);
-      if (ret == SPI_OK_SELECT && SPI_processed > 0) {
-        bool isnull;
-        Datum limit_datum = SPI_getbinval(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &isnull);
-        if (!isnull && DatumGetInt64(limit_datum) > 0) {
-          limit_explicitly_set = true;
-        }
-      }
-    }
-    if (!limit_explicitly_set) {
-      result = false;
-    }
-  }
-
-  /* Guard 2: schema version check.
-   * Compare the inlined table's schema_version (already in *schema_version_out)
-   * with the latest snapshot's schema_version.  If they differ the table has
-   * been ALTER-ed -- fall back to the DuckDB path which handles schema
-   * evolution correctly. */
-  if (result) {
-    ret = SPI_execute("SELECT schema_version "
-                      "FROM ducklake.ducklake_snapshot "
-                      "ORDER BY snapshot_id DESC LIMIT 1",
-                      true, 1);
-    if (ret == SPI_OK_SELECT && SPI_processed > 0) {
-      bool isnull;
-      Datum sv_datum = SPI_getbinval(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &isnull);
-      if (!isnull) {
-        uint64_t latest_schema_version = DatumGetInt64(sv_datum);
-        if (latest_schema_version != *schema_version_out) {
-          result = false;
-        }
-      }
-    }
-  }
+done:
 
   SPI_finish();
   return result;

--- a/test/regression/expected/insert_values.out
+++ b/test/regression/expected/insert_values.out
@@ -364,3 +364,130 @@ SELECT * FROM iv_all_types ORDER BY c_int4 NULLS LAST;
 (3 rows)
 
 DROP TABLE iv_all_types;
+-- ============================================================
+-- Test 15: DDL on unrelated table must not block direct insert
+-- A DDL on table B bumps the global schema_version in
+-- ducklake_snapshot but must not disable direct insert on
+-- table A whose per-table schema has not changed.
+--
+-- Use a dedicated schema so leftover DuckDB catalog entries
+-- don't leak into import_foreign_schema tests.
+-- ============================================================
+CREATE SCHEMA iv_schema;
+SET search_path = iv_schema;
+CREATE TABLE iv_target (id int, val text) USING ducklake;
+CREATE TABLE iv_other (x int) USING ducklake;
+SELECT count(*) FROM ducklake.ensure_inlined_data_table('iv_target'::regclass);
+ count 
+-------
+     1
+(1 row)
+
+-- Direct insert works before any DDL
+EXPLAIN INSERT INTO iv_target VALUES (1, 'before');
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Custom Scan (DuckLakeDirectInsert)  (cost=0.00..0.00 rows=0 width=0)
+   Custom Scan: DuckLakeDirectInsert
+   Pattern: VALUES
+   Expected Rows: 1
+(4 rows)
+
+INSERT INTO iv_target VALUES (1, 'before');
+-- Touch iv_other so DuckDB registers it, then ALTER it
+INSERT INTO iv_other VALUES (1);
+ALTER TABLE iv_other ADD COLUMN y text;
+-- Direct insert on iv_target must still use the fast path
+EXPLAIN INSERT INTO iv_target VALUES (2, 'after');
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Custom Scan (DuckLakeDirectInsert)  (cost=0.00..0.00 rows=0 width=0)
+   Custom Scan: DuckLakeDirectInsert
+   Pattern: VALUES
+   Expected Rows: 1
+(4 rows)
+
+INSERT INTO iv_target VALUES (2, 'after');
+SELECT id, val FROM iv_target ORDER BY id;
+ id |  val   
+----+--------
+  1 | before
+  2 | after
+(2 rows)
+
+DROP TABLE iv_other;
+DROP TABLE iv_target;
+-- ============================================================
+-- Test 16: DDL on the SAME table must disable direct insert
+-- ALTER TABLE on iv_self bumps its per-table schema_version,
+-- so EXPLAIN must NOT show the DuckLakeDirectInsert plan.
+-- ============================================================
+CREATE TABLE iv_self (id int, val text) USING ducklake;
+SELECT count(*) FROM ducklake.ensure_inlined_data_table('iv_self'::regclass);
+ count 
+-------
+     1
+(1 row)
+
+-- Direct insert works before ALTER
+EXPLAIN INSERT INTO iv_self VALUES (1, 'before');
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Custom Scan (DuckLakeDirectInsert)  (cost=0.00..0.00 rows=0 width=0)
+   Custom Scan: DuckLakeDirectInsert
+   Pattern: VALUES
+   Expected Rows: 1
+(4 rows)
+
+INSERT INTO iv_self VALUES (1, 'before');
+-- ALTER the same table
+ALTER TABLE iv_self ADD COLUMN extra int;
+-- Direct insert must NOT be used (schema version mismatch)
+EXPLAIN INSERT INTO iv_self (id, val, extra) VALUES (2, 'after', 42);
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Custom Scan (DuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
+   DuckDB Execution Plan: 
+ 
+ ┌───────────────────────────┐
+ │      DUCKLAKE_INSERT      │
+ │    ────────────────────   │
+ │    Table Name: iv_self    │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │        COPY_TO_FILE       │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │    DUCKLAKE_INLINE_DATA   │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │         PROJECTION        │
+ │    ────────────────────   │
+ │             #0            │
+ │             #1            │
+ │             #2            │
+ │                           │
+ │           ~1 row          │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │      COLUMN_DATA_SCAN     │
+ │    ────────────────────   │
+ │           ~1 row          │
+ └───────────────────────────┘
+ 
+ 
+(30 rows)
+
+-- Data still works via the DuckDB path
+INSERT INTO iv_self (id, val, extra) VALUES (2, 'after', 42);
+SELECT id, val, extra FROM iv_self ORDER BY id;
+ id |  val   | extra 
+----+--------+-------
+  1 | before |      
+  2 | after  |    42
+(2 rows)
+
+DROP TABLE iv_self;
+-- Cleanup dedicated schema
+RESET search_path;
+DROP SCHEMA iv_schema;

--- a/test/regression/sql/insert_values.sql
+++ b/test/regression/sql/insert_values.sql
@@ -208,3 +208,64 @@ INSERT INTO iv_all_types VALUES (
 
 SELECT * FROM iv_all_types ORDER BY c_int4 NULLS LAST;
 DROP TABLE iv_all_types;
+
+-- ============================================================
+-- Test 15: DDL on unrelated table must not block direct insert
+-- A DDL on table B bumps the global schema_version in
+-- ducklake_snapshot but must not disable direct insert on
+-- table A whose per-table schema has not changed.
+--
+-- Use a dedicated schema so leftover DuckDB catalog entries
+-- don't leak into import_foreign_schema tests.
+-- ============================================================
+CREATE SCHEMA iv_schema;
+SET search_path = iv_schema;
+
+CREATE TABLE iv_target (id int, val text) USING ducklake;
+CREATE TABLE iv_other (x int) USING ducklake;
+SELECT count(*) FROM ducklake.ensure_inlined_data_table('iv_target'::regclass);
+
+-- Direct insert works before any DDL
+EXPLAIN INSERT INTO iv_target VALUES (1, 'before');
+INSERT INTO iv_target VALUES (1, 'before');
+
+-- Touch iv_other so DuckDB registers it, then ALTER it
+INSERT INTO iv_other VALUES (1);
+ALTER TABLE iv_other ADD COLUMN y text;
+
+-- Direct insert on iv_target must still use the fast path
+EXPLAIN INSERT INTO iv_target VALUES (2, 'after');
+INSERT INTO iv_target VALUES (2, 'after');
+
+SELECT id, val FROM iv_target ORDER BY id;
+
+DROP TABLE iv_other;
+DROP TABLE iv_target;
+
+-- ============================================================
+-- Test 16: DDL on the SAME table must disable direct insert
+-- ALTER TABLE on iv_self bumps its per-table schema_version,
+-- so EXPLAIN must NOT show the DuckLakeDirectInsert plan.
+-- ============================================================
+CREATE TABLE iv_self (id int, val text) USING ducklake;
+SELECT count(*) FROM ducklake.ensure_inlined_data_table('iv_self'::regclass);
+
+-- Direct insert works before ALTER
+EXPLAIN INSERT INTO iv_self VALUES (1, 'before');
+INSERT INTO iv_self VALUES (1, 'before');
+
+-- ALTER the same table
+ALTER TABLE iv_self ADD COLUMN extra int;
+
+-- Direct insert must NOT be used (schema version mismatch)
+EXPLAIN INSERT INTO iv_self (id, val, extra) VALUES (2, 'after', 42);
+
+-- Data still works via the DuckDB path
+INSERT INTO iv_self (id, val, extra) VALUES (2, 'after', 42);
+SELECT id, val, extra FROM iv_self ORDER BY id;
+
+DROP TABLE iv_self;
+
+-- Cleanup dedicated schema
+RESET search_path;
+DROP SCHEMA iv_schema;


### PR DESCRIPTION
## Summary

- The direct insert optimization incorrectly compared against the **global** `schema_version` from `ducklake_snapshot`, which increments on any DDL to any table. An `ALTER TABLE` on an unrelated table would disable direct insert for all other inlined tables.
- Fix: query `ducklake_schema_versions WHERE table_id = <target>` instead, which tracks per-table schema versions. Only a DDL on the target table itself now disables the fast path.

## Test plan

- **Test 15** (`insert_values`): DDL on an unrelated table does NOT block direct insert -- EXPLAIN still shows `DuckLakeDirectInsert / Pattern: VALUES`
- **Test 16** (`insert_values`): DDL on the same table DOES block direct insert -- EXPLAIN shows the standard `DuckDBScan / DUCKLAKE_INSERT` plan