### PR TITLE
fix: decode name datums in maintenance worker SPI result

### DIFF
--- a/src/pgducklake_maintenance.cpp
+++ b/src/pgducklake_maintenance.cpp
@@ -322,10 +322,11 @@ PGDLLEXPORT void ducklake_maintenance_worker_main(Datum main_arg) {
       tables = (char **)palloc(ntables * sizeof(char *));
       for (int i = 0; i < ntables; i++) {
         bool isnull;
+        /* nspname and relname are `name`, not `text`: decode via DatumGetName/NameStr. */
         Datum s = SPI_getbinval(SPI_tuptable->vals[i], SPI_tuptable->tupdesc, 1, &isnull);
         Datum t = SPI_getbinval(SPI_tuptable->vals[i], SPI_tuptable->tupdesc, 2, &isnull);
-        schemas[i] = pstrdup(TextDatumGetCString(s));
-        tables[i] = pstrdup(TextDatumGetCString(t));
+        schemas[i] = pstrdup(NameStr(*DatumGetName(s)));
+        tables[i] = pstrdup(NameStr(*DatumGetName(t)));
       }
       MemoryContextSwitchTo(old_ctx);
     }

--- a/test/regression/expected/maintenance.out
+++ b/test/regression/expected/maintenance.out
@@ -272,3 +272,55 @@ SELECT * FROM maint_cleanup_orphan ORDER BY a;
 DROP TABLE maint_cleanup_orphan;
 -- Restore default
 CALL ducklake.set_option('data_inlining_row_limit', 0);
+-- =============================================================
+-- Background maintenance worker smoke test (issue #183)
+--
+-- Verifies the launcher/worker pair can run a full cycle without
+-- crashing. If the worker segfaults, the postmaster terminates all
+-- backends and this test's connection dies with a FATAL error.
+-- =============================================================
+CREATE TABLE maint_bgw_smoke (a int) USING ducklake;
+INSERT INTO maint_bgw_smoke VALUES (1), (2), (3);
+ALTER SYSTEM SET ducklake.maintenance_naptime = 1;
+ALTER SYSTEM SET ducklake.maintenance_enabled = on;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+-- Wait long enough for the launcher to wake on SIGHUP, spawn a worker,
+-- and for at least one worker to run to completion.
+SELECT pg_sleep(4);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- The launcher must still be alive; if a worker had segfaulted, the
+-- postmaster would have torn down all backends by now.
+SELECT count(*) = 1 AS launcher_alive
+FROM pg_stat_activity
+WHERE backend_type = 'ducklake maintenance launcher';
+ launcher_alive 
+----------------
+ t
+(1 row)
+
+ALTER SYSTEM RESET ducklake.maintenance_enabled;
+ALTER SYSTEM RESET ducklake.maintenance_naptime;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+-- Give the launcher a cycle to observe maintenance_enabled=off so no
+-- new worker is spawned against a table we're about to drop.
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+DROP TABLE maint_bgw_smoke;

--- a/test/regression/sql/maintenance.sql
+++ b/test/regression/sql/maintenance.sql
@@ -197,3 +197,38 @@ DROP TABLE maint_cleanup_orphan;
 
 -- Restore default
 CALL ducklake.set_option('data_inlining_row_limit', 0);
+
+-- =============================================================
+-- Background maintenance worker smoke test (issue #183)
+--
+-- Verifies the launcher/worker pair can run a full cycle without
+-- crashing. If the worker segfaults, the postmaster terminates all
+-- backends and this test's connection dies with a FATAL error.
+-- =============================================================
+
+CREATE TABLE maint_bgw_smoke (a int) USING ducklake;
+INSERT INTO maint_bgw_smoke VALUES (1), (2), (3);
+
+ALTER SYSTEM SET ducklake.maintenance_naptime = 1;
+ALTER SYSTEM SET ducklake.maintenance_enabled = on;
+SELECT pg_reload_conf();
+
+-- Wait long enough for the launcher to wake on SIGHUP, spawn a worker,
+-- and for at least one worker to run to completion.
+SELECT pg_sleep(4);
+
+-- The launcher must still be alive; if a worker had segfaulted, the
+-- postmaster would have torn down all backends by now.
+SELECT count(*) = 1 AS launcher_alive
+FROM pg_stat_activity
+WHERE backend_type = 'ducklake maintenance launcher';
+
+ALTER SYSTEM RESET ducklake.maintenance_enabled;
+ALTER SYSTEM RESET ducklake.maintenance_naptime;
+SELECT pg_reload_conf();
+
+-- Give the launcher a cycle to observe maintenance_enabled=off so no
+-- new worker is spawned against a table we're about to drop.
+SELECT pg_sleep(2);
+
+DROP TABLE maint_bgw_smoke;


### PR DESCRIPTION
## Summary
- `pg_namespace.nspname` and `pg_class.relname` are `name` (64-byte `NameData`), not `text`; decoding them with `TextDatumGetCString()` reads a bogus varlena length and reliably segfaults the ducklake maintenance worker on the first ducklake table in the database.
- Switch to the canonical `NameStr(*DatumGetName(d))` accessor (matches `src/pgducklake_ddl.cpp` and upstream `pgduckdb_ddl.cpp`).
- Stops the crash-loop that also triggered postmaster crash-recovery every `ducklake.maintenance_naptime`.

Closes #183