### PR TITLE
fix: preserve global schema_version in direct-insert snapshot

### DIFF
--- a/include/pgducklake/pgducklake_metadata_manager.hpp
+++ b/include/pgducklake/pgducklake_metadata_manager.hpp
@@ -52,7 +52,6 @@ protected:
 bool GetTableInliningInfo(Oid table_oid, uint64_t *table_id_out, uint64_t *schema_version_out);
 uint64_t GetNextRowIdForTable(uint64_t table_id, uint64_t schema_version);
 uint64_t GetNextSnapshotId();
-void CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t schema_version, uint64_t table_id,
-                                   int64_t rows_inserted);
+void CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int64_t rows_inserted);
 
 } // namespace pgducklake

--- a/src/pgducklake_copy_from.cpp
+++ b/src/pgducklake_copy_from.cpp
@@ -234,7 +234,7 @@ uint64 DucklakeCopyFromStdin(CopyStmt *stmt, const char *query_string) {
 
   if (rows_inserted > 0) {
     SkipSnapshotSyncGuard sync_guard;
-    CreateSnapshotForDirectInsert(begin_snapshot, schema_version, table_id, rows_inserted);
+    CreateSnapshotForDirectInsert(begin_snapshot, table_id, rows_inserted);
     CommandCounterIncrement();
   }
 

--- a/src/pgducklake_direct_insert.cpp
+++ b/src/pgducklake_direct_insert.cpp
@@ -1099,8 +1099,7 @@ static TupleTableSlot *DirectInsert_ExecCustomScan(CustomScanState *node) {
   node->ss.ps.state->es_processed = state->rows_inserted;
 
   pgducklake::SkipSnapshotSyncGuard sync_guard;
-  pgducklake::CreateSnapshotForDirectInsert(state->begin_snapshot, state->schema_version, state->table_id,
-                                            state->rows_inserted);
+  pgducklake::CreateSnapshotForDirectInsert(state->begin_snapshot, state->table_id, state->rows_inserted);
 
   CommandCounterIncrement();
 

--- a/src/pgducklake_metadata_manager.cpp
+++ b/src/pgducklake_metadata_manager.cpp
@@ -779,28 +779,30 @@ uint64_t GetNextSnapshotId() {
   return next_snapshot_id;
 }
 
-void CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t schema_version, uint64_t table_id,
-                                   int64_t rows_inserted) {
+void CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int64_t rows_inserted) {
   int ret;
 
-  elog(DEBUG1,
-       "CreateSnapshotForDirectInsert: creating snapshot %llu with "
-       "schema_version %llu",
-       (unsigned long long)snapshot_id, (unsigned long long)schema_version);
+  elog(DEBUG1, "CreateSnapshotForDirectInsert: creating snapshot %llu", (unsigned long long)snapshot_id);
 
   if ((ret = SPI_connect()) < 0) {
     elog(ERROR, "CreateSnapshotForDirectInsert: SPI_connect failed: %d", ret);
     return;
   }
 
-  // Use the latest snapshot's values via primary-key index backward scan (O(1))
-  // rather than MAX() over the full table.
-  const char *query_state = "SELECT COALESCE(next_catalog_id, 1), COALESCE(next_file_id, 0) "
+  /* Read the latest snapshot via primary-key index backward scan (O(1))
+   * rather than MAX() over the full table.  We carry its schema_version
+   * forward: direct insert is a data-only change, so the new snapshot
+   * must preserve the global catalog view (which tables are visible).
+   * Using a per-table schema_version here would effectively roll back
+   * the catalog and hide tables created after this one. */
+  const char *query_state = "SELECT COALESCE(next_catalog_id, 1), COALESCE(next_file_id, 0), "
+                            "       COALESCE(schema_version, 0) "
                             "FROM ducklake.ducklake_snapshot "
                             "ORDER BY snapshot_id DESC LIMIT 1";
 
   uint64_t next_catalog_id = 1;
   uint64_t next_file_id = 0;
+  uint64_t schema_version = 0;
 
   ret = SPI_execute(query_state, true, 1);
   if (ret == SPI_OK_SELECT && SPI_processed > 0) {
@@ -816,6 +818,11 @@ void CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t schema_version
     Datum file_id_datum = SPI_getbinval(tuple, tupdesc, 2, &isnull);
     if (!isnull) {
       next_file_id = DatumGetInt64(file_id_datum);
+    }
+
+    Datum schema_version_datum = SPI_getbinval(tuple, tupdesc, 3, &isnull);
+    if (!isnull) {
+      schema_version = DatumGetInt64(schema_version_datum);
     }
   }
 

--- a/test/regression/expected/insert_values.out
+++ b/test/regression/expected/insert_values.out
@@ -488,6 +488,33 @@ SELECT id, val, extra FROM iv_self ORDER BY id;
 (2 rows)
 
 DROP TABLE iv_self;
+-- ============================================================
+-- Test 17: Direct insert must preserve the global catalog view
+-- ducklake_snapshot.schema_version is global: setting it to a
+-- per-table value would roll back the catalog and hide tables
+-- created after the direct-insert target.  Regression test for
+-- #182 where a later SELECT on a sibling table failed with
+-- "Table with name X does not exist" after a direct insert.
+-- ============================================================
+CREATE TABLE iv_first (id int) USING ducklake;
+CREATE TABLE iv_second (id int) USING ducklake;
+SELECT count(*) FROM ducklake.ensure_inlined_data_table('iv_first'::regclass);
+ count 
+-------
+     1
+(1 row)
+
+-- Direct insert into iv_first -- must not rewind the global schema_version
+INSERT INTO iv_first VALUES (1);
+-- iv_second was created after iv_first; a rolled-back snapshot would hide it
+SELECT count(*) FROM iv_second;
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE iv_first;
+DROP TABLE iv_second;
 -- Cleanup dedicated schema
 RESET search_path;
 DROP SCHEMA iv_schema;

--- a/test/regression/sql/insert_values.sql
+++ b/test/regression/sql/insert_values.sql
@@ -266,6 +266,27 @@ SELECT id, val, extra FROM iv_self ORDER BY id;
 
 DROP TABLE iv_self;
 
+-- ============================================================
+-- Test 17: Direct insert must preserve the global catalog view
+-- ducklake_snapshot.schema_version is global: setting it to a
+-- per-table value would roll back the catalog and hide tables
+-- created after the direct-insert target.  Regression test for
+-- #182 where a later SELECT on a sibling table failed with
+-- "Table with name X does not exist" after a direct insert.
+-- ============================================================
+CREATE TABLE iv_first (id int) USING ducklake;
+CREATE TABLE iv_second (id int) USING ducklake;
+SELECT count(*) FROM ducklake.ensure_inlined_data_table('iv_first'::regclass);
+
+-- Direct insert into iv_first -- must not rewind the global schema_version
+INSERT INTO iv_first VALUES (1);
+
+-- iv_second was created after iv_first; a rolled-back snapshot would hide it
+SELECT count(*) FROM iv_second;
+
+DROP TABLE iv_first;
+DROP TABLE iv_second;
+
 -- Cleanup dedicated schema
 RESET search_path;
 DROP SCHEMA iv_schema;


### PR DESCRIPTION
## Summary

- `CreateSnapshotForDirectInsert` wrote the new `ducklake_snapshot` row with the per-table schema_version from `ducklake_inlined_data_tables`, but `ducklake_snapshot.schema_version` is the *global* catalog view -- setting it to a per-table value rolled the catalog back and hid any table created after the direct-insert target.
- Fix: read the latest snapshot's `schema_version` and carry it forward (direct insert is a data-only change, so the global view must not change). The per-table `schema_version` parameter is no longer needed and is removed from the function signature.
- Unblocks 5 failing regression tests on all PG versions: `insert_cte`, `options`, `freeze`, `frozen_fdw`, `import_foreign_schema`.

## Test plan

- New Test 17 in `insert_values.sql`: two tables are created, direct insert into the first, then `SELECT` on the second -- confirms the global view is preserved.
- Verified locally on PG 18: full regression suite goes from 5 failing to all 43 passing; all 3 isolation tests pass.

Closes #182