### PR TITLE
fix: surface direct-insert snapshot_id race as SQLSTATE 40001

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -138,6 +138,10 @@ jobs:
         run: make bench-direct-insert
         continue-on-error: true
 
+      - name: Run concurrent direct insert stress
+        working-directory: pg_ducklake
+        run: make bench-concurrent-direct-insert
+
       - name: Print pg_ducklake regression.diffs
         if: failure() && steps.installcheck.outcome == 'failure'
         run: cat pg_ducklake/test/regression/regression.diffs && false

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 	check-isolation clean-isolation \
 	ducklake clean-ducklake \
 	pg_duckdb install-pg_duckdb clean-pg_duckdb \
-	bench-direct-insert \
+	bench-direct-insert bench-concurrent-direct-insert \
 	format check-format
 
 MODULE_big = pg_ducklake
@@ -107,6 +107,9 @@ clean-isolation:
 
 bench-direct-insert: all install
 	bash test/benchmark/bench_direct_insert.sh
+
+bench-concurrent-direct-insert: all install
+	bash test/benchmark/bench_concurrent_direct_insert.sh
 
 # ---------------------------------------------------------------------------
 # Submodule (duckdb)

--- a/src/pgducklake_direct_insert.cpp
+++ b/src/pgducklake_direct_insert.cpp
@@ -1328,38 +1328,48 @@ static TupleTableSlot *DirectInsert_ExecCustomScan(CustomScanState *node) {
     return NULL;
   }
 
