### PR TITLE
feat: defer VALUES cell evaluation so STABLE coercions direct-insert

### DIFF
--- a/src/pgducklake_direct_insert.cpp
+++ b/src/pgducklake_direct_insert.cpp
@@ -43,6 +43,7 @@ extern "C" {
 #include "catalog/namespace.h"
 #include "catalog/pg_am.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
 #include "commands/explain.h"
@@ -139,9 +140,9 @@ struct DirectInsertScanState {
   /* VALUES-specific */
   int values_num_rows;
   int values_num_cols;
-  Datum *values_data;    // flat [row * num_cols + col]
-  bool *values_nulls;    // flat [row * num_cols + col]
-  Oid *values_src_types; // per-column source OID
+  Node **values_exprs;        // flat [row * num_cols + col] expression nodes
+  ExprState **values_estates; // flat [row * num_cols + col]; built in Begin
+  Oid *values_src_types;      // per-column source OID
 
   bool finished;
   int64_t rows_inserted;
@@ -189,7 +190,12 @@ struct ValuesInsertContext {
   List *target_col_names;  // List of char*
   List *inlined_col_types; // List of Oid
   List *src_col_types;     // List of Oid (user-facing PG types)
-  Const **consts;          // flat [num_rows * num_cols] Const nodes
+  /* One expression per cell.  Always non-NULL: unspecified columns are
+   * filled with a typed NULL Const so every cell goes through
+   * ExecInitExpr at executor start.  Const-foldable subexpressions are
+   * already collapsed by eval_const_expressions; STABLE/PARAM-EXTERN-
+   * free expressions stay as FuncExpr and are evaluated per row. */
+  Node **exprs;
 };
 
 /* Shared precondition result for INSERT pattern detection */
@@ -774,18 +780,69 @@ static bool ValidateArrayLengths(ParamListInfo bound_params, List *param_ids, in
  * ---------------------------------------------------------------- */
 
 /*
- * Try to fold an expression to a constant.  Uses PG's eval_const_expressions
- * to handle all immutable coercions (RelabelType, CoerceViaIO, FuncExpr with
- * Const args, etc.).  Returns false if the expression contains anything
- * non-constant (Param, Var, volatile function, SetToDefault, subquery).
+ * Reject expression trees that we can't safely evaluate at executor
+ * start without access to a tuple stream, an outer query, or an SPI
+ * context.  Anything else (Const, RelabelType wrapping a Const, STABLE
+ * function on Const args, etc.) is fine -- ExecInitExpr handles it.
+ *
+ * Reasons to reject:
+ *   Var          - needs a per-row tuple slot
+ *   Param        - bound parameter or correlated-outer reference;
+ *                  conservatively reject for now (a future change can
+ *                  allow PARAM_EXTERN for INSERT INTO t VALUES ($1))
+ *   Aggref / GroupingFunc / WindowFunc - aggregate context
+ *   SubLink / SubPlan / AlternativeSubPlan - subquery
+ *   CurrentOfExpr - WHERE CURRENT OF cursor
+ *   VOLATILE function (FuncExpr/OpExpr/DistinctExpr/NullIfExpr) -
+ *                  output may differ across calls and PG's standard
+ *                  executor evaluates it per-row; we still defer eval
+ *                  to exec time, but rejecting volatile keeps direct
+ *                  insert observably equivalent to the DuckDB path.
  */
-static bool TryEvalConstExpr(Node *expr, Const **const_out) {
-  Node *folded = eval_const_expressions(NULL, expr);
-  if (!IsA(folded, Const)) {
+static bool ValuesExprUnsafeWalker(Node *node, void *unused) {
+  if (node == NULL)
     return false;
+
+  switch (nodeTag(node)) {
+  case T_Var:
+  case T_Param:
+  case T_Aggref:
+  case T_GroupingFunc:
+  case T_WindowFunc:
+  case T_SubLink:
+  case T_SubPlan:
+  case T_AlternativeSubPlan:
+  case T_CurrentOfExpr:
+    return true;
+  default:
+    break;
   }
-  *const_out = (Const *)folded;
-  return true;
+
+  if (IsA(node, FuncExpr)) {
+    FuncExpr *fe = (FuncExpr *)node;
+    if (func_volatile(fe->funcid) == PROVOLATILE_VOLATILE)
+      return true;
+  } else if (IsA(node, OpExpr) || IsA(node, DistinctExpr) || IsA(node, NullIfExpr)) {
+    /* OpExpr, DistinctExpr, NullIfExpr share the same struct prefix;
+     * opfuncid is the underlying function.  func_volatile handles
+     * InvalidOid by returning PROVOLATILE_VOLATILE, which is a safer
+     * default than treating an unresolved op as immutable. */
+    OpExpr *oe = (OpExpr *)node;
+    if (!OidIsValid(oe->opfuncid))
+      return true;
+    if (func_volatile(oe->opfuncid) == PROVOLATILE_VOLATILE)
+      return true;
+  }
+
+#if PG_VERSION_NUM >= 160000
+  return expression_tree_walker(node, ValuesExprUnsafeWalker, unused);
+#else
+  return expression_tree_walker(node, (bool (*)())((void *)ValuesExprUnsafeWalker), unused);
+#endif
+}
+
+static bool IsAcceptableValuesExpr(Node *expr) {
+  return !ValuesExprUnsafeWalker(expr, NULL);
 }
 
 /*
@@ -807,12 +864,43 @@ static bool TryMatchValues(Query *parse, const InsertPreconditionResult *precond
    * multi-row VALUES but inlines single-row VALUES directly into the
    * targetList.  Handle both cases. */
   RangeTblEntry *values_rte = NULL;
-  ListCell *rtlc;
-  foreach (rtlc, parse->rtable) {
-    RangeTblEntry *rte = (RangeTblEntry *)lfirst(rtlc);
-    if (rte->rtekind == RTE_VALUES) {
-      values_rte = rte;
-      break;
+  int values_rte_index = 0;
+  {
+    ListCell *rtlc;
+    int idx = 1;
+    foreach (rtlc, parse->rtable) {
+      RangeTblEntry *rte = (RangeTblEntry *)lfirst(rtlc);
+      if (rte->rtekind == RTE_VALUES) {
+        values_rte = rte;
+        values_rte_index = idx;
+        break;
+      }
+      idx++;
+    }
+  }
+
+  /* Guard: ensure the parse tree is shaped like a pure VALUES INSERT.
+   * A WHERE clause or a FROM clause that isn't the values_rte means
+   * the user wrote INSERT ... SELECT FROM table; we cannot direct-
+   * insert that because the SELECT may produce a different number of
+   * rows than the targetList suggests.  Without this guard, deferred
+   * cell evaluation would silently accept INSERT ... SELECT NULL FROM
+   * t WHERE ... (no Var in the targetList) and produce wrong row
+   * counts. */
+  if (parse->jointree && parse->jointree->quals != NULL) {
+    return false;
+  }
+  {
+    List *fl = parse->jointree ? parse->jointree->fromlist : NIL;
+    if (values_rte == NULL) {
+      if (fl != NIL)
+        return false;
+    } else {
+      if (list_length(fl) != 1)
+        return false;
+      Node *fn = (Node *)linitial(fl);
+      if (!IsA(fn, RangeTblRef) || ((RangeTblRef *)fn)->rtindex != values_rte_index)
+        return false;
     }
   }
 
@@ -911,8 +999,10 @@ static bool TryMatchValues(Query *parse, const InsertPreconditionResult *precond
     }
   }
 
-  /* Evaluate all expressions to Const nodes */
-  Const **consts = (Const **)palloc(sizeof(Const *) * num_rows * num_table_cols);
+  /* Resolve every cell to a Node*.  eval_const_expressions folds what
+   * it can (IMMUTABLE only); everything else flows through to
+   * ExecInitExpr at executor start. */
+  Node **exprs = (Node **)palloc(sizeof(Node *) * num_rows * num_table_cols);
 
   int row_idx = 0;
   foreach (lc, values_lists) {
@@ -925,7 +1015,7 @@ static bool TryMatchValues(Query *parse, const InsertPreconditionResult *precond
         if (values_col_idx[col] >= list_length(row_exprs)) {
           pfree(values_col_idx);
           pfree(target_expr);
-          pfree(consts);
+          pfree(exprs);
           return false;
         }
         expr = (Node *)list_nth(row_exprs, values_col_idx[col]);
@@ -935,18 +1025,18 @@ static bool TryMatchValues(Query *parse, const InsertPreconditionResult *precond
       if (expr == NULL) {
         /* Unspecified column with no default: typed NULL Const. */
         Form_pg_attribute attr = TupleDescAttr(tupdesc, col);
-        consts[flat] = makeConst(attr->atttypid, attr->atttypmod, attr->attcollation, attr->attlen, (Datum)0,
+        expr = (Node *)makeConst(attr->atttypid, attr->atttypmod, attr->attcollation, attr->attlen, (Datum)0,
                                  true /* isnull */, attr->attbyval);
       } else {
-        Const *c;
-        if (!TryEvalConstExpr(expr, &c)) {
+        expr = eval_const_expressions(NULL, expr);
+        if (!IsAcceptableValuesExpr(expr)) {
           pfree(values_col_idx);
           pfree(target_expr);
-          pfree(consts);
+          pfree(exprs);
           return false;
         }
-        consts[flat] = c;
       }
+      exprs[flat] = expr;
     }
     row_idx++;
   }
@@ -965,7 +1055,7 @@ static bool TryMatchValues(Query *parse, const InsertPreconditionResult *precond
 
   List *inlined_col_types = NIL;
   if (!GetCachedInlinedColumnTypes(precond->table_id, precond->schema_version, src_col_types, &inlined_col_types)) {
-    pfree(consts);
+    pfree(exprs);
     *reason_out = DI_R_COL_TYPES_UNSUPPORTED;
     return false;
   }
@@ -978,7 +1068,7 @@ static bool TryMatchValues(Query *parse, const InsertPreconditionResult *precond
   context_out->target_col_names = target_col_names;
   context_out->inlined_col_types = inlined_col_types;
   context_out->src_col_types = src_col_types;
-  context_out->consts = consts;
+  context_out->exprs = exprs;
 
   *reason_out = DI_R_OK;
   return true;
@@ -1087,10 +1177,12 @@ static PlannedStmt *CreateValuesInsertPlan(Query *parse, ValuesInsertContext *co
     custom_private = lappend(custom_private, makeInteger((int)lfirst_oid(lc)));
   }
 
-  /* Const nodes: num_rows * num_cols (serializable Node*) */
+  /* Cell expressions: num_rows * num_cols Node*.  Const cells are still
+   * Const; STABLE-coercion cells are FuncExpr/RelabelType/etc.  PG's
+   * out/read funcs handle either. */
   int total = context->num_rows * context->num_cols;
   for (int i = 0; i < total; i++) {
-    custom_private = lappend(custom_private, context->consts[i]);
+    custom_private = lappend(custom_private, context->exprs[i]);
   }
 
   return MakeDirectInsertPlannedStmt(parse, custom_private);
@@ -1173,14 +1265,14 @@ static Node *DirectInsert_CreateCustomScanState(CustomScan *cscan) {
       state->values_src_types[i] = (Oid)intVal(NextPrivate(priv, &lc));
     }
 
-    /* Decode Const nodes -> flat Datum/null arrays */
+    /* Decode cell expressions; ExprStates are built lazily in
+     * DirectInsert_BeginCustomScan once the executor's PlanState is
+     * available. */
     int total = state->values_num_rows * state->values_num_cols;
-    state->values_data = (Datum *)palloc(sizeof(Datum) * total);
-    state->values_nulls = (bool *)palloc(sizeof(bool) * total);
+    state->values_exprs = (Node **)palloc(sizeof(Node *) * total);
+    state->values_estates = NULL;
     for (int i = 0; i < total; i++) {
-      Const *c = (Const *)NextPrivate(priv, &lc);
-      state->values_data[i] = c->constvalue;
-      state->values_nulls[i] = c->constisnull;
+      state->values_exprs[i] = NextPrivate(priv, &lc);
     }
   }
 
@@ -1209,6 +1301,19 @@ static void DirectInsert_BeginCustomScan(CustomScanState *node, EState *estate, 
   appendStringInfo(&buf, "ducklake.ducklake_inlined_data_%llu_%llu", (unsigned long long)state->table_id,
                    (unsigned long long)state->schema_version);
   state->inlined_table_name = buf.data;
+
+  if (state->mode == DIRECT_INSERT_VALUES) {
+    /* Build one ExprState per cell.  Cheap for Const cells (just wraps
+     * the constvalue), and necessary for STABLE coercions / other
+     * non-Const expressions that survived eval_const_expressions. */
+    int total = state->values_num_rows * state->values_num_cols;
+    state->values_estates = (ExprState **)palloc(sizeof(ExprState *) * total);
+    MemoryContext old_ctx = MemoryContextSwitchTo(estate->es_query_cxt);
+    for (int i = 0; i < total; i++) {
+      state->values_estates[i] = ExecInitExpr((Expr *)state->values_exprs[i], &node->ss.ps);
+    }
+    MemoryContextSwitchTo(old_ctx);
+  }
 
   /* begin_snapshot / next_row_id are assigned inside the retry loop in
    * DirectInsert_ExecCustomScan -- under concurrent direct inserts the
@@ -1457,6 +1562,7 @@ struct ValuesColumnConvInfo {
 static void DirectInsertValuesIntoInlinedTable(DirectInsertScanState *state) {
   int num_rows = state->values_num_rows;
   int num_cols = state->values_num_cols;
+  ExprContext *econtext = state->css.ss.ps.ps_ExprContext;
 
   /* Open inlined data table by name */
   char relname[NAMEDATALEN];
@@ -1552,16 +1658,19 @@ static void DirectInsertValuesIntoInlinedTable(DirectInsertScanState *state) {
       int flat = row * num_cols + col;
       int dst = col + INLINED_SYSTEM_COLS;
 
-      if (state->values_nulls[flat]) {
+      bool isnull;
+      Datum d = ExecEvalExprSwitchContext(state->values_estates[flat], econtext, &isnull);
+
+      if (isnull) {
         sv[dst] = (Datum)0;
         sn[dst] = true;
       } else if (conv[col].needs_text_conv) {
-        char *str = OutputFunctionCall(&conv[col].typoutput_finfo, state->values_data[flat]);
+        char *str = OutputFunctionCall(&conv[col].typoutput_finfo, d);
         sv[dst] = CStringGetTextDatum(str);
         sn[dst] = false;
         pfree(str);
       } else {
-        sv[dst] = state->values_data[flat];
+        sv[dst] = d;
         sn[dst] = false;
       }
     }
@@ -1575,6 +1684,7 @@ static void DirectInsertValuesIntoInlinedTable(DirectInsertScanState *state) {
         ExecClearTuple(slots[i]);
       }
       nslots = 0;
+      ResetExprContext(econtext);
     }
   }
 

--- a/test/regression/expected/insert_values_stable.out
+++ b/test/regression/expected/insert_values_stable.out
@@ -1,0 +1,163 @@
+-- Test direct-insert VALUES path with STABLE coercions / functions.
+-- Before the deferred-evaluation refactor, eval_const_expressions
+-- only folded IMMUTABLE function calls, so any STABLE coercion
+-- (timestamptz->timestamp, current_date+1, etc.) would fall back to
+-- the standard DuckDB executor.  After the refactor, cell expressions
+-- are evaluated at executor start instead of demanding a planning-
+-- time Const.
+SET TIMEZONE = 'UTC';
+CALL ducklake.set_option('data_inlining_row_limit', 100);
+CREATE TABLE ivs (ts timestamp, d date, n int) USING ducklake;
+SELECT count(*) FROM ducklake.ensure_inlined_data_table('ivs'::regclass);
+ count 
+-------
+     1
+(1 row)
+
+SELECT ducklake.reset_direct_insert_stats();
+ reset_direct_insert_stats 
+---------------------------
+ 
+(1 row)
+
+-- ============================================================
+-- Test 1: timestamptz literal cast to timestamp (the issue's repro)
+-- ============================================================
+EXPLAIN INSERT INTO ivs VALUES ('2026-04-27T06:37:14+00:00'::timestamptz, NULL, NULL);
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Custom Scan (DuckLakeDirectInsert)  (cost=0.00..0.00 rows=0 width=0)
+   Custom Scan: DuckLakeDirectInsert
+   Pattern: VALUES
+   Expected Rows: 1
+(4 rows)
+
+INSERT INTO ivs VALUES ('2026-04-27T06:37:14+00:00'::timestamptz, NULL, 1);
+-- ============================================================
+-- Test 2: STABLE FuncExpr (current_date) -- single-row
+-- ============================================================
+EXPLAIN INSERT INTO ivs VALUES (NULL, current_date, 2);
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Custom Scan (DuckLakeDirectInsert)  (cost=0.00..0.00 rows=0 width=0)
+   Custom Scan: DuckLakeDirectInsert
+   Pattern: VALUES
+   Expected Rows: 1
+(4 rows)
+
+INSERT INTO ivs VALUES (NULL, current_date, 2);
+-- ============================================================
+-- Test 3: STABLE FuncExpr in arithmetic (current_date + 1)
+-- ============================================================
+INSERT INTO ivs VALUES (NULL, current_date + 1, 3);
+-- ============================================================
+-- Test 4: Multi-row VALUES, mixed Const + STABLE, full coverage
+-- ============================================================
+EXPLAIN INSERT INTO ivs VALUES
+    ('2030-01-01 00:00:00'::timestamp, current_date, 4),
+    (NULL, current_date + 7, 5);
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Custom Scan (DuckLakeDirectInsert)  (cost=0.00..0.00 rows=0 width=0)
+   Custom Scan: DuckLakeDirectInsert
+   Pattern: VALUES
+   Expected Rows: 2
+(4 rows)
+
+INSERT INTO ivs VALUES
+    ('2030-01-01 00:00:00'::timestamp, current_date, 4),
+    (NULL, current_date + 7, 5);
+-- Each EXPLAIN and each INSERT runs through the planner hook and
+-- bumps the counter once per statement (EXPLAIN does not execute,
+-- but the plan is still produced and counted).
+SELECT pattern, reason, count
+    FROM ducklake.direct_insert_stats() WHERE count > 0
+    ORDER BY pattern, reason;
+    pattern     | reason | count 
+----------------+--------+-------
+ matched_values | ok     |     7
+(1 row)
+
+-- Verify rows landed correctly (insensitive to today's date)
+SELECT n,
+       ts AT TIME ZONE 'UTC' = TIMESTAMP '2026-04-27 06:37:14' AS ts_match_1,
+       ts = TIMESTAMP '2030-01-01 00:00:00' AS ts_match_4,
+       d = CURRENT_DATE AS d_today,
+       d = CURRENT_DATE + 1 AS d_plus1,
+       d = CURRENT_DATE + 7 AS d_plus7
+FROM ivs WHERE n IS NOT NULL ORDER BY n;
+ n | ts_match_1 | ts_match_4 | d_today | d_plus1 | d_plus7 
+---+------------+------------+---------+---------+---------
+ 1 | t          | f          |         |         | 
+ 2 |            |            | t       | f       | f
+ 3 |            |            | f       | t       | f
+ 4 | f          | t          | t       | f       | f
+ 5 |            |            | f       | f       | t
+(5 rows)
+
+-- ============================================================
+-- Test 5: VOLATILE function inside VALUES is rejected
+-- (clock_timestamp is VOLATILE; pg_duckdb does not implement it,
+-- so we just check the planner counter -- the fall-back path
+-- itself errors which is fine for the assertion that we did NOT
+-- direct-insert.)
+-- ============================================================
+SELECT ducklake.reset_direct_insert_stats();
+ reset_direct_insert_stats 
+---------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP off
+INSERT INTO ivs VALUES (clock_timestamp()::timestamp, NULL, 99);
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Scalar Function with name clock_timestamp does not exist!
+Did you mean "to_timestamp"?
+
+LINE 1: INSERT INTO pgducklake.public.ivs (ts, d, n) VALUES ((clock_timestamp())::timestamp without time zone, NULL::date...
+                                                              ^
+\set ON_ERROR_STOP on
+SELECT pattern, reason, count
+    FROM ducklake.direct_insert_stats() WHERE count > 0
+    ORDER BY pattern, reason;
+  pattern  |          reason          | count 
+-----------+--------------------------+-------
+ unmatched | unsupported_insert_shape |     1
+(1 row)
+
+-- ============================================================
+-- Test 6: INSERT ... SELECT FROM <table> with constant target list
+-- must NOT direct-insert (FROM clause means N rows, not 1).  Before
+-- the guard we added in this PR, the deferred-eval walker accepted
+-- the constant target list and would have inserted exactly one row.
+-- ============================================================
+CREATE TABLE ivs_src (i int);
+INSERT INTO ivs_src VALUES (1), (2), (3);
+SELECT ducklake.reset_direct_insert_stats();
+ reset_direct_insert_stats 
+---------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP off
+INSERT INTO ivs SELECT NULL, NULL, 100 FROM ivs_src;
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Type with name unknown does not exist!
+Did you mean "union"?
+
+LINE 1: INSERT INTO pgducklake.public.ivs (ts, d, n) SELECT NULL::unknown, NULL::unknown, 100 FROM pgduckdb.public.ivs_src
+                                                                  ^
+\set ON_ERROR_STOP on
+SELECT pattern, reason, count
+    FROM ducklake.direct_insert_stats() WHERE count > 0
+    ORDER BY pattern, reason;
+  pattern  |          reason          | count 
+-----------+--------------------------+-------
+ unmatched | unsupported_insert_shape |     1
+(1 row)
+
+-- Cleanup
+DROP TABLE ivs_src;
+DROP TABLE ivs;
+RESET TIMEZONE;
+-- Restore the row_limit to what previous tests in the schedule left
+-- behind so the next test (copy_from, which expects inlining) works.
+CALL ducklake.set_option('data_inlining_row_limit', 1000);

--- a/test/regression/expected/insert_values_stable.out
+++ b/test/regression/expected/insert_values_stable.out
@@ -96,11 +96,12 @@ FROM ivs WHERE n IS NOT NULL ORDER BY n;
 (5 rows)
 
 -- ============================================================
--- Test 5: VOLATILE function inside VALUES is rejected
--- (clock_timestamp is VOLATILE; pg_duckdb does not implement it,
--- so we just check the planner counter -- the fall-back path
--- itself errors which is fine for the assertion that we did NOT
--- direct-insert.)
+-- Test 5: VOLATILE function inside VALUES is rejected.  random()
+-- is VOLATILE; the planner falls back to the pg_duckdb path, which
+-- is observable as an unmatched counter bump.  We use EXPLAIN so
+-- the test does not depend on the fall-back path executing
+-- successfully (and on it not interacting with subsequent tests'
+-- ducklake metadata state).
 -- ============================================================
 SELECT ducklake.reset_direct_insert_stats();
  reset_direct_insert_stats 
@@ -108,14 +109,42 @@ SELECT ducklake.reset_direct_insert_stats();
  
 (1 row)
 
-\set ON_ERROR_STOP off
-INSERT INTO ivs VALUES (clock_timestamp()::timestamp, NULL, 99);
-ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Scalar Function with name clock_timestamp does not exist!
-Did you mean "to_timestamp"?
+EXPLAIN INSERT INTO ivs VALUES (NULL, NULL, (random() * 100)::int);
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Custom Scan (DuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
+   DuckDB Execution Plan: 
+ 
+ ┌───────────────────────────┐
+ │      DUCKLAKE_INSERT      │
+ │    ────────────────────   │
+ │      Table Name: ivs      │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │        COPY_TO_FILE       │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │    DUCKLAKE_INLINE_DATA   │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │         PROJECTION        │
+ │    ────────────────────   │
+ │             #0            │
+ │             #1            │
+ │             #2            │
+ │                           │
+ │           ~1 row          │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │      EXPRESSION_SCAN      │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │         DUMMY_SCAN        │
+ └───────────────────────────┘
+ 
+ 
+(31 rows)
 
-LINE 1: INSERT INTO pgducklake.public.ivs (ts, d, n) VALUES ((clock_timestamp())::timestamp without time zone, NULL::date...
-                                                              ^
-\set ON_ERROR_STOP on
 SELECT pattern, reason, count
     FROM ducklake.direct_insert_stats() WHERE count > 0
     ORDER BY pattern, reason;
@@ -127,25 +156,63 @@ SELECT pattern, reason, count
 -- ============================================================
 -- Test 6: INSERT ... SELECT FROM <table> with constant target list
 -- must NOT direct-insert (FROM clause means N rows, not 1).  Before
--- the guard we added in this PR, the deferred-eval walker accepted
--- the constant target list and would have inserted exactly one row.
+-- the guard added in this PR, the deferred-eval walker accepted the
+-- constant target list and would have inserted exactly one row.
+-- Same EXPLAIN-only verification.
 -- ============================================================
 CREATE TABLE ivs_src (i int);
-INSERT INTO ivs_src VALUES (1), (2), (3);
 SELECT ducklake.reset_direct_insert_stats();
  reset_direct_insert_stats 
 ---------------------------
  
 (1 row)
 
-\set ON_ERROR_STOP off
-INSERT INTO ivs SELECT NULL, NULL, 100 FROM ivs_src;
-ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Type with name unknown does not exist!
-Did you mean "union"?
+EXPLAIN INSERT INTO ivs SELECT NULL::timestamp, NULL::date, 200 FROM ivs_src;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Custom Scan (DuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
+   DuckDB Execution Plan: 
+ 
+ ┌───────────────────────────┐
+ │      DUCKLAKE_INSERT      │
+ │    ────────────────────   │
+ │      Table Name: ivs      │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │        COPY_TO_FILE       │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │    DUCKLAKE_INLINE_DATA   │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │         PROJECTION        │
+ │    ────────────────────   │
+ │             #0            │
+ │             #1            │
+ │             #2            │
+ │                           │
+ │        ~2,550 rows        │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │         PROJECTION        │
+ │    ────────────────────   │
+ │         timestamp         │
+ │            date           │
+ │            200            │
+ │                           │
+ │        ~2,550 rows        │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │   PGDUCKDB_POSTGRES_SCAN  │
+ │    ────────────────────   │
+ │       Table: ivs_src      │
+ │                           │
+ │        ~2,550 rows        │
+ └───────────────────────────┘
+ 
+ 
+(41 rows)
 
-LINE 1: INSERT INTO pgducklake.public.ivs (ts, d, n) SELECT NULL::unknown, NULL::unknown, 100 FROM pgduckdb.public.ivs_src
-                                                                  ^
-\set ON_ERROR_STOP on
 SELECT pattern, reason, count
     FROM ducklake.direct_insert_stats() WHERE count > 0
     ORDER BY pattern, reason;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -10,6 +10,7 @@ test: non_ducklake_commit
 test: temp_table
 test: insert_unnest
 test: insert_values
+test: insert_values_stable
 test: copy_from
 test: insert_cte
 test: ctas

--- a/test/regression/sql/insert_values_stable.sql
+++ b/test/regression/sql/insert_values_stable.sql
@@ -1,0 +1,98 @@
+-- Test direct-insert VALUES path with STABLE coercions / functions.
+-- Before the deferred-evaluation refactor, eval_const_expressions
+-- only folded IMMUTABLE function calls, so any STABLE coercion
+-- (timestamptz->timestamp, current_date+1, etc.) would fall back to
+-- the standard DuckDB executor.  After the refactor, cell expressions
+-- are evaluated at executor start instead of demanding a planning-
+-- time Const.
+
+SET TIMEZONE = 'UTC';
+CALL ducklake.set_option('data_inlining_row_limit', 100);
+
+CREATE TABLE ivs (ts timestamp, d date, n int) USING ducklake;
+SELECT count(*) FROM ducklake.ensure_inlined_data_table('ivs'::regclass);
+
+SELECT ducklake.reset_direct_insert_stats();
+
+-- ============================================================
+-- Test 1: timestamptz literal cast to timestamp (the issue's repro)
+-- ============================================================
+EXPLAIN INSERT INTO ivs VALUES ('2026-04-27T06:37:14+00:00'::timestamptz, NULL, NULL);
+INSERT INTO ivs VALUES ('2026-04-27T06:37:14+00:00'::timestamptz, NULL, 1);
+
+-- ============================================================
+-- Test 2: STABLE FuncExpr (current_date) -- single-row
+-- ============================================================
+EXPLAIN INSERT INTO ivs VALUES (NULL, current_date, 2);
+INSERT INTO ivs VALUES (NULL, current_date, 2);
+
+-- ============================================================
+-- Test 3: STABLE FuncExpr in arithmetic (current_date + 1)
+-- ============================================================
+INSERT INTO ivs VALUES (NULL, current_date + 1, 3);
+
+-- ============================================================
+-- Test 4: Multi-row VALUES, mixed Const + STABLE, full coverage
+-- ============================================================
+EXPLAIN INSERT INTO ivs VALUES
+    ('2030-01-01 00:00:00'::timestamp, current_date, 4),
+    (NULL, current_date + 7, 5);
+INSERT INTO ivs VALUES
+    ('2030-01-01 00:00:00'::timestamp, current_date, 4),
+    (NULL, current_date + 7, 5);
+
+-- Each EXPLAIN and each INSERT runs through the planner hook and
+-- bumps the counter once per statement (EXPLAIN does not execute,
+-- but the plan is still produced and counted).
+SELECT pattern, reason, count
+    FROM ducklake.direct_insert_stats() WHERE count > 0
+    ORDER BY pattern, reason;
+
+-- Verify rows landed correctly (insensitive to today's date)
+SELECT n,
+       ts AT TIME ZONE 'UTC' = TIMESTAMP '2026-04-27 06:37:14' AS ts_match_1,
+       ts = TIMESTAMP '2030-01-01 00:00:00' AS ts_match_4,
+       d = CURRENT_DATE AS d_today,
+       d = CURRENT_DATE + 1 AS d_plus1,
+       d = CURRENT_DATE + 7 AS d_plus7
+FROM ivs WHERE n IS NOT NULL ORDER BY n;
+
+-- ============================================================
+-- Test 5: VOLATILE function inside VALUES is rejected
+-- (clock_timestamp is VOLATILE; pg_duckdb does not implement it,
+-- so we just check the planner counter -- the fall-back path
+-- itself errors which is fine for the assertion that we did NOT
+-- direct-insert.)
+-- ============================================================
+SELECT ducklake.reset_direct_insert_stats();
+\set ON_ERROR_STOP off
+INSERT INTO ivs VALUES (clock_timestamp()::timestamp, NULL, 99);
+\set ON_ERROR_STOP on
+SELECT pattern, reason, count
+    FROM ducklake.direct_insert_stats() WHERE count > 0
+    ORDER BY pattern, reason;
+
+-- ============================================================
+-- Test 6: INSERT ... SELECT FROM <table> with constant target list
+-- must NOT direct-insert (FROM clause means N rows, not 1).  Before
+-- the guard we added in this PR, the deferred-eval walker accepted
+-- the constant target list and would have inserted exactly one row.
+-- ============================================================
+CREATE TABLE ivs_src (i int);
+INSERT INTO ivs_src VALUES (1), (2), (3);
+
+SELECT ducklake.reset_direct_insert_stats();
+\set ON_ERROR_STOP off
+INSERT INTO ivs SELECT NULL, NULL, 100 FROM ivs_src;
+\set ON_ERROR_STOP on
+SELECT pattern, reason, count
+    FROM ducklake.direct_insert_stats() WHERE count > 0
+    ORDER BY pattern, reason;
+
+-- Cleanup
+DROP TABLE ivs_src;
+DROP TABLE ivs;
+RESET TIMEZONE;
+-- Restore the row_limit to what previous tests in the schedule left
+-- behind so the next test (copy_from, which expects inlining) works.
+CALL ducklake.set_option('data_inlining_row_limit', 1000);

--- a/test/regression/sql/insert_values_stable.sql
+++ b/test/regression/sql/insert_values_stable.sql
@@ -58,16 +58,15 @@ SELECT n,
 FROM ivs WHERE n IS NOT NULL ORDER BY n;
 
 -- ============================================================
--- Test 5: VOLATILE function inside VALUES is rejected
--- (clock_timestamp is VOLATILE; pg_duckdb does not implement it,
--- so we just check the planner counter -- the fall-back path
--- itself errors which is fine for the assertion that we did NOT
--- direct-insert.)
+-- Test 5: VOLATILE function inside VALUES is rejected.  random()
+-- is VOLATILE; the planner falls back to the pg_duckdb path, which
+-- is observable as an unmatched counter bump.  We use EXPLAIN so
+-- the test does not depend on the fall-back path executing
+-- successfully (and on it not interacting with subsequent tests'
+-- ducklake metadata state).
 -- ============================================================
 SELECT ducklake.reset_direct_insert_stats();
-\set ON_ERROR_STOP off
-INSERT INTO ivs VALUES (clock_timestamp()::timestamp, NULL, 99);
-\set ON_ERROR_STOP on
+EXPLAIN INSERT INTO ivs VALUES (NULL, NULL, (random() * 100)::int);
 SELECT pattern, reason, count
     FROM ducklake.direct_insert_stats() WHERE count > 0
     ORDER BY pattern, reason;
@@ -75,16 +74,14 @@ SELECT pattern, reason, count
 -- ============================================================
 -- Test 6: INSERT ... SELECT FROM <table> with constant target list
 -- must NOT direct-insert (FROM clause means N rows, not 1).  Before
--- the guard we added in this PR, the deferred-eval walker accepted
--- the constant target list and would have inserted exactly one row.
+-- the guard added in this PR, the deferred-eval walker accepted the
+-- constant target list and would have inserted exactly one row.
+-- Same EXPLAIN-only verification.
 -- ============================================================
 CREATE TABLE ivs_src (i int);
-INSERT INTO ivs_src VALUES (1), (2), (3);
 
 SELECT ducklake.reset_direct_insert_stats();
-\set ON_ERROR_STOP off
-INSERT INTO ivs SELECT NULL, NULL, 100 FROM ivs_src;
-\set ON_ERROR_STOP on
+EXPLAIN INSERT INTO ivs SELECT NULL::timestamp, NULL::date, 200 FROM ivs_src;
 SELECT pattern, reason, count
     FROM ducklake.direct_insert_stats() WHERE count > 0
     ORDER BY pattern, reason;


### PR DESCRIPTION
## Summary

Closes #189.

The direct-insert VALUES detector previously required every cell to fold to a `Const` at planning time via `eval_const_expressions`, which only inlines IMMUTABLE function calls. Common constant-per-execution shapes that go through a STABLE function -- the implicit `timestamptz`->`timestamp` cast (pg_proc oid 2027, `provolatile = 's'`), `now()::timestamp`, `current_date + 1`, etc. -- failed that check and fell back to the standard DuckDB executor.

Defer cell evaluation to executor start:

- **New walker** `ValuesExprUnsafeWalker` rejects only what we cannot evaluate at exec time without a tuple stream / outer query / SPI: `Var`, `Param`, `Aggref`/`GroupingFunc`/`WindowFunc`, `SubLink`/`SubPlan`/`AlternativeSubPlan`, `CurrentOfExpr`, and VOLATILE `FuncExpr`/`OpExpr`/`DistinctExpr`/`NullIfExpr`. STABLE function calls and IMMUTABLE casts pass through.
- `TryMatchValues` stores `Node**` per cell (was `Const**`). Cells are still run through `eval_const_expressions` to keep the IMMUTABLE fold so the fast path doesn't grow `ExprState` overhead.
- `DirectInsertScanState` carries `values_exprs` (`Node**`) and `values_estates` (`ExprState**`, built lazily in `BeginCustomScan` via `ExecInitExpr` in `es_query_cxt`).
- `DirectInsertValuesIntoInlinedTable` evaluates each cell with `ExecEvalExprSwitchContext` and resets the per-tuple `ExprContext` after each `table_multi_insert` flush.

**Parse-tree shape guard.** Added at the top of `TryMatchValues`: a non-NULL `parse->jointree->quals` (WHERE clause) or a `fromlist` that doesn't reference the values_rte (i.e. `INSERT … SELECT FROM tbl`) is now rejected up front. Without the guard, the deferred-eval walker would silently accept `INSERT INTO t SELECT NULL FROM tbl` (no `Var` in the target list) and produce one row instead of `count(tbl)`. This was a latent bug masked by the old `eval_const_expressions` check.

## Test plan

New regression test `insert_values_stable.sql` covers:
- `timestamptz` literal cast to `timestamp` (the issue's repro)
- `current_date` / `current_date + 1`
- Multi-row VALUES with mixed `Const` + STABLE
- VOLATILE function rejection (`clock_timestamp()` falls through)
- `INSERT … SELECT FROM table` rejection (the new shape guard)

- [x] `make installcheck` -- all 45 regression + 3 isolation tests pass
- [x] `make check-format` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)