### PR TITLE
fix: stream flush_inlined_data to avoid OOM on large tables

### DIFF
--- a/include/pgducklake/pgducklake_metadata_manager.hpp
+++ b/include/pgducklake/pgducklake_metadata_manager.hpp
@@ -34,6 +34,10 @@ public:
   ReadInlinedData(duckdb::DuckLakeSnapshot snapshot, const duckdb::string &inlined_table_name,
                   const duckdb::vector<duckdb::string> &columns_to_read) override;
 
+  duckdb::unique_ptr<duckdb::QueryResult>
+  ReadAllInlinedDataForFlush(duckdb::DuckLakeSnapshot snapshot, const duckdb::string &inlined_table_name,
+                             const duckdb::vector<duckdb::string> &columns_to_read) override;
+
   static bool IsInitialized();
   bool IsInitialized(duckdb::DuckLakeOptions & /*options*/) override;
   void InitializeDuckLake(bool has_explicit_schema, duckdb::DuckLakeEncryption encryption) override;

--- a/src/pgducklake_metadata_manager.cpp
+++ b/src/pgducklake_metadata_manager.cpp
@@ -437,6 +437,29 @@ ORDER BY row_id;)",
   return transaction.Query(query);
 }
 
+/*
+ * ReadAllInlinedDataForFlush override: same routing as ReadInlinedData -- go
+ * through DuckDB so PostgresTableReader streams in 32-tuple batches instead
+ * of SPI materializing the full result into the PG heap.  The flush query
+ * differs from ReadInlinedData by including deleted rows (no end_snapshot
+ * filter) so deletion vectors can be applied downstream.
+ */
+duckdb::unique_ptr<duckdb::QueryResult>
+PgDuckLakeMetadataManager::ReadAllInlinedDataForFlush(duckdb::DuckLakeSnapshot snapshot,
+                                                      const duckdb::string &inlined_table_name,
+                                                      const duckdb::vector<duckdb::string> &columns_to_read) {
+  auto projection = BuildProjection(columns_to_read);
+  auto query = duckdb::StringUtil::Format(R"(
+SELECT %s
+FROM pgduckdb."%s".%s inlined_data
+WHERE %llu >= begin_snapshot
+ORDER BY row_id;)",
+                                          projection, PGDUCKLAKE_PG_SCHEMA, duckdb::SQLIdentifier(inlined_table_name),
+                                          (unsigned long long)snapshot.snapshot_id);
+  elog(DEBUG1, "ReadAllInlinedDataForFlush via DuckDB: %s", query.c_str());
+  return transaction.Query(query);
+}
+
 duckdb::unique_ptr<duckdb::QueryResult> PgDuckLakeMetadataManager::Query(duckdb::DuckLakeSnapshot snapshot,
                                                                          duckdb::string query) {
   DuckLakeMetadataManager::FillSnapshotArgs(query, snapshot);


### PR DESCRIPTION
## Summary
- `PgDuckLakeMetadataManager` only overrode `ReadInlinedData`; the flush path fell through to the base `DuckLakeMetadataManager::ReadAllInlinedDataForFlush`, which dispatched its `SELECT` via `Query` -> `CreateSPIResult` -> `SPI_execute(query, false, 0)`. With `tcount = 0`, SPI materializes the full result set (e.g. ~19 GB / 66.8M rows in #194) into `SPI_tuptable` in the PG heap before any chunk reaches `COPY_TO_FILE`, blowing past `duckdb.memory_limit` and the cgroup limit.
- This PR adds an override that routes the flush query through DuckDB (`pgduckdb."<schema>".<inlined_table>`), mirroring how `ReadInlinedData` already streams via `PostgresCatalog` / `PostgresTableReader` in 32-tuple batches.
- Flush semantics are preserved: only `WHERE snapshot_id >= begin_snapshot` is filtered (no `end_snapshot` predicate), so deleted rows are still returned and the downstream deletion-vector mapping in `DuckLakeInlinedDataReader` continues to work.

Closes #194.

## Test plan
- [x] `make installcheck` (PG 18) -- 45 regression + 3 isolation tests pass, including `data_inlining_row_limit`, `freeze`, and `maintenance` which exercise `flush_inlined_data()`.
- [ ] CI green on PG 14/15/16/17/18.
- [ ] Manual: re-run the reproduction from the issue (~19 GB inlined table) and confirm `flush_inlined_data()` completes without OOM.