### PR TITLE
feat: pre-reserve snapshot_id and row_id for direct insert

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -138,6 +138,11 @@ jobs:
         run: make bench-direct-insert
         continue-on-error: true
 
+      - name: Run concurrent direct insert stress
+        id: concurrent_stress
+        working-directory: pg_ducklake
+        run: make bench-concurrent-direct-insert
+
       - name: Print pg_ducklake regression.diffs
         if: failure() && steps.installcheck.outcome == 'failure'
         run: cat pg_ducklake/test/regression/regression.diffs && false

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 	check-isolation clean-isolation \
 	ducklake clean-ducklake \
 	pg_duckdb install-pg_duckdb clean-pg_duckdb \
-	bench-direct-insert \
+	bench-direct-insert bench-concurrent-direct-insert \
 	format check-format
 
 MODULE_big = pg_ducklake
@@ -107,6 +107,13 @@ clean-isolation:
 
 bench-direct-insert: all install
 	bash test/benchmark/bench_direct_insert.sh
+
+# Concurrency stress: 4 sessions x 60 inserts x 125 rows = 30k rows total.
+# Asserts row count, snapshot count, and storage-level row_id uniqueness;
+# failure indicates a concurrency regression in DirectInsertReservation.
+bench-concurrent-direct-insert: all install
+	NUM_SESSIONS=4 INSERTS_PER_SESSION=60 BATCH_SIZE=125 \
+	  bash test/benchmark/bench_concurrent_direct_insert.sh
 
 # ---------------------------------------------------------------------------
 # Submodule (duckdb)

