### PR TITLE
fix: handle partial INSERT column list with DEFAULT in VALUES detector

### DIFF
--- a/src/pgducklake_direct_insert.cpp
+++ b/src/pgducklake_direct_insert.cpp
@@ -854,22 +854,61 @@ static bool TryMatchValues(Query *parse, const InsertPreconditionResult *precond
   TupleDesc tupdesc = RelationGetDescr(target_rel);
   int num_table_cols = tupdesc->natts;
 
-  /* Build column map from targetList: col_map[table_attr] = values_list index, or -1 */
-  int *col_map = (int *)palloc(sizeof(int) * num_table_cols);
-  memset(col_map, -1, sizeof(int) * num_table_cols);
+  /* For each table column, choose one source:
+   *   values_col_idx[col] >= 0  -> values_lists[row][values_col_idx[col]]
+   *   target_expr[col] != NULL  -> evaluate this expression once per row
+   *                                (default / explicit constant; same value
+   *                                across rows so eval_const_expressions
+   *                                can fold it)
+   *   neither set               -> typed NULL filler
+   *
+   * Multi-row VALUES distinguishes the two by inspecting each targetList
+   * entry: a Var pointing at the RTE_VALUES is per-row, anything else
+   * (default expr, plain Const) is row-independent.
+   *
+   * Single-row VALUES inlines the source expressions directly into the
+   * targetList, with one entry per non-junk TargetEntry; the synthetic
+   * values_lists we built mirrors that order. */
+  int *values_col_idx = (int *)palloc(sizeof(int) * num_table_cols);
+  Node **target_expr = (Node **)palloc0(sizeof(Node *) * num_table_cols);
+  for (int i = 0; i < num_table_cols; i++)
+    values_col_idx[i] = -1;
 
-  int val_col = 0;
+  int values_rte_varno = 0;
+  if (values_rte) {
+    int idx = 1;
+    ListCell *rtlc;
+    foreach (rtlc, parse->rtable) {
+      if (lfirst(rtlc) == values_rte) {
+        values_rte_varno = idx;
+        break;
+      }
+      idx++;
+    }
+  }
+
+  int single_row_seq = 0;
   ListCell *lc;
   foreach (lc, parse->targetList) {
     TargetEntry *tle = (TargetEntry *)lfirst(lc);
-    if (tle->resjunk) {
+    if (tle->resjunk)
       continue;
-    }
     if (tle->resno < 1 || tle->resno > num_table_cols) {
-      pfree(col_map);
+      pfree(values_col_idx);
+      pfree(target_expr);
       return false;
     }
-    col_map[tle->resno - 1] = val_col++;
+    int col = tle->resno - 1;
+    if (values_rte) {
+      Var *v = IsA(tle->expr, Var) ? (Var *)tle->expr : NULL;
+      if (v && v->varno == values_rte_varno) {
+        values_col_idx[col] = v->varattno - 1;
+      } else {
+        target_expr[col] = (Node *)tle->expr;
+      }
+    } else {
+      values_col_idx[col] = single_row_seq++;
+    }
   }
 
   /* Evaluate all expressions to Const nodes */
@@ -881,17 +920,28 @@ static bool TryMatchValues(Query *parse, const InsertPreconditionResult *precond
 
     for (int col = 0; col < num_table_cols; col++) {
       int flat = row_idx * num_table_cols + col;
-      int mapped = col_map[col];
-      if (mapped < 0) {
-        /* Unspecified column: create a typed NULL Const */
+      Node *expr = NULL;
+      if (values_col_idx[col] >= 0) {
+        if (values_col_idx[col] >= list_length(row_exprs)) {
+          pfree(values_col_idx);
+          pfree(target_expr);
+          pfree(consts);
+          return false;
+        }
+        expr = (Node *)list_nth(row_exprs, values_col_idx[col]);
+      } else if (target_expr[col]) {
+        expr = target_expr[col];
+      }
+      if (expr == NULL) {
+        /* Unspecified column with no default: typed NULL Const. */
         Form_pg_attribute attr = TupleDescAttr(tupdesc, col);
         consts[flat] = makeConst(attr->atttypid, attr->atttypmod, attr->attcollation, attr->attlen, (Datum)0,
                                  true /* isnull */, attr->attbyval);
       } else {
-        Node *expr = (Node *)list_nth(row_exprs, mapped);
         Const *c;
         if (!TryEvalConstExpr(expr, &c)) {
-          pfree(col_map);
+          pfree(values_col_idx);
+          pfree(target_expr);
           pfree(consts);
           return false;
         }
@@ -901,7 +951,8 @@ static bool TryMatchValues(Query *parse, const InsertPreconditionResult *precond
     row_idx++;
   }
 
-  pfree(col_map);
+  pfree(values_col_idx);
+  pfree(target_expr);
 
   /* Collect user-facing column types + names from TupleDesc */
   List *src_col_types = NIL;

--- a/test/regression/expected/direct_insert_stats.out
+++ b/test/regression/expected/direct_insert_stats.out
@@ -62,6 +62,44 @@ SELECT * FROM direct_insert_stats_nonzero;
 (2 rows)
 
 -- ------------------------------------------------------------------
+-- INSERT INTO t (col-list) VALUES (...)  -- column-list shapes all
+-- match matched_values, with defaults honored and unspecified columns
+-- filled with typed NULL.  Multi-row partial column list with DEFAULT
+-- exercises the values-vs-default discrimination in the planner.
+-- ------------------------------------------------------------------
+CREATE TABLE dis_cols (a INT, b TEXT DEFAULT 'foo', c INT) USING ducklake;
+INSERT INTO dis_cols VALUES (0, 'init', 0);  -- warm up inlined table
+SELECT ducklake.reset_direct_insert_stats();
+ reset_direct_insert_stats 
+---------------------------
+ 
+(1 row)
+
+INSERT INTO dis_cols (a, b, c) VALUES (1, 'x', 2);              -- full
+INSERT INTO dis_cols (a, c) VALUES (10, 20);                    -- partial, default for b
+INSERT INTO dis_cols (b) VALUES ('z');                          -- single col
+INSERT INTO dis_cols (a, c) VALUES (30, 31), (32, 33);          -- multi-row partial + default
+INSERT INTO dis_cols DEFAULT VALUES;                            -- all defaults
+SELECT * FROM direct_insert_stats_nonzero;
+    pattern     | reason | count 
+----------------+--------+-------
+ matched_values | ok     |     5
+(1 row)
+
+SELECT a, b, c FROM dis_cols ORDER BY a NULLS FIRST, c NULLS FIRST;
+ a  |  b   | c  
+----+------+----
+    | z    |   
+    | foo  |   
+  0 | init |  0
+  1 | x    |  2
+ 10 | foo  | 20
+ 30 | foo  | 31
+ 32 | foo  | 33
+(7 rows)
+
+DROP TABLE dis_cols;
+-- ------------------------------------------------------------------
 -- Gating: GUC off, tx block, non-ducklake -- NO counters bumped
 -- ------------------------------------------------------------------
 SELECT ducklake.reset_direct_insert_stats();

--- a/test/regression/sql/direct_insert_stats.sql
+++ b/test/regression/sql/direct_insert_stats.sql
@@ -35,6 +35,28 @@ DEALLOCATE dis_unnest;
 SELECT * FROM direct_insert_stats_nonzero;
 
 -- ------------------------------------------------------------------
+-- INSERT INTO t (col-list) VALUES (...)  -- column-list shapes all
+-- match matched_values, with defaults honored and unspecified columns
+-- filled with typed NULL.  Multi-row partial column list with DEFAULT
+-- exercises the values-vs-default discrimination in the planner.
+-- ------------------------------------------------------------------
+CREATE TABLE dis_cols (a INT, b TEXT DEFAULT 'foo', c INT) USING ducklake;
+INSERT INTO dis_cols VALUES (0, 'init', 0);  -- warm up inlined table
+
+SELECT ducklake.reset_direct_insert_stats();
+
+INSERT INTO dis_cols (a, b, c) VALUES (1, 'x', 2);              -- full
+INSERT INTO dis_cols (a, c) VALUES (10, 20);                    -- partial, default for b
+INSERT INTO dis_cols (b) VALUES ('z');                          -- single col
+INSERT INTO dis_cols (a, c) VALUES (30, 31), (32, 33);          -- multi-row partial + default
+INSERT INTO dis_cols DEFAULT VALUES;                            -- all defaults
+
+SELECT * FROM direct_insert_stats_nonzero;
+SELECT a, b, c FROM dis_cols ORDER BY a NULLS FIRST, c NULLS FIRST;
+
+DROP TABLE dis_cols;
+
+-- ------------------------------------------------------------------
 -- Gating: GUC off, tx block, non-ducklake -- NO counters bumped
 -- ------------------------------------------------------------------
 SELECT ducklake.reset_direct_insert_stats();


### PR DESCRIPTION
## Summary

Follow-up to #187 / #186.

A multi-row INSERT with an explicit column list whose unspecified columns have a `DEFAULT` (e.g. `INSERT INTO t(a,c) VALUES (1,2),(3,4)` where `b` has `DEFAULT 'foo'`) crashed `TryCreateDirectInsertPlan` with `TRAP: failed Assert("n >= 0 && n < list->length")` under `list_nth`.

The root cause: for multi-row VALUES with partial column list and DEFAULT, `parse->targetList` contains a mix of `Var` nodes pointing at the `RTE_VALUES` (per-row sources) and `Const`/default expressions (constant across rows). The old `col_map` walked targetList sequentially and used those positional indices into `values_lists`, reading past the end of each row.

Fix: resolve each table column independently:
- `values_col_idx[col] >= 0` -> use `values_lists[row][idx]`
- `target_expr[col] != NULL` -> evaluate the targetList expr once per row (default)
- neither set -> typed NULL filler

Multi-row mode discriminates by checking whether the targetList expr is a `Var` pointing at the `values_rte`. Single-row mode keeps the existing synthetic-targetList behavior (PG inlines the constants into targetList directly).

## Test plan

Extended `direct_insert_stats` regression test to cover:
- Full column list
- Partial column list with `DEFAULT` (single row)
- Single-column-only insert
- **Multi-row partial column list with `DEFAULT`** (the previously crashing case)
- `INSERT ... DEFAULT VALUES`

All five shapes match `matched_values` and the table contents show that DEFAULTs are honored and unspecified columns without a default are NULL.

- [x] `make installcheck` -- all 44 regression + 3 isolation tests pass
- [x] `make check-format` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)