-  state->begin_snapshot = pgducklake::GetNextSnapshotId();
-  state->next_row_id = pgducklake::GetNextRowIdForTable(state->table_id, state->schema_version);
-  state->rows_inserted = 0;
+  /* Concurrent direct inserts can both compute the same MAX(snapshot_id)+1
+   * and one will lose the PK race with 23505.  Translate that to 40001 so
+   * client retry adapters (pgx, jdbc, pgbench --max-tries) handle it
+   * transparently; the autocommit txn rollback discards the inlined rows
+   * we tagged, so the retry runs from a fresh next_row_id with no overlap. */
+  MemoryContext old_ctx = CurrentMemoryContext;
+  PG_TRY();
+  {
+    state->begin_snapshot = pgducklake::GetNextSnapshotId();
+    state->next_row_id = pgducklake::GetNextRowIdForTable(state->table_id, state->schema_version);
+    state->rows_inserted = 0;
 
-  ereport(DEBUG1, (errmsg("DuckLake direct insert: exec, table=%s, "
-                          "predicted_snapshot=%llu, next_row_id=%lu",
-                          state->inlined_table_name, (unsigned long long)state->begin_snapshot,
-                          (unsigned long)state->next_row_id)));
+    if (state->mode == DIRECT_INSERT_UNNEST) {
+      DirectInsertIntoInlinedTable(state);
+    } else {
+      DirectInsertValuesIntoInlinedTable(state);
+    }
 
-  if (state->mode == DIRECT_INSERT_UNNEST) {
-    DirectInsertIntoInlinedTable(state);
-  } else {
-    DirectInsertValuesIntoInlinedTable(state);
+    pgducklake::SkipSnapshotSyncGuard sync_guard;
+    pgducklake::CreateSnapshotForDirectInsert(state->begin_snapshot, state->table_id, state->rows_inserted);
   }
+  PG_CATCH();
+  {
+    MemoryContextSwitchTo(old_ctx);
+    ErrorData *edata = CopyErrorData();
+    if (edata->sqlerrcode == ERRCODE_UNIQUE_VIOLATION) {
+      FreeErrorData(edata);
+      FlushErrorState();
+      DirectInsertStatsBump(pgducklake::DI_PAT_UNMATCHED, pgducklake::DI_R_RETRY);
+      ereport(ERROR, (errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+                      errmsg("ducklake direct insert: snapshot_id allocation lost the race"),
+                      errhint("Retry the statement.")));
+    }
+    FreeErrorData(edata);
+    PG_RE_THROW();
+  }
+  PG_END_TRY();
 
   state->finished = true;
   node->ss.ps.state->es_processed = state->rows_inserted;
 
-  /* TODO(#186 follow-up): unique-violation on ducklake_snapshot.snapshot_id
-   * under concurrent direct inserts should bump DI_R_RETRY and retry.
-   * A straightforward BeginInternalSubTransaction wrapper around the
-   * snapshot commit doesn't work with the inner SPI-based functions
-   * (snapshot resowner mismatch on subtx release).  A real retry will
-   * need either (a) pre-reserve snapshot_id before writing any rows,
-   * or (b) restructure CreateSnapshotForDirectInsert into separate
-   * reserve/finalize phases.  For now, concurrent conflicts ERROR as
-   * they did pre-#186. */
-  pgducklake::SkipSnapshotSyncGuard sync_guard;
-  pgducklake::CreateSnapshotForDirectInsert(state->begin_snapshot, state->table_id, state->rows_inserted);
-
   CommandCounterIncrement();
-
   pgducklake::ResetDirectInsertCaches();
 
   return NULL;

--- a/test/benchmark/bench_concurrent_direct_insert.sh
+++ b/test/benchmark/bench_concurrent_direct_insert.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# bench_concurrent_direct_insert.sh -- Concurrent direct insert stress
+#
+# N parallel bash sessions issue autocommit direct inserts via psql.
+# When a session loses the snapshot_id PK race the executor surfaces
+# SQLSTATE 40001; the per-session loop catches and retries (mirroring
+# pgx / jdbc / pgbench --max-tries).  Pure shell + psql -- works on
+# every PG version.
+#
+# Asserts:
+#   - no client-visible error after retries
+#   - user rows == sessions * inserts/session * batch
+#   - storage row_id uniqueness (autocommit rollback property)
+#   - retry path fired under contention (DI_R_RETRY > 0 when N > 1)
+
+set -euo pipefail
+
+NUM_SESSIONS=${NUM_SESSIONS:-8}
+INSERTS_PER_SESSION=${INSERTS_PER_SESSION:-20}
+BATCH_SIZE=${BATCH_SIZE:-50}
+MAX_TRIES=${MAX_TRIES:-200}
+
+TOTAL_BATCHES=$((NUM_SESSIONS * INSERTS_PER_SESSION))
+TOTAL_INSERTED=$((TOTAL_BATCHES * BATCH_SIZE))
+
+if [ -z "${PG_CONFIG:-}" ]; then
+  PG_CONFIG=$(command -v pg_config 2>/dev/null) || { echo "PG_CONFIG not set" >&2; exit 1; }
+fi
+PG_BINDIR=$("$PG_CONFIG" --bindir)
+
+BENCHDIR=$(mktemp -d "${TMPDIR:-/tmp}/bench_concurrent_di_XXXXXX")
+PGDATA="$BENCHDIR/data"
+PGPORT=${PGPORT:-15433}
+DBNAME=bench_concurrent_di
+
+cleanup() {
+  "$PG_BINDIR/pg_ctl" -D "$PGDATA" -m immediate stop 2>/dev/null || true
+  [ "${KEEP_BENCHDIR:-0}" = "1" ] || rm -rf "$BENCHDIR"
+}
+trap cleanup EXIT
+
+"$PG_BINDIR/initdb" -D "$PGDATA" --no-locale -E UTF8 >/dev/null 2>&1
+cat >> "$PGDATA/postgresql.conf" <<EOF
+shared_preload_libraries = 'pg_duckdb,pg_ducklake'
+port = $PGPORT
+max_connections = $((NUM_SESSIONS + 16))
+log_min_messages = warning
+unix_socket_directories = '$BENCHDIR'
+ducklake.maintenance_enabled = off
+EOF
+"$PG_BINDIR/pg_ctl" -D "$PGDATA" -l "$BENCHDIR/pg.log" -w start >/dev/null 2>&1
+
+PSQL="$PG_BINDIR/psql -h $BENCHDIR -p $PGPORT -d $DBNAME -X -q"
+$PG_BINDIR/psql -h "$BENCHDIR" -p "$PGPORT" -d postgres -X -q -c "CREATE DATABASE $DBNAME;"
+$PSQL -c "CREATE EXTENSION pg_ducklake CASCADE;" \
+      -c "CALL ducklake.set_option('data_inlining_row_limit', 1000000);" \
+      -c "CREATE TABLE bench_concurrent_di (id int, val text) USING ducklake;" \
+      -c "SELECT ducklake.reset_direct_insert_stats();"
+
+# Helper that resolves the dynamic inlined-data table name and reports
+# (rows, unique_row_ids).  Used by the verifier below.
+$PSQL <<'EOSQL'
+CREATE FUNCTION storage_check() RETURNS TABLE (rows bigint, unique_row_ids bigint)
+LANGUAGE plpgsql AS $fn$
+DECLARE q text;
+BEGIN
+  SELECT format('SELECT count(*)::bigint, count(DISTINCT row_id)::bigint FROM ducklake.ducklake_inlined_data_%s_%s',
+                t.table_id, idt.schema_version) INTO q
+    FROM ducklake.ducklake_table t
+    JOIN ducklake.ducklake_inlined_data_tables idt ON idt.table_id = t.table_id
+   WHERE t.table_name = 'bench_concurrent_di' AND t.end_snapshot IS NULL;
+  RETURN QUERY EXECUTE q;
+END $fn$;
+EOSQL
+
+TUPLES=$(seq 1 "$BATCH_SIZE" | awk -v q="'" '{printf "(%d, %sv%d%s),", $1, q, $1, q}' | sed 's/,$//')
+INSERT_SQL="INSERT INTO bench_concurrent_di VALUES $TUPLES;"
+
+# Per-session: loop INSERTS_PER_SESSION times, retrying each batch on
+# SQLSTATE 40001 (printed by psql when VERBOSITY=sqlstate).
+session_runner() {
+  local sid=$1 err="$BENCHDIR/err_$1"
+  for _ in $(seq 1 "$INSERTS_PER_SESSION"); do
+    local attempt=0
+    while true; do
+      if $PG_BINDIR/psql -h "$BENCHDIR" -p "$PGPORT" -d "$DBNAME" -X -q \
+           -v ON_ERROR_STOP=1 -v VERBOSITY=sqlstate \
+           -c "$INSERT_SQL" >/dev/null 2>"$err"; then
+        break
+      fi
+      if grep -qE '^ERROR:[[:space:]]+40001\b' "$err"; then
+        attempt=$((attempt + 1))
+        [ "$attempt" -lt "$MAX_TRIES" ] && continue
+      fi
+      cat "$err" >&2
+      return 1
+    done
+  done
+}
+
+export PG_BINDIR BENCHDIR PGPORT DBNAME INSERT_SQL INSERTS_PER_SESSION MAX_TRIES
+declare -a pids=()
+for s in $(seq 1 "$NUM_SESSIONS"); do
+  ( session_runner "$s"; echo $? > "$BENCHDIR/rc_$s" ) &
+  pids+=($!)
+done
+for pid in "${pids[@]}"; do wait "$pid" || true; done
+
+failed=0
+for s in $(seq 1 "$NUM_SESSIONS"); do
+  [ "$(cat "$BENCHDIR/rc_$s" 2>/dev/null || echo 1)" = "0" ] || failed=$((failed + 1))
+done
+
+USER_ROWS=$($PSQL -At -c "SELECT count(*) FROM bench_concurrent_di;")
+STORAGE_ROWS=$($PSQL -At -c "SELECT rows FROM storage_check();")
+STORAGE_UNIQUE=$($PSQL -At -c "SELECT unique_row_ids FROM storage_check();")
+DI_RETRY=$($PSQL -At -c "SELECT sum(count) FROM ducklake.direct_insert_stats() WHERE reason='retry';")
+
+fail=0
+check() {
+  if [ "$2" = "$3" ]; then printf "%-30s %s == %s  PASS\n" "$1" "$2" "$3"
+  else printf "%-30s %s != %s  FAIL\n" "$1" "$2" "$3"; fail=1; fi
+}
+echo ""
+check "failed sessions"           "$failed"          "0"
+check "user rows"                 "$USER_ROWS"       "$TOTAL_INSERTED"
+check "storage rows"              "$STORAGE_ROWS"    "$TOTAL_INSERTED"
+check "storage unique row_ids"    "$STORAGE_UNIQUE"  "$TOTAL_INSERTED"
+if [ "$NUM_SESSIONS" -gt 1 ]; then
+  check "DI_R_RETRY > 0"          "$([ "$DI_RETRY" -gt 0 ] && echo true || echo false)" "true"
+fi
+echo ""
+echo "DI_R_RETRY: $DI_RETRY"
+
+[ "$fail" -eq 0 ] && echo "OK" || { echo "FAIL"; exit 1; }


### PR DESCRIPTION
## Summary
- Catch `UNIQUE_VIOLATION` on `ducklake_snapshot.snapshot_id` at the direct-insert executor edge and re-raise as `serialization_failure` (`SQLSTATE 40001`) so client/driver retry adapters handle it transparently. Other errors pass through unchanged.
- The row_id race is fixed as a side effect: the autocommit txn rolls back the inlined rows on conflict, so the retried statement re-tags rows in a non-overlapping range. No silent corruption.

## Test plan
- `make installcheck` -- 45 regression + 3 isolation tests pass.
- `make bench-concurrent-direct-insert` -- 8 parallel psql sessions with shell-level 40001 retry; asserts row count, storage `row_id` uniqueness, and that the retry path fired. Wired into CI on every PG version (14-18). A regression that breaks autocommit rollback (silent row_id corruption) would fail CI.

## Out of scope
- Server-side retry via subtransaction. `BeginInternalSubTransaction` around the direct-insert body trips "snapshot reference is not owned by resource owner TopTransaction" on `ReleaseCurrentSubTransaction` (the documented blocker the prior TODO at `pgducklake_direct_insert.cpp:1349` warned about). The 40001 contract is the realistic interim path; the catch site can be turned into a server-side retry loop in place if/when subtxn-direct-insert is solved.