--- a/docs/sql_objects.md
+++ b/docs/sql_objects.md
@@ -90,6 +90,7 @@ See [Foreign Data Wrapper](foreign_data_wrapper.md) for usage guide.
 | | [`ducklake.file_index()`](#file_index) | passthrough | - |
 | Diagnostics | [`ducklake.direct_insert_stats()`](#direct_insert_stats) | native | - |
 | | [`ducklake.reset_direct_insert_stats()`](#reset_direct_insert_stats) | native | - |
+| | [`ducklake.direct_insert_lock_ns()`](#direct_insert_lock_ns) | native | - |
 | Freeze | [`ducklake.freeze(text)`](#freeze) | native proc | - |
 
 **Kind legend:**
@@ -123,7 +124,7 @@ non-`ok` reason.
 | `unmatched` | `greater_than_limit` | the batch row count exceeds `data_inlining_row_limit` |
 | `unmatched` | `unsupported_insert_shape` | neither `UNNEST` nor `VALUES` detector matched (e.g. `INSERT ... SELECT` from a table, `RETURNING`, `ON CONFLICT`, non-const `VALUES`) |
 | `unmatched` | `invalid_rte` | the `FROM` clause's RTE kind isn't recognized by the UNNEST detector (rare) |
-| `unmatched` | `retry` | *reserved* -- reserved for a future retry-on-snapshot-conflict counter |
+| `unmatched` | `retry` | a direct insert lost the `ducklake_snapshot.snapshot_id` PK race and re-attempted (see `ducklake.direct_insert_max_retries`) |
 
 Counts are **only** bumped for `INSERT` statements that pass these
 gates (non-counted early exits):
@@ -134,6 +135,16 @@ gates (non-counted early exits):
 ### <a id="reset_direct_insert_stats"></a>`ducklake.reset_direct_insert_stats()`
 
 Zeroes all counters.  Returns `void`.
+
+### <a id="direct_insert_lock_ns"></a>`ducklake.direct_insert_lock_ns()`
+
+Returns the integer namespace key (`int4`) used by direct insert's
+internal advisory lock: every direct insert calls
+`pg_advisory_xact_lock(<this_value>, table_id::int4)` so concurrent
+direct inserts on the same table serialize without needing a UNIQUE
+index on `ducklake_table_stats`.  Exposed for isolation tests that
+need to take the same lock from outside C code; not intended for
+application use.  `IMMUTABLE`.
 
 ## Bootstrap
 

--- a/include/pgducklake/pgducklake_guc.hpp
+++ b/include/pgducklake/pgducklake_guc.hpp
@@ -5,6 +5,7 @@ namespace pgducklake {
 extern char *default_table_path;
 extern double vacuum_delete_threshold;
 extern bool enable_direct_insert;
+extern int direct_insert_max_retries;
 extern bool ctas_skip_data;
 
 extern bool enable_metadata_sync;

--- a/include/pgducklake/pgducklake_metadata_manager.hpp
+++ b/include/pgducklake/pgducklake_metadata_manager.hpp
@@ -11,6 +11,12 @@
 #include <storage/ducklake_metadata_manager.hpp>
 #include <storage/ducklake_transaction.hpp>
 
+/* MUST come after the DuckLake/DuckDB headers above: this header
+ * transitively pulls in postgres.h, whose FATAL macro clobbers
+ * DuckDB's ExceptionType::FATAL when DuckDB headers are parsed
+ * afterwards. */
+#include "pgducklake/pgducklake_direct_insert_stats.hpp"
+
 namespace pgducklake {
 
 class PgDuckLakeMetadataManager : public duckdb::PostgresMetadataManager {
@@ -72,6 +78,69 @@ bool GetTableInliningInfo(Oid table_oid, uint64_t *table_id_out, uint64_t *schem
 
 uint64_t GetNextRowIdForTable(uint64_t table_id, uint64_t schema_version);
 uint64_t GetNextSnapshotId();
-void CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int64_t rows_inserted);
+
+/* COPY FROM commit path.  Distinct from the direct-insert path because COPY
+ * does not know its row count up-front and cannot use the atomic reservation
+ * API.  Inserts the snapshot row, the snapshot_changes row, and
+ * updates/inserts the stats row from a pre-allocated snapshot_id and
+ * post-hoc rows_inserted count.  Has the same MAX(snapshot_id)+1 and
+ * read-then-update concurrency hazards as the pre-#191 direct-insert path;
+ * a chunked reservation migration for COPY FROM is tracked separately. */
+void CreateSnapshotForCopyFrom(uint64_t snapshot_id, uint64_t table_id, int64_t rows_inserted);
+
+/* Advisory-lock namespace for direct-insert per-table row_id reservation.
+ * Used as the first argument of pg_advisory_xact_lock(int4, int4); the
+ * second argument is table_id cast to int4 (DuckLake table_ids are
+ * monotonically issued from 1, so 32 bits is ample in practice).  Different
+ * tables get distinct keys and remain parallel; concurrent direct inserts
+ * on the same table serialize on this lock.  The constant is arbitrary but
+ * fixed: 'pDLK' in ASCII = 0x70444C4B.  Exposed to SQL via
+ * ducklake.direct_insert_lock_ns() so isolation specs do not duplicate the
+ * literal. */
+static constexpr int32_t DUCKLAKE_DIRECT_INSERT_LOCK_NS = 0x70444C4B;
+
+/* RAII handle for a direct-insert metadata reservation.  Encodes the
+ * three-step protocol -- reserve row_ids, reserve snapshot_id, commit --
+ * at the type level so callers cannot misuse it.
+ *
+ * Lifecycle (all within one Postgres transaction; direct insert is
+ * autocommit, so that is automatic):
+ *   1. Construct: takes a per-table advisory lock, atomically advances
+ *      ducklake_table_stats.next_row_id by `nrows`, then reserves a fresh
+ *      snapshot_id via INSERT ... ON CONFLICT (snapshot_id) DO NOTHING
+ *      with a bounded retry loop (cap: ducklake.direct_insert_max_retries).
+ *      Each lost race bumps DI_R_RETRY for `pattern`.  Raises ERROR
+ *      with SQLSTATE 40001 if retries are exhausted.
+ *   2. Caller writes inlined rows tagged with RowIdStart()..+nrows-1
+ *      and SnapshotId().
+ *   3. Commit(): writes ducklake_snapshot_changes and idempotently
+ *      bootstraps ducklake_table_column_stats via WHERE NOT EXISTS
+ *      (safe to run on every direct insert; cheap when rows already
+ *      exist).
+ *
+ * If the caller throws or returns without calling Commit(), the
+ * surrounding Postgres transaction will abort and roll back the
+ * reservation rows; the advisory lock auto-releases at xact end. */
+class DirectInsertReservation {
+public:
+  DirectInsertReservation(uint64_t table_id, uint64_t nrows, DirectInsertPattern pattern);
+
+  uint64_t RowIdStart() const {
+    return row_id_start_;
+  }
+  uint64_t SnapshotId() const {
+    return snapshot_id_;
+  }
+
+  void Commit();
+
+  DirectInsertReservation(const DirectInsertReservation &) = delete;
+  DirectInsertReservation &operator=(const DirectInsertReservation &) = delete;
+
+private:
+  uint64_t table_id_;
+  uint64_t row_id_start_;
+  uint64_t snapshot_id_;
+};
 
 } // namespace pgducklake

--- a/sql/pg_ducklake--0.1.0.sql
+++ b/sql/pg_ducklake--0.1.0.sql
@@ -611,6 +611,15 @@ CREATE FUNCTION ducklake.reset_direct_insert_stats()
     AS 'MODULE_PATHNAME', 'ducklake_reset_direct_insert_stats'
     LANGUAGE C VOLATILE;
 
+-- native: integer constant used as the namespace key for
+-- pg_advisory_xact_lock(int4, int4) inside the direct-insert
+-- DirectInsertReservation.  Exposed so isolation tests can take the
+-- same lock without hardcoding the literal.
+CREATE FUNCTION ducklake.direct_insert_lock_ns()
+    RETURNS int4
+    AS 'MODULE_PATHNAME', 'ducklake_direct_insert_lock_ns'
+    LANGUAGE C IMMUTABLE STRICT;
+
 -- Freeze ------------------------------------------------------------
 
 -- native proc: export metadata to a standalone .ducklake file.

--- a/src/pgducklake_copy_from.cpp
+++ b/src/pgducklake_copy_from.cpp
@@ -234,7 +234,7 @@ uint64 DucklakeCopyFromStdin(CopyStmt *stmt, const char *query_string) {
 
   if (rows_inserted > 0) {
     SkipSnapshotSyncGuard sync_guard;
-    CreateSnapshotForDirectInsert(begin_snapshot, table_id, rows_inserted);
+    CreateSnapshotForCopyFrom(begin_snapshot, table_id, rows_inserted);
     CommandCounterIncrement();
   }
 

--- a/src/pgducklake_direct_insert.cpp
+++ b/src/pgducklake_direct_insert.cpp
@@ -1328,14 +1328,33 @@ static TupleTableSlot *DirectInsert_ExecCustomScan(CustomScanState *node) {
     return NULL;
   }
 
-  state->begin_snapshot = pgducklake::GetNextSnapshotId();
-  state->next_row_id = pgducklake::GetNextRowIdForTable(state->table_id, state->schema_version);
+  /* Suppress the AFTER INSERT trigger on ducklake_snapshot for the
+   * lifetime of this direct insert.  The reverse-sync trigger is meant
+   * for DuckDB-driven commits, not direct insert.  Hoisted above the
+   * reservation so the snapshot_id INSERT inside the constructor is
+   * also covered (mirrors pgducklake_copy_from.cpp). */
+  pgducklake::SkipSnapshotSyncGuard sync_guard;
+
+  /* Both modes know the exact row count up-front: UNNEST validates array
+   * lengths at planning time, VALUES counts list elements. */
+  uint64_t nrows =
+      (uint64_t)((state->mode == DIRECT_INSERT_UNNEST) ? state->expected_row_count : state->values_num_rows);
+  pgducklake::DirectInsertPattern pattern =
+      (state->mode == DIRECT_INSERT_UNNEST) ? pgducklake::DI_PAT_MATCHED_UNNEST : pgducklake::DI_PAT_MATCHED_VALUES;
+
+  /* Reserve both ids atomically before any inlined row is written.  The
+   * constructor takes the per-table advisory lock and runs the
+   * snapshot_id retry loop.  See DirectInsertReservation in
+   * pgducklake_metadata_manager.hpp for the lifecycle contract. */
+  pgducklake::DirectInsertReservation reservation(state->table_id, nrows, pattern);
+  state->next_row_id = reservation.RowIdStart();
+  state->begin_snapshot = reservation.SnapshotId();
   state->rows_inserted = 0;
 
   ereport(DEBUG1, (errmsg("DuckLake direct insert: exec, table=%s, "
-                          "predicted_snapshot=%llu, next_row_id=%lu",
+                          "snapshot=%llu, row_id_start=%lu, nrows=%llu",
                           state->inlined_table_name, (unsigned long long)state->begin_snapshot,
-                          (unsigned long)state->next_row_id)));
+                          (unsigned long)state->next_row_id, (unsigned long long)nrows)));
 
   if (state->mode == DIRECT_INSERT_UNNEST) {
     DirectInsertIntoInlinedTable(state);
@@ -1346,17 +1365,7 @@ static TupleTableSlot *DirectInsert_ExecCustomScan(CustomScanState *node) {
   state->finished = true;
   node->ss.ps.state->es_processed = state->rows_inserted;
 
-  /* TODO(#186 follow-up): unique-violation on ducklake_snapshot.snapshot_id
-   * under concurrent direct inserts should bump DI_R_RETRY and retry.
-   * A straightforward BeginInternalSubTransaction wrapper around the
-   * snapshot commit doesn't work with the inner SPI-based functions
-   * (snapshot resowner mismatch on subtx release).  A real retry will
-   * need either (a) pre-reserve snapshot_id before writing any rows,
-   * or (b) restructure CreateSnapshotForDirectInsert into separate
-   * reserve/finalize phases.  For now, concurrent conflicts ERROR as
-   * they did pre-#186. */
-  pgducklake::SkipSnapshotSyncGuard sync_guard;
-  pgducklake::CreateSnapshotForDirectInsert(state->begin_snapshot, state->table_id, state->rows_inserted);
+  reservation.Commit();
 
   CommandCounterIncrement();
 
@@ -1715,3 +1724,15 @@ static void DirectInsertValuesIntoInlinedTable(DirectInsertScanState *state) {
 }
 
 } // namespace pgducklake
+
+extern "C" {
+
+/* SQL-visible accessor for DUCKLAKE_DIRECT_INSERT_LOCK_NS so isolation
+ * tests can take the same advisory lock as DirectInsertReservation
+ * without duplicating the magic number. */
+PG_FUNCTION_INFO_V1(ducklake_direct_insert_lock_ns);
+Datum ducklake_direct_insert_lock_ns(PG_FUNCTION_ARGS) {
+  PG_RETURN_INT32(pgducklake::DUCKLAKE_DIRECT_INSERT_LOCK_NS);
+}
+
+} // extern "C"

--- a/src/pgducklake_guc.cpp
+++ b/src/pgducklake_guc.cpp
@@ -21,6 +21,7 @@ namespace pgducklake {
 char *default_table_path = strdup("");
 double vacuum_delete_threshold = 0.1;
 bool enable_direct_insert = true;
+int direct_insert_max_retries = 10;
 bool ctas_skip_data = false;
 
 bool enable_metadata_sync = true;
@@ -51,6 +52,13 @@ void RegisterGUCs() {
                            "Enable direct insert optimization for INSERT ... "
                            "SELECT UNNEST($n) statements.",
                            NULL, &enable_direct_insert, true, PGC_USERSET, 0, NULL, NULL, NULL);
+
+  DefineCustomIntVariable("ducklake.direct_insert_max_retries",
+                          "Maximum retry attempts when a direct insert loses the snapshot_id "
+                          "allocation race against a concurrent commit.  After exhaustion, the "
+                          "statement fails with SQLSTATE 40001 (serialization_failure) so the "
+                          "client can retry at the application layer.",
+                          NULL, &direct_insert_max_retries, 10, 0, 1000, PGC_USERSET, 0, NULL, NULL, NULL);
 
   DefineCustomBoolVariable("ducklake.enable_metadata_sync",
                            "Enable reverse metadata sync from DuckDB to PostgreSQL. "

--- a/src/pgducklake_metadata_manager.cpp
+++ b/src/pgducklake_metadata_manager.cpp
@@ -727,8 +727,8 @@ uint64_t GetNextRowIdForTable(uint64_t table_id, uint64_t schema_version) {
   }
 
   /* Read next_row_id from ducklake_table_stats (O(1) index lookup).
-   * CreateSnapshotForDirectInsert keeps this row up to date after
-   * each direct insert.  If no row exists (first insert into this
+   * The COPY FROM commit path keeps this row up to date after
+   * each insert.  If no row exists (first insert into this
    * table), fall back to MAX(row_id) + 1 from the inlined data table. */
   StringInfoData query;
   initStringInfo(&query);
@@ -770,6 +770,83 @@ uint64_t GetNextRowIdForTable(uint64_t table_id, uint64_t schema_version) {
   return next_row_id;
 }
 
+/* File-local helper for DirectInsertReservation: reserve the row_id range
+ * under the per-table advisory lock.  Returns row_id_start. */
+static uint64_t ReserveRowIdRangeImpl(uint64_t table_id, uint64_t nrows) {
+  int ret;
+  uint64_t row_id_start = 0;
+
+  if ((ret = SPI_connect()) < 0) {
+    elog(ERROR, "SPI_connect failed: %d", ret);
+  }
+
+  /* Per-table advisory lock; auto-released at xact end.  Serializes
+   * concurrent direct inserts on the same table so the read+update of
+   * ducklake_table_stats below is atomic without needing a UNIQUE on
+   * table_id. */
+  StringInfoData lock_query;
+  initStringInfo(&lock_query);
+  appendStringInfo(&lock_query, "SELECT pg_advisory_xact_lock(%d::int4, %lld::int4)",
+                   (int)DUCKLAKE_DIRECT_INSERT_LOCK_NS, (long long)table_id);
+  ret = SPI_execute(lock_query.data, false, 0);
+  if (ret != SPI_OK_SELECT) {
+    SPI_finish();
+    elog(ERROR, "DirectInsertReservation: advisory lock acquire failed: %d", ret);
+  }
+
+  /* Read current next_row_id under the lock. */
+  StringInfoData read_query;
+  initStringInfo(&read_query);
+  appendStringInfo(&read_query, "SELECT next_row_id FROM ducklake.ducklake_table_stats WHERE table_id = %llu",
+                   (unsigned long long)table_id);
+  ret = SPI_execute(read_query.data, true, 1);
+  if (ret == SPI_OK_SELECT && SPI_processed > 0) {
+    HeapTuple tuple = SPI_tuptable->vals[0];
+    bool isnull;
+    Datum d = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 1, &isnull);
+    if (!isnull) {
+      row_id_start = DatumGetInt64(d);
+    }
+  }
+
+  /* Try UPDATE first; on 0 rows this is the first direct insert into
+   * this table and we INSERT the stats row instead.  The advisory lock
+   * makes this read-then-update sequence atomic against concurrent
+   * direct inserts. */
+  StringInfoData stats_update;
+  initStringInfo(&stats_update);
+  appendStringInfo(&stats_update,
+                   "UPDATE ducklake.ducklake_table_stats "
+                   "SET next_row_id  = next_row_id  + %llu, "
+                   "    record_count = record_count + %llu "
+                   "WHERE table_id = %llu",
+                   (unsigned long long)nrows, (unsigned long long)nrows, (unsigned long long)table_id);
+  ret = SPI_execute(stats_update.data, false, 0);
+  if (ret != SPI_OK_UPDATE) {
+    SPI_finish();
+    elog(ERROR, "DirectInsertReservation: stats UPDATE failed: %d", ret);
+  }
+
+  if (SPI_processed == 0) {
+    StringInfoData stats_insert;
+    initStringInfo(&stats_insert);
+    appendStringInfo(&stats_insert,
+                     "INSERT INTO ducklake.ducklake_table_stats "
+                     "(table_id, record_count, next_row_id, file_size_bytes) "
+                     "VALUES (%llu, %llu, %llu, 0)",
+                     (unsigned long long)table_id, (unsigned long long)nrows, (unsigned long long)nrows);
+    ret = SPI_execute(stats_insert.data, false, 0);
+    if (ret != SPI_OK_INSERT) {
+      SPI_finish();
+      elog(ERROR, "DirectInsertReservation: stats INSERT failed: %d", ret);
+    }
+    /* row_id_start stays 0 -- the freshly inserted stats row started at 0. */
+  }
+
+  SPI_finish();
+  return row_id_start;
+}
+
 uint64_t GetNextSnapshotId() {
   int ret;
   uint64_t next_snapshot_id = 1; // Default to 1 if no snapshots exist yet
@@ -796,13 +873,111 @@ uint64_t GetNextSnapshotId() {
   return next_snapshot_id;
 }
 
-void CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int64_t rows_inserted) {
+/* File-local helper for DirectInsertReservation: reserve a fresh
+ * snapshot_id via INSERT ... ON CONFLICT DO NOTHING RETURNING with a
+ * bounded retry loop.  `max_retries` is the count of *re-attempts* after
+ * the first try, so 0 means single attempt with no retry.
+ *
+ * The LEFT JOIN against `(SELECT 1)` guarantees the outer SELECT always
+ * produces exactly one row even when ducklake_snapshot is empty (in which
+ * case latest.* are NULL and the COALESCE defaults take over).  All four
+ * reads of `latest` come from the same MVCC instant inside the INSERT, so
+ * schema_version / next_catalog_id / next_file_id stay consistent with
+ * the chosen snapshot_id. */
+static uint64_t ReserveSnapshotIdImpl(DirectInsertPattern pattern_for_stats) {
+  const int max_retries = direct_insert_max_retries;
+
+  static const char *insert_query = "INSERT INTO ducklake.ducklake_snapshot "
+                                    "(snapshot_id, snapshot_time, schema_version, next_catalog_id, next_file_id) "
+                                    "SELECT COALESCE(latest.snapshot_id,     0) + 1, "
+                                    "       NOW(), "
+                                    "       COALESCE(latest.schema_version,  0), "
+                                    "       COALESCE(latest.next_catalog_id, 1), "
+                                    "       COALESCE(latest.next_file_id,    0) "
+                                    "  FROM (SELECT 1) AS d "
+                                    "  LEFT JOIN ("
+                                    "    SELECT snapshot_id, schema_version, next_catalog_id, next_file_id "
+                                    "      FROM ducklake.ducklake_snapshot "
+                                    "     ORDER BY snapshot_id DESC LIMIT 1"
+                                    "  ) latest ON true "
+                                    "ON CONFLICT (snapshot_id) DO NOTHING "
+                                    "RETURNING snapshot_id";
+
+  uint64_t base_wait_us = 100UL * 1000UL; /* 100 ms */
+
+  /* Loop covers max_retries + 1 attempts: the initial try plus
+   * max_retries re-attempts. */
+  for (int attempt = 0; attempt <= max_retries; attempt++) {
+    int ret;
+    if ((ret = SPI_connect()) < 0) {
+      elog(ERROR, "SPI_connect failed: %d", ret);
+    }
+
+    ret = SPI_execute(insert_query, false, 0);
+    /* PG returns SPI_OK_INSERT_RETURNING for INSERT ... RETURNING even
+     * when ON CONFLICT DO NOTHING resulted in zero rows inserted; the
+     * conflict case is signalled by SPI_processed == 0. */
+    if (ret != SPI_OK_INSERT_RETURNING) {
+      SPI_finish();
+      elog(ERROR, "DirectInsertReservation: snapshot INSERT failed: %d", ret);
+    }
+
+    if (SPI_processed > 0) {
+      uint64_t snapshot_id = 0;
+      HeapTuple tuple = SPI_tuptable->vals[0];
+      bool isnull;
+      Datum d = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 1, &isnull);
+      if (!isnull) {
+        snapshot_id = DatumGetInt64(d);
+      }
+      SPI_finish();
+      return snapshot_id;
+    }
+
+    /* Lost the PK race: ON CONFLICT DO NOTHING swallowed our row. */
+    SPI_finish();
+    DirectInsertStatsBump(pattern_for_stats, DI_R_RETRY);
+
+    if (attempt >= max_retries) {
+      ereport(ERROR, (errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+                      errmsg("ducklake direct insert: snapshot_id reservation failed "
+                             "after %d retr%s",
+                             max_retries, max_retries == 1 ? "y" : "ies"),
+                      errhint("Concurrent commit pressure on ducklake_snapshot; "
+                              "retry the statement or raise ducklake.direct_insert_max_retries.")));
+    }
+
+    /* Exponential backoff (1.5x) with +/-25% jitter to avoid thundering
+     * herd.  base_wait_us starts at 100ms and grows; the floor of 4us
+     * defends against future changes that might lower the start point. */
+    if (base_wait_us < 4) {
+      base_wait_us = 4;
+    }
+    long jitter_us = ((long)random() % (long)(base_wait_us / 2)) - (long)(base_wait_us / 4);
+    long sleep_us = (long)base_wait_us + jitter_us;
+    if (sleep_us < 1000) {
+      sleep_us = 1000;
+    }
+    pg_usleep(sleep_us);
+    base_wait_us = base_wait_us + (base_wait_us >> 1); /* *= 1.5 */
+  }
+
+  /* unreachable */
+  return 0;
+}
+
+/* COPY FROM commit path.  Distinct from the direct-insert path because
+ * COPY does not know its row count up-front and cannot use the
+ * DirectInsertReservation API.  Has the same MAX(snapshot_id)+1 and
+ * read-then-update stats races as the pre-#191 direct-insert path; a
+ * chunked reservation migration for COPY FROM is tracked separately. */
+void CreateSnapshotForCopyFrom(uint64_t snapshot_id, uint64_t table_id, int64_t rows_inserted) {
   int ret;
 
-  elog(DEBUG1, "CreateSnapshotForDirectInsert: creating snapshot %llu", (unsigned long long)snapshot_id);
+  elog(DEBUG1, "CreateSnapshotForCopyFrom: creating snapshot %llu", (unsigned long long)snapshot_id);
 
   if ((ret = SPI_connect()) < 0) {
-    elog(ERROR, "CreateSnapshotForDirectInsert: SPI_connect failed: %d", ret);
+    elog(ERROR, "CreateSnapshotForCopyFrom: SPI_connect failed: %d", ret);
     return;
   }
 
@@ -853,14 +1028,11 @@ void CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int6
                    (unsigned long long)snapshot_id, (unsigned long long)schema_version,
                    (unsigned long long)next_catalog_id, (unsigned long long)next_file_id);
 
-  elog(DEBUG1, "CreateSnapshotForDirectInsert: executing %s", snapshot_insert.data);
   ret = SPI_execute(snapshot_insert.data, false, 0);
   if (ret != SPI_OK_INSERT) {
-    elog(ERROR, "CreateSnapshotForDirectInsert: failed to insert snapshot: %d", ret);
+    elog(ERROR, "CreateSnapshotForCopyFrom: failed to insert snapshot: %d", ret);
   }
 
-  // Build INSERT for ducklake_snapshot_changes
-  // Use a simple description for the changes_made field
   StringInfoData changes_insert;
   initStringInfo(&changes_insert);
   appendStringInfo(&changes_insert,
@@ -869,18 +1041,11 @@ void CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int6
                    "VALUES (%llu, 'inlined_data_insert', NULL, NULL, NULL)",
                    (unsigned long long)snapshot_id);
 
-  elog(DEBUG1, "CreateSnapshotForDirectInsert: executing %s", changes_insert.data);
   ret = SPI_execute(changes_insert.data, false, 0);
   if (ret != SPI_OK_INSERT) {
-    elog(ERROR, "CreateSnapshotForDirectInsert: failed to insert snapshot changes: %d", ret);
+    elog(ERROR, "CreateSnapshotForCopyFrom: failed to insert snapshot changes: %d", ret);
   }
 
-  /* Update ducklake_table_stats, or create it if this is the first insert.
-   * DuckDB normally creates this row on its first data commit, but the
-   * direct-insert path bypasses DuckDB entirely.  When inserting a new
-   * stats row we must also populate ducklake_table_column_stats so that
-   * DuckDB's GetGlobalTableStats LEFT JOIN doesn't produce a NULL
-   * column_id (TransformGlobalStatsRow reads it without a null check). */
   StringInfoData stats_update;
   initStringInfo(&stats_update);
   appendStringInfo(&stats_update,
@@ -892,11 +1057,10 @@ void CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int6
 
   ret = SPI_execute(stats_update.data, false, 0);
   if (ret != SPI_OK_UPDATE) {
-    elog(ERROR, "CreateSnapshotForDirectInsert: failed to update table stats: %d", ret);
+    elog(ERROR, "CreateSnapshotForCopyFrom: failed to update table stats: %d", ret);
   }
 
   if (SPI_processed == 0) {
-    /* No existing stats row -- first direct insert into this table. */
     StringInfoData stats_insert;
     initStringInfo(&stats_insert);
     appendStringInfo(&stats_insert,
@@ -907,10 +1071,9 @@ void CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int6
 
     ret = SPI_execute(stats_insert.data, false, 0);
     if (ret != SPI_OK_INSERT) {
-      elog(ERROR, "CreateSnapshotForDirectInsert: failed to insert table stats: %d", ret);
+      elog(ERROR, "CreateSnapshotForCopyFrom: failed to insert table stats: %d", ret);
     }
 
-    /* Populate ducklake_table_column_stats for each active column. */
     StringInfoData col_stats_insert;
     initStringInfo(&col_stats_insert);
     appendStringInfo(&col_stats_insert,
@@ -924,14 +1087,68 @@ void CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int6
 
     ret = SPI_execute(col_stats_insert.data, false, 0);
     if (ret != SPI_OK_INSERT) {
-      elog(ERROR, "CreateSnapshotForDirectInsert: failed to insert column stats: %d", ret);
+      elog(ERROR, "CreateSnapshotForCopyFrom: failed to insert column stats: %d", ret);
     }
-
-    elog(DEBUG1, "CreateSnapshotForDirectInsert: created new stats row for table %llu", (unsigned long long)table_id);
   }
 
   SPI_finish();
-  elog(DEBUG1, "CreateSnapshotForDirectInsert: successfully created snapshot %llu", (unsigned long long)snapshot_id);
+}
+
+DirectInsertReservation::DirectInsertReservation(uint64_t table_id, uint64_t nrows, DirectInsertPattern pattern)
+    : table_id_(table_id), row_id_start_(ReserveRowIdRangeImpl(table_id, nrows)),
+      snapshot_id_(ReserveSnapshotIdImpl(pattern)) {
+}
+
+void DirectInsertReservation::Commit() {
+  int ret;
+
+  if ((ret = SPI_connect()) < 0) {
+    elog(ERROR, "DirectInsertReservation::Commit: SPI_connect failed: %d", ret);
+    return;
+  }
+
+  /* The ducklake_snapshot row was already inserted by ReserveSnapshotIdImpl;
+   * ducklake_table_stats was already advanced by ReserveRowIdRangeImpl.
+   * Here we only record the change set, then idempotently bootstrap
+   * ducklake_table_column_stats so DuckLake's stats LEFT JOIN finds the
+   * column rows.  The bootstrap runs unconditionally because the WHERE
+   * NOT EXISTS subselect makes it cheap when rows already exist and the
+   * only correctness risk is a concurrent path racing for the same
+   * (table_id, column_id) pair, which is harmless here. */
+  StringInfoData changes_insert;
+  initStringInfo(&changes_insert);
+  appendStringInfo(&changes_insert,
+                   "INSERT INTO ducklake.ducklake_snapshot_changes "
+                   "(snapshot_id, changes_made, author, commit_message, commit_extra_info) "
+                   "VALUES (%llu, 'inlined_data_insert', NULL, NULL, NULL)",
+                   (unsigned long long)snapshot_id_);
+  ret = SPI_execute(changes_insert.data, false, 0);
+  if (ret != SPI_OK_INSERT) {
+    SPI_finish();
+    elog(ERROR, "DirectInsertReservation::Commit: snapshot_changes INSERT failed: %d", ret);
+  }
+
+  StringInfoData col_stats_insert;
+  initStringInfo(&col_stats_insert);
+  appendStringInfo(&col_stats_insert,
+                   "INSERT INTO ducklake.ducklake_table_column_stats "
+                   "(table_id, column_id, contains_null, contains_nan, "
+                   " min_value, max_value, extra_stats) "
+                   "SELECT %llu, c.column_id, NULL, NULL, NULL, NULL, NULL "
+                   "  FROM ducklake.ducklake_column c "
+                   " WHERE c.table_id = %llu AND c.end_snapshot IS NULL "
+                   "   AND NOT EXISTS ("
+                   "     SELECT 1 FROM ducklake.ducklake_table_column_stats ts "
+                   "      WHERE ts.table_id = c.table_id AND ts.column_id = c.column_id"
+                   "   )",
+                   (unsigned long long)table_id_, (unsigned long long)table_id_);
+  ret = SPI_execute(col_stats_insert.data, false, 0);
+  if (ret != SPI_OK_INSERT) {
+    SPI_finish();
+    elog(ERROR, "DirectInsertReservation::Commit: column_stats INSERT failed: %d", ret);
+  }
+
+  SPI_finish();
 }
 
 } // namespace pgducklake

--- a/src/pgducklake_metadata_manager.cpp
+++ b/src/pgducklake_metadata_manager.cpp
@@ -42,6 +42,8 @@ extern "C" {
 #include "catalog/pg_class.h"
 #include "catalog/pg_namespace.h"
 #include "executor/spi.h"
+#include "miscadmin.h"
+#include "storage/lock.h"
 #include "utils/elog.h"
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
@@ -770,31 +772,43 @@ uint64_t GetNextRowIdForTable(uint64_t table_id, uint64_t schema_version) {
   return next_row_id;
 }
 
+/* File-local helper: take the per-table advisory lock used by
+ * DirectInsertReservation.  Bypasses SPI / the planner because pg_duckdb's
+ * planner hook intercepts inner SELECTs in this execution context and
+ * silently no-ops `SELECT pg_advisory_xact_lock(...)`, which would defeat
+ * the serialization.  Direct LockAcquire on LOCKTAG_ADVISORY produces the
+ * same xact-scoped lock that pg_advisory_xact_lock(int4, int4) does, but
+ * cannot be hijacked. */
+static void AcquireDirectInsertTableLock(uint64_t table_id) {
+  LOCKTAG tag;
+  /* Match pg_advisory_xact_lock(int4, int4) semantics: 4-tuple is
+   * (MyDatabaseId, key1, key2, 2) where the trailing 2 means 2-key form. */
+  SET_LOCKTAG_ADVISORY(tag, MyDatabaseId, (uint32)DUCKLAKE_DIRECT_INSERT_LOCK_NS, (uint32)table_id, 2);
+  (void)LockAcquire(&tag, ExclusiveLock, false, false);
+}
+
 /* File-local helper for DirectInsertReservation: reserve the row_id range
  * under the per-table advisory lock.  Returns row_id_start. */
 static uint64_t ReserveRowIdRangeImpl(uint64_t table_id, uint64_t nrows) {
   int ret;
   uint64_t row_id_start = 0;
 
+  /* Acquire the lock BEFORE SPI_connect so it cannot be intercepted by
+   * any inner-query hook.  Auto-released at the surrounding txn end. */
+  AcquireDirectInsertTableLock(table_id);
+
   if ((ret = SPI_connect()) < 0) {
     elog(ERROR, "SPI_connect failed: %d", ret);
   }
 
-  /* Per-table advisory lock; auto-released at xact end.  Serializes
-   * concurrent direct inserts on the same table so the read+update of
-   * ducklake_table_stats below is atomic without needing a UNIQUE on
-   * table_id. */
-  StringInfoData lock_query;
-  initStringInfo(&lock_query);
-  appendStringInfo(&lock_query, "SELECT pg_advisory_xact_lock(%d::int4, %lld::int4)",
-                   (int)DUCKLAKE_DIRECT_INSERT_LOCK_NS, (long long)table_id);
-  ret = SPI_execute(lock_query.data, false, 0);
-  if (ret != SPI_OK_SELECT) {
-    SPI_finish();
-    elog(ERROR, "DirectInsertReservation: advisory lock acquire failed: %d", ret);
-  }
+  /* Push a fresh MVCC snapshot AFTER acquiring the lock.  Without this,
+   * SPI inherits the caller's outer-statement snapshot, which was taken
+   * before the lock was held and would still hide changes a peer
+   * direct-insert committed while we were blocked.  GetTransactionSnapshot
+   * advances to a fresh statement snapshot under READ COMMITTED. */
+  PushActiveSnapshot(GetTransactionSnapshot());
 
-  /* Read current next_row_id under the lock. */
+  /* Read current next_row_id under the lock + fresh snapshot. */
   StringInfoData read_query;
   initStringInfo(&read_query);
   appendStringInfo(&read_query, "SELECT next_row_id FROM ducklake.ducklake_table_stats WHERE table_id = %llu",
@@ -843,6 +857,7 @@ static uint64_t ReserveRowIdRangeImpl(uint64_t table_id, uint64_t nrows) {
     /* row_id_start stays 0 -- the freshly inserted stats row started at 0. */
   }
 
+  PopActiveSnapshot();
   SPI_finish();
   return row_id_start;
 }
@@ -913,11 +928,18 @@ static uint64_t ReserveSnapshotIdImpl(DirectInsertPattern pattern_for_stats) {
       elog(ERROR, "SPI_connect failed: %d", ret);
     }
 
+    /* Push a fresh statement snapshot so the SELECT subqueries inside the
+     * INSERT see committed peer snapshots.  Without this the outer
+     * transaction's snapshot would hide concurrent commits and we would
+     * loop forever on PK conflicts under contention. */
+    PushActiveSnapshot(GetTransactionSnapshot());
+
     ret = SPI_execute(insert_query, false, 0);
     /* PG returns SPI_OK_INSERT_RETURNING for INSERT ... RETURNING even
      * when ON CONFLICT DO NOTHING resulted in zero rows inserted; the
      * conflict case is signalled by SPI_processed == 0. */
     if (ret != SPI_OK_INSERT_RETURNING) {
+      PopActiveSnapshot();
       SPI_finish();
       elog(ERROR, "DirectInsertReservation: snapshot INSERT failed: %d", ret);
     }
@@ -930,11 +952,13 @@ static uint64_t ReserveSnapshotIdImpl(DirectInsertPattern pattern_for_stats) {
       if (!isnull) {
         snapshot_id = DatumGetInt64(d);
       }
+      PopActiveSnapshot();
       SPI_finish();
       return snapshot_id;
     }
 
     /* Lost the PK race: ON CONFLICT DO NOTHING swallowed our row. */
+    PopActiveSnapshot();
     SPI_finish();
     DirectInsertStatsBump(pattern_for_stats, DI_R_RETRY);
 

--- a/test/benchmark/bench_concurrent_direct_insert.sh
+++ b/test/benchmark/bench_concurrent_direct_insert.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+#
+# bench_concurrent_direct_insert.sh -- Concurrent direct insert stress
+#
+# Spawns N parallel psql sessions, each firing M autocommit direct
+# inserts (UNNEST pattern) at the same ducklake table.  Verifies the
+# concurrency-safety properties enforced by DirectInsertReservation:
+#
+#   1. No client error.  Phase 2's retry loop hides the snapshot_id PK
+#      race; if exhaustion happened the client would see SQLSTATE 40001.
+#   2. User row count matches expected.  Catches lost writes.
+#   3. Storage row_id uniqueness in the inlined data table.  The row_id
+#      race used to allow overlapping ranges; a regression that
+#      reintroduces it surfaces here even when the user count looks
+#      fine.
+#   4. Snapshot count matches expected.  Each direct insert produces
+#      exactly one ducklake_snapshot row -- verifies the reservation
+#      did not double-allocate or skip on retry.
+#   5. Reports DI_R_RETRY so you can see whether concurrent contention
+#      actually exercised the snapshot_id retry path.
+#
+# Usage:
+#   PG_CONFIG=/path/to/pg_config ./bench_concurrent_direct_insert.sh
+#   NUM_SESSIONS=16 INSERTS_PER_SESSION=100 BATCH_SIZE=50 \
+#     ./bench_concurrent_direct_insert.sh
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+NUM_SESSIONS=${NUM_SESSIONS:-8}
+INSERTS_PER_SESSION=${INSERTS_PER_SESSION:-50}
+BATCH_SIZE=${BATCH_SIZE:-100}
+DATA_INLINING_ROW_LIMIT=${DATA_INLINING_ROW_LIMIT:-1000000}
+
+TOTAL_BATCHES=$((NUM_SESSIONS * INSERTS_PER_SESSION))
+TOTAL_INSERTED=$((TOTAL_BATCHES * BATCH_SIZE))
+
+# ---------------------------------------------------------------------------
+# Resolve PG binaries
+# ---------------------------------------------------------------------------
+if [ -z "${PG_CONFIG:-}" ]; then
+  PG_CONFIG=$(command -v pg_config 2>/dev/null || true)
+  if [ -z "$PG_CONFIG" ]; then
+    echo "ERROR: PG_CONFIG not set and pg_config not found in PATH" >&2
+    exit 1
+  fi
+fi
+
+PG_BINDIR=$("$PG_CONFIG" --bindir)
+INITDB="$PG_BINDIR/initdb"
+PG_CTL="$PG_BINDIR/pg_ctl"
+PSQL="$PG_BINDIR/psql"
+
+# ---------------------------------------------------------------------------
+# Temp cluster
+# ---------------------------------------------------------------------------
+BENCHDIR=$(mktemp -d "${TMPDIR:-/tmp}/bench_concurrent_di_XXXXXX")
+PGDATA="$BENCHDIR/data"
+PGPORT=${PGPORT:-15433}
+DBNAME=bench_concurrent_di
+
+cleanup() {
+  "$PG_CTL" -D "$PGDATA" -m immediate stop 2>/dev/null || true
+  rm -rf "$BENCHDIR"
+}
+trap cleanup EXIT
+
+echo "Setting up temporary PostgreSQL cluster on port $PGPORT..."
+"$INITDB" -D "$PGDATA" --no-locale -E UTF8 >/dev/null 2>&1
+
+# max_connections must comfortably exceed NUM_SESSIONS + a small margin
+# for the verifier psql + background workers + walwriter + bgwriter etc.
+MAX_CONN=$((NUM_SESSIONS + 16))
+
+cat >> "$PGDATA/postgresql.conf" <<EOF
+shared_preload_libraries = 'pg_duckdb,pg_ducklake'
+port = $PGPORT
+max_connections = $MAX_CONN
+log_min_messages = warning
+logging_collector = off
+unix_socket_directories = '$BENCHDIR'
+ducklake.maintenance_enabled = off
+EOF
+
+"$PG_CTL" -D "$PGDATA" -l "$BENCHDIR/pg.log" -w start >/dev/null 2>&1
+
+run_sql() {
+  "$PSQL" -h "$BENCHDIR" -p "$PGPORT" -d "$DBNAME" -X -q "$@"
+}
+run_sql_t() {
+  "$PSQL" -h "$BENCHDIR" -p "$PGPORT" -d "$DBNAME" -X -At "$@"
+}
+
+"$PSQL" -h "$BENCHDIR" -p "$PGPORT" -d postgres -X -q \
+  -c "CREATE DATABASE $DBNAME;"
+run_sql -c "CREATE EXTENSION pg_ducklake CASCADE;"
+
+# ---------------------------------------------------------------------------
+# Helpers (lifted from bench_direct_insert.sh)
+# ---------------------------------------------------------------------------
+# Build a VALUES tuple list: (1,'v1'),(2,'v2'),...,(n,'vn')
+gen_values_tuples() {
+  local n=$1
+  seq 1 "$n" | awk -v q="'" '{printf "(%d, %sv%d%s),", $1, q, $1, q}' | sed 's/,$//'
+}
+
+# Helper that resolves the dynamic inlined-data table name and returns
+# (rows, unique_row_ids) so the verifier can assert no row_id collision.
+run_sql -c "CALL ducklake.set_option('data_inlining_row_limit', $DATA_INLINING_ROW_LIMIT);"
+run_sql <<'EOSQL'
+CREATE FUNCTION bench_concurrent_storage_check(target_table text)
+RETURNS TABLE (rows bigint, unique_row_ids bigint)
+LANGUAGE plpgsql AS $fn$
+DECLARE
+  tbl_id bigint;
+  sv bigint;
+  q text;
+BEGIN
+  SELECT t.table_id, idt.schema_version
+    INTO tbl_id, sv
+    FROM ducklake.ducklake_table t
+    JOIN ducklake.ducklake_inlined_data_tables idt ON idt.table_id = t.table_id
+   WHERE t.table_name = $1 AND t.end_snapshot IS NULL
+   LIMIT 1;
+
+  q := format('SELECT count(*)::bigint, count(DISTINCT row_id)::bigint '
+              'FROM ducklake.ducklake_inlined_data_%s_%s',
+              tbl_id, sv);
+  RETURN QUERY EXECUTE q;
+END;
+$fn$;
+EOSQL
+
+run_sql -c "CREATE TABLE bench_concurrent_di (id int, val text) USING ducklake;"
+run_sql -c "SELECT ducklake.reset_direct_insert_stats();"
+
+BASELINE_SNAPSHOTS=$(run_sql_t -c "SELECT count(*) FROM ducklake.ducklake_snapshot;")
+
+# ---------------------------------------------------------------------------
+# Build the per-session script: M direct inserts of BATCH_SIZE rows each.
+# Uses a literal VALUES tuple list (matches DIRECT_INSERT_VALUES).  The
+# UNNEST pattern requires a PREPARE'd statement with array parameters
+# to be detected as direct-insertable, but pg_duckdb's plan cache trips
+# a "UNKNOWN to Postgres type" error around the 6th EXECUTE of such a
+# PREPARE -- unrelated to the concurrency we want to stress.  VALUES
+# avoids the bug and exercises the same DirectInsertReservation code
+# path.
+# ---------------------------------------------------------------------------
+TUPLES=$(gen_values_tuples "$BATCH_SIZE")
+
+{
+  echo "SET ducklake.enable_direct_insert = true;"
+  for _ in $(seq 1 "$INSERTS_PER_SESSION"); do
+    echo "INSERT INTO bench_concurrent_di VALUES $TUPLES;"
+  done
+} > "$BENCHDIR/session.sql"
+
+# ---------------------------------------------------------------------------
+# Fire NUM_SESSIONS in parallel
+# ---------------------------------------------------------------------------
+echo ""
+echo "Concurrent Direct Insert Stress"
+echo "==============================="
+echo "Sessions:         $NUM_SESSIONS"
+echo "Inserts/session:  $INSERTS_PER_SESSION"
+echo "Batch size:       $BATCH_SIZE"
+echo "Total inserts:    $TOTAL_INSERTED rows in $TOTAL_BATCHES direct-insert batches"
+echo ""
+
+START_NS=$(date +%s)
+for s in $(seq 1 "$NUM_SESSIONS"); do
+  (
+    if "$PSQL" -h "$BENCHDIR" -p "$PGPORT" -d "$DBNAME" -X -q \
+        -v ON_ERROR_STOP=1 -f "$BENCHDIR/session.sql" \
+        > "$BENCHDIR/session_$s.out" 2>&1; then
+      echo 0 > "$BENCHDIR/session_$s.rc"
+    else
+      echo "$?" > "$BENCHDIR/session_$s.rc"
+    fi
+  ) &
+done
+wait
+END_NS=$(date +%s)
+ELAPSED_S=$((END_NS - START_NS))
+[ "$ELAPSED_S" -lt 1 ] && ELAPSED_S=1
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+errors=0
+for s in $(seq 1 "$NUM_SESSIONS"); do
+  rc=$(cat "$BENCHDIR/session_$s.rc")
+  if [ "$rc" -ne 0 ]; then
+    echo "Session $s failed (rc=$rc):"
+    sed 's/^/  /' "$BENCHDIR/session_$s.out"
+    errors=$((errors + 1))
+  fi
+done
+
+USER_COUNT=$(run_sql_t -c "SELECT count(*) FROM bench_concurrent_di;")
+STORAGE=$(run_sql_t -c "SELECT rows || '|' || unique_row_ids FROM bench_concurrent_storage_check('bench_concurrent_di');")
+STORAGE_ROWS=$(echo "$STORAGE" | cut -d'|' -f1)
+STORAGE_UNIQUE=$(echo "$STORAGE" | cut -d'|' -f2)
+
+NEW_SNAPSHOTS=$(run_sql_t -c \
+  "SELECT count(*) - $BASELINE_SNAPSHOTS FROM ducklake.ducklake_snapshot;")
+RETRY_COUNT=$(run_sql_t -c \
+  "SELECT sum(count) FROM ducklake.direct_insert_stats() WHERE reason = 'retry';")
+OK_COUNT=$(run_sql_t -c \
+  "SELECT count FROM ducklake.direct_insert_stats() WHERE pattern = 'matched_values' AND reason = 'ok';")
+
+THROUGHPUT=$(awk "BEGIN {printf \"%.0f\", $TOTAL_INSERTED / $ELAPSED_S}")
+
+# ---------------------------------------------------------------------------
+# Report + verdict
+# ---------------------------------------------------------------------------
+fail=0
+result() {
+  local label=$1; local actual=$2; local expected=$3
+  if [ "$actual" = "$expected" ]; then
+    printf "%-22s %s == %s  PASS\n" "$label" "$actual" "$expected"
+  else
+    printf "%-22s %s != %s  FAIL\n" "$label" "$actual" "$expected"
+    fail=1
+  fi
+}
+
+echo ""
+echo "Throughput:           ${THROUGHPUT} rows/sec  (${ELAPSED_S}s elapsed)"
+echo ""
+result "Failed sessions"      "$errors"          "0"
+result "User row count"       "$USER_COUNT"      "$TOTAL_INSERTED"
+result "Storage rows"         "$STORAGE_ROWS"    "$TOTAL_INSERTED"
+result "Storage unique row_ids" "$STORAGE_UNIQUE" "$TOTAL_INSERTED"
+result "Snapshots created"    "$NEW_SNAPSHOTS"   "$TOTAL_BATCHES"
+result "DI matched_values ok" "$OK_COUNT"        "$TOTAL_BATCHES"
+echo ""
+echo "DI_R_RETRY:           $RETRY_COUNT  (>0 means concurrent contention exercised the snapshot_id retry loop)"
+echo ""
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL"
+  exit 1
+fi
+
+echo "OK"
+exit 0

--- a/test/benchmark/bench_concurrent_direct_insert.sh
+++ b/test/benchmark/bench_concurrent_direct_insert.sh
@@ -169,7 +169,7 @@ echo "Batch size:       $BATCH_SIZE"
 echo "Total inserts:    $TOTAL_INSERTED rows in $TOTAL_BATCHES direct-insert batches"
 echo ""
 
-START_NS=$(date +%s)
+START=$(python3 -c 'import time; print(time.monotonic())')
 for s in $(seq 1 "$NUM_SESSIONS"); do
   (
     if "$PSQL" -h "$BENCHDIR" -p "$PGPORT" -d "$DBNAME" -X -q \
@@ -182,9 +182,8 @@ for s in $(seq 1 "$NUM_SESSIONS"); do
   ) &
 done
 wait
-END_NS=$(date +%s)
-ELAPSED_S=$((END_NS - START_NS))
-[ "$ELAPSED_S" -lt 1 ] && ELAPSED_S=1
+END=$(python3 -c 'import time; print(time.monotonic())')
+ELAPSED_MS=$(python3 -c "print(round(($END - $START) * 1000, 1))")
 
 # ---------------------------------------------------------------------------
 # Verify
@@ -211,7 +210,7 @@ RETRY_COUNT=$(run_sql_t -c \
 OK_COUNT=$(run_sql_t -c \
   "SELECT count FROM ducklake.direct_insert_stats() WHERE pattern = 'matched_values' AND reason = 'ok';")
 
-THROUGHPUT=$(awk "BEGIN {printf \"%.0f\", $TOTAL_INSERTED / $ELAPSED_S}")
+THROUGHPUT=$(python3 -c "print(round($TOTAL_INSERTED / ($ELAPSED_MS / 1000), 0))")
 
 # ---------------------------------------------------------------------------
 # Report + verdict
@@ -228,7 +227,7 @@ result() {
 }
 
 echo ""
-echo "Throughput:           ${THROUGHPUT} rows/sec  (${ELAPSED_S}s elapsed)"
+echo "Throughput:           ${THROUGHPUT} rows/sec  (${ELAPSED_MS} ms elapsed)"
 echo ""
 result "Failed sessions"      "$errors"          "0"
 result "User row count"       "$USER_COUNT"      "$TOTAL_INSERTED"

--- a/test/isolation/expected/direct_insert_cross_path_xfail.out
+++ b/test/isolation/expected/direct_insert_cross_path_xfail.out
@@ -1,0 +1,27 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s1_seed s1_begin s1_delete s2_di s1_commit s1_rollback check_count check_ids
+step s1_seed: INSERT INTO iso_di_xp VALUES (1, 'seed1'), (2, 'seed2'), (3, 'seed3');
+step s1_begin: BEGIN;
+step s1_delete: DELETE FROM iso_di_xp WHERE id IN (1, 2);
+step s2_di: INSERT INTO iso_di_xp VALUES (10, 'new1'), (20, 'new2');
+step s1_commit: COMMIT;
+ERROR:  pg_ducklake commit hook failed to commit DuckDB: (PGDuckDB/pgduckdb_raw_query_cpp) TransactionContext Error: Failed to commit: Failed to commit DuckLake transaction.
+Unsupported change type inlined_data_insert
+step s1_rollback: ROLLBACK;
+step check_count: SELECT count(*) AS total, count(DISTINCT id) AS unique_ids FROM iso_di_xp;
+total|unique_ids
+-----+----------
+    5|         5
+(1 row)
+
+step check_ids: SELECT id FROM iso_di_xp ORDER BY id;
+id
+--
+ 1
+ 2
+ 3
+10
+20
+(5 rows)
+

--- a/test/isolation/expected/direct_insert_self_race.out
+++ b/test/isolation/expected/direct_insert_self_race.out
@@ -1,0 +1,72 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s1_di s2_di check_user_count check_select check_storage_rows
+step s1_di: INSERT INTO iso_di_self VALUES (1, 'a1'), (2, 'a2'), (3, 'a3');
+step s2_di: INSERT INTO iso_di_self VALUES (10, 'b1'), (20, 'b2');
+step check_user_count: 
+  SELECT count(*) AS total, count(DISTINCT id) AS unique_ids FROM iso_di_self;
+
+total|unique_ids
+-----+----------
+    5|         5
+(1 row)
+
+step check_select: SELECT id FROM iso_di_self ORDER BY id;
+id
+--
+ 1
+ 2
+ 3
+10
+20
+(5 rows)
+
+step check_storage_rows: SELECT * FROM iso_di_self_storage_check('iso_di_self');
+row_count|distinct_row_ids
+---------+----------------
+        5|               5
+(1 row)
+
+
+starting permutation: s1_hold_lock s2_di s1_release s1_di check_user_count check_select check_storage_rows
+step s1_hold_lock: 
+  BEGIN;
+  SELECT pg_advisory_xact_lock(
+           ducklake.direct_insert_lock_ns(),
+           (SELECT table_id FROM ducklake.ducklake_table
+             WHERE table_name = 'iso_di_self' AND end_snapshot IS NULL)::int4
+         );
+
+pg_advisory_xact_lock
+---------------------
+                     
+(1 row)
+
+step s2_di: INSERT INTO iso_di_self VALUES (10, 'b1'), (20, 'b2'); <waiting ...>
+step s1_release: COMMIT;
+step s2_di: <... completed>
+step s1_di: INSERT INTO iso_di_self VALUES (1, 'a1'), (2, 'a2'), (3, 'a3');
+step check_user_count: 
+  SELECT count(*) AS total, count(DISTINCT id) AS unique_ids FROM iso_di_self;
+
+total|unique_ids
+-----+----------
+    5|         5
+(1 row)
+
+step check_select: SELECT id FROM iso_di_self ORDER BY id;
+id
+--
+ 1
+ 2
+ 3
+10
+20
+(5 rows)
+
+step check_storage_rows: SELECT * FROM iso_di_self_storage_check('iso_di_self');
+row_count|distinct_row_ids
+---------+----------------
+        5|               5
+(1 row)
+

--- a/test/isolation/expected/direct_insert_vs_alter.out
+++ b/test/isolation/expected/direct_insert_vs_alter.out
@@ -1,0 +1,64 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s1_seed s1_begin s1_alter s1_commit s2_di_new check_count check_ids
+step s1_seed: INSERT INTO iso_di_alt VALUES (1, 'pre');
+step s1_begin: BEGIN;
+step s1_alter: ALTER TABLE iso_di_alt ADD COLUMN extra int DEFAULT 0;
+step s1_commit: COMMIT;
+step s2_di_new: INSERT INTO iso_di_alt(id, val, extra) VALUES (30, 'c1', 100);
+step check_count: SELECT count(*) AS total FROM iso_di_alt;
+total
+-----
+    2
+(1 row)
+
+step check_ids: SELECT id FROM iso_di_alt ORDER BY id;
+id
+--
+ 1
+30
+(2 rows)
+
+
+starting permutation: s1_seed s2_di_old s1_begin s1_alter s1_commit check_count check_ids
+step s1_seed: INSERT INTO iso_di_alt VALUES (1, 'pre');
+step s2_di_old: INSERT INTO iso_di_alt VALUES (10, 'b1'), (20, 'b2');
+step s1_begin: BEGIN;
+step s1_alter: ALTER TABLE iso_di_alt ADD COLUMN extra int DEFAULT 0;
+step s1_commit: COMMIT;
+step check_count: SELECT count(*) AS total FROM iso_di_alt;
+total
+-----
+    3
+(1 row)
+
+step check_ids: SELECT id FROM iso_di_alt ORDER BY id;
+id
+--
+ 1
+10
+20
+(3 rows)
+
+
+starting permutation: s1_seed s1_begin s1_alter s2_di_old s1_commit check_count check_ids
+step s1_seed: INSERT INTO iso_di_alt VALUES (1, 'pre');
+step s1_begin: BEGIN;
+step s1_alter: ALTER TABLE iso_di_alt ADD COLUMN extra int DEFAULT 0;
+step s2_di_old: INSERT INTO iso_di_alt VALUES (10, 'b1'), (20, 'b2'); <waiting ...>
+step s1_commit: COMMIT;
+step s2_di_old: <... completed>
+step check_count: SELECT count(*) AS total FROM iso_di_alt;
+total
+-----
+    3
+(1 row)
+
+step check_ids: SELECT id FROM iso_di_alt ORDER BY id;
+id
+--
+ 1
+10
+20
+(3 rows)
+

--- a/test/isolation/expected/direct_insert_vs_delete.out
+++ b/test/isolation/expected/direct_insert_vs_delete.out
@@ -1,0 +1,43 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s1_seed s1_begin s1_delete s1_commit s2_di check_count check_ids
+step s1_seed: INSERT INTO iso_di_del VALUES (1, 'seed1'), (2, 'seed2'), (3, 'seed3');
+step s1_begin: BEGIN;
+step s1_delete: DELETE FROM iso_di_del WHERE id IN (1, 2);
+step s1_commit: COMMIT;
+step s2_di: INSERT INTO iso_di_del VALUES (10, 'new1'), (20, 'new2');
+step check_count: SELECT count(*) AS total FROM iso_di_del;
+total
+-----
+    3
+(1 row)
+
+step check_ids: SELECT id FROM iso_di_del ORDER BY id;
+id
+--
+ 3
+10
+20
+(3 rows)
+
+
+starting permutation: s1_seed s2_di s1_begin s1_delete s1_commit check_count check_ids
+step s1_seed: INSERT INTO iso_di_del VALUES (1, 'seed1'), (2, 'seed2'), (3, 'seed3');
+step s2_di: INSERT INTO iso_di_del VALUES (10, 'new1'), (20, 'new2');
+step s1_begin: BEGIN;
+step s1_delete: DELETE FROM iso_di_del WHERE id IN (1, 2);
+step s1_commit: COMMIT;
+step check_count: SELECT count(*) AS total FROM iso_di_del;
+total
+-----
+    3
+(1 row)
+
+step check_ids: SELECT id FROM iso_di_del ORDER BY id;
+id
+--
+ 3
+10
+20
+(3 rows)
+

--- a/test/isolation/schedule
+++ b/test/isolation/schedule
@@ -1,3 +1,7 @@
 test: explicit_transaction_commit
 test: concurrent_writes
 test: concurrent_cross_table_writes
+test: direct_insert_self_race
+test: direct_insert_vs_delete
+test: direct_insert_vs_alter
+test: direct_insert_cross_path_xfail

--- a/test/isolation/specs/direct_insert_cross_path_xfail.spec
+++ b/test/isolation/specs/direct_insert_cross_path_xfail.spec
@@ -1,0 +1,64 @@
+# XFAIL TRACKER: cross-path concurrency between direct insert and the
+# DuckDB-path commit.
+#
+# Phase 1+2 made direct-insert-vs-direct-insert race-free.  The
+# remaining hazard, which this spec documents, is that the upstream
+# DuckLake commit (`DuckLakeTransaction::ExecuteCommit`) does not know
+# how to apply a `ducklake_snapshot_changes.changes_made =
+# 'inlined_data_insert'` row that some other path produced.  When a
+# DuckDB-path commit is open and a direct insert lands in the gap, the
+# DuckDB-path COMMIT throws:
+#
+#   ERROR: pg_ducklake commit hook failed to commit DuckDB:
+#          ... TransactionContext Error: Failed to commit:
+#          ... Unsupported change type inlined_data_insert
+#
+# The direct insert itself succeeds (autocommit); the DuckDB-path
+# transaction is the loser.  Net data state is correct for the direct
+# insert and rolled back for the DuckDB-path side -- nothing is
+# corrupted, but the DuckDB-path's intent is silently dropped.
+#
+# Resolution requires either an upstream change to DuckLake's commit
+# (recognise `inlined_data_insert` change rows) or pg_ducklake-side
+# advisory-lock injection that serialises the two paths.  Both are
+# out of scope for the initial pre-reserve PR.
+#
+# The expected output captures *current* (broken) behaviour so that:
+#   1. CI runs are deterministic against the failure mode.
+#   2. The day either fix lands, the expected output flips and these
+#      permutations move to the must-pass specs.
+
+setup
+{
+  CALL ducklake.set_option('data_inlining_row_limit', 1000);
+  CREATE TABLE iso_di_xp (id int, val text) USING ducklake;
+}
+
+session s1
+step s1_seed   { INSERT INTO iso_di_xp VALUES (1, 'seed1'), (2, 'seed2'), (3, 'seed3'); }
+step s1_begin  { BEGIN; }
+step s1_delete { DELETE FROM iso_di_xp WHERE id IN (1, 2); }
+step s1_commit { COMMIT; }
+# When s1_commit fails (the documented xfail), the session's transaction
+# state is left aborted; an explicit ROLLBACK clears it.
+step s1_rollback { ROLLBACK; }
+
+session s2
+step s2_di { INSERT INTO iso_di_xp VALUES (10, 'new1'), (20, 'new2'); }
+
+session checker
+step check_count { SELECT count(*) AS total, count(DISTINCT id) AS unique_ids FROM iso_di_xp; }
+step check_ids   { SELECT id FROM iso_di_xp ORDER BY id; }
+
+teardown
+{
+  DROP TABLE iso_di_xp;
+}
+
+# Direct insert lands inside an open DELETE transaction.  DELETE rolls
+# back at COMMIT (Unsupported change type); direct insert's rows are
+# committed.  Final state: the seeds (1, 2, 3) plus direct insert (10,
+# 20) -- the DELETE intent is silently lost.  When the upstream issue
+# is fixed, this expected output flips to "DELETE applied, then
+# direct-insert rows visible -> 3, 10, 20".
+permutation s1_seed s1_begin s1_delete s2_di s1_commit s1_rollback check_count check_ids

--- a/test/isolation/specs/direct_insert_self_race.spec
+++ b/test/isolation/specs/direct_insert_self_race.spec
@@ -1,0 +1,86 @@
+# Concurrent direct inserts into the same ducklake table must produce
+# distinct snapshots and non-overlapping row_id ranges.  The advisory
+# lock taken inside DirectInsertReservation serializes concurrent
+# reservers without needing a UNIQUE constraint on ducklake_table_stats.
+#
+# Verification has two layers:
+#   - check_user_count   -- user-visible row count and id uniqueness
+#   - check_storage_rows -- storage-level row_id uniqueness in the
+#                           inlined data table.  This is the property
+#                           that the row_id race fix actually enforces;
+#                           a regression that re-introduces overlapping
+#                           ranges would surface here even though
+#                           user-visible queries might still look fine.
+
+setup
+{
+  CALL ducklake.set_option('data_inlining_row_limit', 1000);
+  CREATE TABLE iso_di_self (id int, val text) USING ducklake;
+
+  -- Helper that resolves the dynamic inlined-data table name and
+  -- reports row_id uniqueness; used by check_storage_rows below.
+  CREATE FUNCTION iso_di_self_storage_check(table_name text)
+  RETURNS TABLE (row_count bigint, distinct_row_ids bigint)
+  LANGUAGE plpgsql AS $fn$
+  DECLARE
+    tbl_id bigint;
+    sv bigint;
+    q text;
+  BEGIN
+    SELECT t.table_id, idt.schema_version
+      INTO tbl_id, sv
+      FROM ducklake.ducklake_table t
+      JOIN ducklake.ducklake_inlined_data_tables idt ON idt.table_id = t.table_id
+     WHERE t.table_name = $1 AND t.end_snapshot IS NULL
+     LIMIT 1;
+
+    q := format('SELECT count(*)::bigint, count(DISTINCT row_id)::bigint '
+                'FROM ducklake.ducklake_inlined_data_%s_%s',
+                tbl_id, sv);
+    RETURN QUERY EXECUTE q;
+  END;
+  $fn$;
+}
+
+session s1
+# Hold the same advisory lock that direct insert acquires inside
+# DirectInsertReservation.  Source the namespace key from
+# ducklake.direct_insert_lock_ns() rather than hardcoding the literal,
+# so any future change to the C constant is picked up automatically.
+step s1_hold_lock {
+  BEGIN;
+  SELECT pg_advisory_xact_lock(
+           ducklake.direct_insert_lock_ns(),
+           (SELECT table_id FROM ducklake.ducklake_table
+             WHERE table_name = 'iso_di_self' AND end_snapshot IS NULL)::int4
+         );
+}
+step s1_release { COMMIT; }
+step s1_di { INSERT INTO iso_di_self VALUES (1, 'a1'), (2, 'a2'), (3, 'a3'); }
+
+session s2
+step s2_di { INSERT INTO iso_di_self VALUES (10, 'b1'), (20, 'b2'); }
+
+session checker
+step check_user_count {
+  SELECT count(*) AS total, count(DISTINCT id) AS unique_ids FROM iso_di_self;
+}
+step check_select { SELECT id FROM iso_di_self ORDER BY id; }
+# Asserts row_count == distinct_row_ids in the inlined data table.
+step check_storage_rows { SELECT * FROM iso_di_self_storage_check('iso_di_self'); }
+
+teardown
+{
+  DROP TABLE iso_di_self;
+  DROP FUNCTION iso_di_self_storage_check(text);
+}
+
+# Serial direct inserts: both succeed immediately.  No contention.
+permutation s1_di s2_di check_user_count check_select check_storage_rows
+
+# Lock-induced interleaving: s2's direct insert blocks on the advisory
+# lock held by s1.  s1 commits (releases the lock), s2 then completes,
+# and s1 fires its own direct insert.  Total still 5 rows; advisory lock
+# ensured the reservation phases were strictly serial so no row_id
+# collision could happen.
+permutation s1_hold_lock s2_di s1_release s1_di check_user_count check_select check_storage_rows

--- a/test/isolation/specs/direct_insert_vs_alter.spec
+++ b/test/isolation/specs/direct_insert_vs_alter.spec
@@ -1,0 +1,45 @@
+# Direct insert (autocommit) racing with ALTER TABLE ADD COLUMN.  ALTER
+# bumps the table's schema_version, which the direct insert captures at
+# planning time.  Phase 2's snapshot reservation reads schema_version at
+# the same instant it picks the snapshot_id, so the recorded snapshot is
+# always self-consistent, regardless of which side wins.
+#
+# Key invariant: after both operations land, no row should be hidden by
+# a stale schema_version on the snapshot row.
+
+setup
+{
+  CALL ducklake.set_option('data_inlining_row_limit', 1000);
+  CREATE TABLE iso_di_alt (id int, val text) USING ducklake;
+}
+
+session s1
+# Pre-seed via direct insert (autocommit step); see direct_insert_vs_delete
+# for the rationale (setup can't mix Postgres+DuckDB writes).
+step s1_seed   { INSERT INTO iso_di_alt VALUES (1, 'pre'); }
+step s1_begin  { BEGIN; }
+step s1_alter  { ALTER TABLE iso_di_alt ADD COLUMN extra int DEFAULT 0; }
+step s1_commit { COMMIT; }
+
+session s2
+step s2_di_old { INSERT INTO iso_di_alt VALUES (10, 'b1'), (20, 'b2'); }
+step s2_di_new { INSERT INTO iso_di_alt(id, val, extra) VALUES (30, 'c1', 100); }
+
+session checker
+step check_count   { SELECT count(*) AS total FROM iso_di_alt; }
+step check_ids     { SELECT id FROM iso_di_alt ORDER BY id; }
+
+teardown
+{
+  DROP TABLE iso_di_alt;
+}
+
+# Serial: alter commits first, then direct insert with the new column.
+permutation s1_seed s1_begin s1_alter s1_commit s2_di_new check_count check_ids
+
+# Serial reverse: direct insert without the new column, then alter.
+permutation s1_seed s2_di_old s1_begin s1_alter s1_commit check_count check_ids
+
+# Interleaved: alter txn open, direct insert fires (sees the pre-alter
+# schema), then alter commits.  Both writes must end up visible.
+permutation s1_seed s1_begin s1_alter s2_di_old s1_commit check_count check_ids

--- a/test/isolation/specs/direct_insert_vs_delete.spec
+++ b/test/isolation/specs/direct_insert_vs_delete.spec
@@ -1,0 +1,46 @@
+# Direct insert (autocommit) racing with DELETE (DuckDB-path) on the same
+# ducklake table.  DELETE goes through the DuckDB commit path and writes
+# to the inlined deletion table; direct insert writes to the inlined data
+# table with a fresh snapshot_id.  No row_id collision should occur
+# within the direct insert's own range, and previously-deleted rows must
+# stay deleted regardless of insert ordering.
+
+setup
+{
+  CALL ducklake.set_option('data_inlining_row_limit', 1000);
+  CREATE TABLE iso_di_del (id int, val text) USING ducklake;
+}
+
+session s1
+# Seed has to live in a step (not setup) -- setup runs as a single
+# transaction, and CALL ducklake.set_option already wrote to a Postgres
+# metadata table there, so a DuckDB-path INSERT in the same block
+# trips the "no mixed PG+DuckDB writes" guard.  Direct insert in an
+# autocommit step is fine.
+step s1_seed    { INSERT INTO iso_di_del VALUES (1, 'seed1'), (2, 'seed2'), (3, 'seed3'); }
+step s1_begin   { BEGIN; }
+step s1_delete  { DELETE FROM iso_di_del WHERE id IN (1, 2); }
+step s1_commit  { COMMIT; }
+
+session s2
+step s2_di { INSERT INTO iso_di_del VALUES (10, 'new1'), (20, 'new2'); }
+
+session checker
+step check_count  { SELECT count(*) AS total FROM iso_di_del; }
+step check_ids    { SELECT id FROM iso_di_del ORDER BY id; }
+
+teardown
+{
+  DROP TABLE iso_di_del;
+}
+
+# Serial: delete commits first, then direct insert.  Final: id 3, 10, 20.
+permutation s1_seed s1_begin s1_delete s1_commit s2_di check_count check_ids
+
+# Direct insert before the delete: id 1 and 2 still get deleted; final: 3, 10, 20.
+permutation s1_seed s2_di s1_begin s1_delete s1_commit check_count check_ids
+
+# The interleaved case (delete txn open + direct insert fires before commit)
+# trips a known cross-path limitation: DuckLake's commit cannot accept a
+# snapshot_changes row with `inlined_data_insert` from another path.  That
+# permutation lives in direct_insert_cross_path_xfail.spec.


### PR DESCRIPTION
## Summary
- Atomic reservation API (`DirectInsertReservation`) fixes two concurrency hazards in direct insert: a loud `snapshot_id` PK race that surfaced as `unique_violation` to the client, and a silent `row_id` race that produced overlapping ranges in the inlined data table.
- Per-table `pg_advisory_xact_lock` serializes concurrent direct-insert reservers without changing any DuckLake metadata schema. `snapshot_id` is allocated via `INSERT ... ON CONFLICT DO NOTHING RETURNING` in a bounded retry loop (cap: new GUC `ducklake.direct_insert_max_retries`, default 10); on exhaustion the client gets `SQLSTATE 40001` instead of the raw `23505`.
- Legacy `CreateSnapshotForDirectInsert` is renamed to `CreateSnapshotForCopyFrom` and kept for COPY FROM (which cannot pre-reserve without knowing its row count); COPY migration is tracked separately.
- Adds `ducklake.direct_insert_lock_ns()` SQL helper so isolation tests source the advisory-lock namespace from the C constant rather than duplicating the literal. Wires up the previously reserved `DI_R_RETRY` counter.

## Test plan
- [x] `make installcheck` -- 45 regression + 7 isolation specs all pass.
- [x] `make check-format` -- clean.
- New isolation specs:
  - `direct_insert_self_race` -- advisory lock serialization plus a storage-level row_id uniqueness assertion (the property the fix actually enforces; user-visible counts alone would not catch the row_id race).
  - `direct_insert_vs_delete` -- DELETE + direct insert orderings; final state correct in serial cases.
  - `direct_insert_vs_alter` -- ALTER TABLE blocking direct insert, schema_version carry-forward stays consistent with the chosen snapshot_id.
  - `direct_insert_cross_path_xfail` -- documents an unrelated upstream limitation (DuckLake commit cannot apply a cross-path `inlined_data_insert` change row). Captured deterministically; expected output flips when fixed upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)