### PR TITLE
perf: stream flush_inlined_data end-to-end (no CDC re-buffer)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; case \"$f\" in *.cpp|*.hpp|*.h) clang-format -i \"$f\" ;; esac; } 2>/dev/null || true",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; case \"$f\" in */third_party/*) ;; *.cpp|*.hpp|*.h) clang-format -i \"$f\" ;; esac; } 2>/dev/null || true",
             "statusMessage": "Formatting C++..."
           }
         ]

--- a/src/pgducklake_metadata_manager.cpp
+++ b/src/pgducklake_metadata_manager.cpp
@@ -21,7 +21,10 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/connection.hpp"
 #include "duckdb/main/materialized_query_result.hpp"
+#include "duckdb/main/pending_query_result.hpp"
+#include "duckdb/main/query_parameters.hpp"
 #include <duckdb/common/string_util.hpp>
 
 #include "common/ducklake_util.hpp"
@@ -438,11 +441,27 @@ ORDER BY row_id;)",
 }
 
 /*
- * ReadAllInlinedDataForFlush override: same routing as ReadInlinedData -- go
- * through DuckDB so PostgresTableReader streams in 32-tuple batches instead
- * of SPI materializing the full result into the PG heap.  The flush query
- * differs from ReadInlinedData by including deleted rows (no end_snapshot
- * filter) so deletion vectors can be applied downstream.
+ * ReadAllInlinedDataForFlush override: route through DuckDB *streaming*. Unlike
+ * the regular read path (ReadInlinedData), flushes can grow to many GB; the
+ * default transaction.Query() materializes the full result into a
+ * MaterializedQueryResult, after which TransformInlinedData re-buffers the
+ * same data into a ColumnDataCollection -- O(table) peak memory, OOM at scale
+ * (issue #194).
+ *
+ * Use Connection::PendingQuery(allow_stream_result) -> Execute() so the call
+ * returns a StreamQueryResult. DuckLakeInlinedDataReader detects the
+ * STREAM_RESULT type, skips TransformInlinedData / CDC entirely, and pulls
+ * chunks one at a time during Scan -- peak memory becomes O(chunk).
+ *
+ * ORDER BY row_id is required for correctness, not just convention: Finalize
+ * issues a separate ROW_NUMBER() OVER (ORDER BY row_id) query to compute each
+ * deleted row's output_position in the freshly-written parquet. If the parquet
+ * rows are written in any other order, the deletion file marks the wrong
+ * positions. Heap scan order on the inlined table does NOT match row_id order
+ * once any DELETE has run, because Postgres' MVCC relocates the
+ * end_snapshot-updated tuples. We pay for the explicit sort, but DuckDB spills
+ * it to duckdb.temporary_directory via BufferManager, so peak resident memory
+ * is bounded by duckdb.memory_limit -- not by the inline-table size.
  */
 duckdb::unique_ptr<duckdb::QueryResult>
 PgDuckLakeMetadataManager::ReadAllInlinedDataForFlush(duckdb::DuckLakeSnapshot snapshot,
@@ -456,8 +475,14 @@ WHERE %llu >= begin_snapshot
 ORDER BY row_id;)",
                                           projection, PGDUCKLAKE_PG_SCHEMA, duckdb::SQLIdentifier(inlined_table_name),
                                           (unsigned long long)snapshot.snapshot_id);
-  elog(DEBUG1, "ReadAllInlinedDataForFlush via DuckDB: %s", query.c_str());
-  return transaction.Query(query);
+  elog(DEBUG1, "ReadAllInlinedDataForFlush via DuckDB stream: %s", query.c_str());
+
+  auto &connection = transaction.GetConnection();
+  auto pending = connection.PendingQuery(query, duckdb::QueryResultOutputType::ALLOW_STREAMING);
+  if (pending->HasError()) {
+    return duckdb::make_uniq<duckdb::MaterializedQueryResult>(pending->GetErrorObject());
+  }
+  return pending->Execute();
 }
 
 duckdb::unique_ptr<duckdb::QueryResult> PgDuckLakeMetadataManager::Query(duckdb::DuckLakeSnapshot snapshot,

--- a/test/regression/expected/data_inlining_row_limit.out
+++ b/test/regression/expected/data_inlining_row_limit.out
@@ -114,3 +114,46 @@ SELECT COUNT(*) AS row_count_after_flush FROM test_inlining;
 
 -- Cleanup
 DROP TABLE test_inlining;
+-- Test 7: flush with prior deletes on an inlined table
+-- Exercises streaming flush + deletion-vector-write path: the inlined source
+-- streams every row (deleted and live), Finalize then writes a delete file
+-- using ROW_NUMBER() OVER (ORDER BY row_id) -- this regression test catches
+-- mismatches between the streamed scan order and the deletion-position math.
+CALL ducklake.set_option('data_inlining_row_limit', 1000);
+CREATE TABLE flush_with_deletes (i INT, j TEXT) USING ducklake;
+INSERT INTO flush_with_deletes
+SELECT g, 'row-' || g FROM generate_series(1, 200) g;
+DELETE FROM flush_with_deletes WHERE i % 7 = 0;
+SELECT count(*) FROM flush_with_deletes;
+ count 
+-------
+   172
+(1 row)
+
+SELECT * FROM ducklake.flush_inlined_data('flush_with_deletes'::regclass);
+ schema_name |     table_name     | rows_flushed 
+-------------+--------------------+--------------
+ public      | flush_with_deletes |          200
+(1 row)
+
+SELECT count(*) FROM flush_with_deletes;
+ count 
+-------
+   172
+(1 row)
+
+SELECT min(i), max(i), sum(i) FROM flush_with_deletes;
+ min | max |  sum  
+-----+-----+-------
+   1 | 200 | 17258
+(1 row)
+
+SELECT * FROM flush_with_deletes WHERE i BETWEEN 13 AND 15 ORDER BY i;
+ i  |   j    
+----+--------
+ 13 | row-13
+ 15 | row-15
+(2 rows)
+
+DROP TABLE flush_with_deletes;
+CALL ducklake.set_option('data_inlining_row_limit', 0);

--- a/test/regression/sql/data_inlining_row_limit.sql
+++ b/test/regression/sql/data_inlining_row_limit.sql
@@ -66,3 +66,21 @@ SELECT COUNT(*) AS row_count_after_flush FROM test_inlining;
 
 -- Cleanup
 DROP TABLE test_inlining;
+
+-- Test 7: flush with prior deletes on an inlined table
+-- Exercises streaming flush + deletion-vector-write path: the inlined source
+-- streams every row (deleted and live), Finalize then writes a delete file
+-- using ROW_NUMBER() OVER (ORDER BY row_id) -- this regression test catches
+-- mismatches between the streamed scan order and the deletion-position math.
+CALL ducklake.set_option('data_inlining_row_limit', 1000);
+CREATE TABLE flush_with_deletes (i INT, j TEXT) USING ducklake;
+INSERT INTO flush_with_deletes
+SELECT g, 'row-' || g FROM generate_series(1, 200) g;
+DELETE FROM flush_with_deletes WHERE i % 7 = 0;
+SELECT count(*) FROM flush_with_deletes;
+SELECT * FROM ducklake.flush_inlined_data('flush_with_deletes'::regclass);
+SELECT count(*) FROM flush_with_deletes;
+SELECT min(i), max(i), sum(i) FROM flush_with_deletes;
+SELECT * FROM flush_with_deletes WHERE i BETWEEN 13 AND 15 ORDER BY i;
+DROP TABLE flush_with_deletes;
+CALL ducklake.set_option('data_inlining_row_limit', 0);

--- a/third_party/ducklake/src/include/storage/ducklake_inlined_data_reader.hpp
+++ b/third_party/ducklake/src/include/storage/ducklake_inlined_data_reader.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/multi_file/base_file_reader.hpp"
+#include "duckdb/main/query_result.hpp"
 #include "storage/ducklake_inlined_data.hpp"
 #include "common/ducklake_snapshot.hpp"
 #include "duckdb/execution/expression_executor.hpp"
@@ -52,6 +53,12 @@ private:
 	vector<column_t> scan_column_ids;
 	ColumnDataScanState state;
 	DataChunk scan_chunk;
+	//! Streaming source for SCAN_FOR_FLUSH paths whose metadata manager returns a
+	//! StreamQueryResult. When set, scan pulls chunks from this stream instead of
+	//! draining a ColumnDataCollection -- making peak memory O(chunk).
+	unique_ptr<QueryResult> stream_result;
+	//! Target types for the streaming path (per-chunk casts in Scan match these).
+	vector<LogicalType> stream_expected_types;
 	//! Expression executors for expression_map entries, keyed by column_t (from column_ids)
 	unordered_map<column_t, unique_ptr<ExpressionExecutor>> expression_executors;
 };

--- a/third_party/ducklake/src/storage/ducklake_inlined_data_reader.cpp
+++ b/third_party/ducklake/src/storage/ducklake_inlined_data_reader.cpp
@@ -123,6 +123,36 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 		default:
 			throw InternalException("Unknown DuckLake scan type");
 		}
+
+		// Streaming path: metadata managers may return a StreamQueryResult to avoid
+		// materializing the entire inlined table into a ColumnDataCollection. We
+		// detect this and skip the TransformInlinedData/CDC build entirely; per-chunk
+		// type casts run inside Scan(). Streaming requires no deletion_filter,
+		// because that path scans all rows once to map row_ids to ordinals (a
+		// two-pass operation incompatible with a single-shot stream).
+		if (query_result->type == QueryResultType::STREAM_RESULT) {
+			if (deletion_filter) {
+				throw NotImplementedException(
+				    "DuckLakeInlinedDataReader: deletion_filter is not supported with a streaming inlined data result");
+			}
+			stream_expected_types = expected_types;
+			// Force the scan_chunk path so Scan() routes through the virtual_columns
+			// mapping below (which is the only code path that knows how to consume
+			// scan_chunk into the output chunk).
+			if (virtual_columns.empty()) {
+				for (idx_t i = 0; i < expected_types.size(); i++) {
+					scan_column_ids.push_back(i);
+					virtual_columns.push_back(InlinedVirtualColumn::NONE);
+				}
+			}
+			scan_chunk.Initialize(context, expected_types);
+			stream_result = std::move(query_result);
+			for (auto &entry : expression_map) {
+				expression_executors[entry.first] = make_uniq<ExpressionExecutor>(context, *entry.second);
+			}
+			return true;
+		}
+
 		data = metadata_manager.TransformInlinedData(*query_result, expected_types);
 		if (!virtual_columns.empty()) {
 			auto scan_types = data->data->Types();
@@ -203,9 +233,34 @@ bool DuckLakeInlinedDataReader::TryEvaluateExpression(ClientContext &context, id
 
 AsyncResult DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
                                             LocalTableFunctionState &local_state, DataChunk &chunk) {
-	if (!virtual_columns.empty()) {
+	if (stream_result) {
+		// Streaming inlined data: fetch raw chunks and apply per-column casts to
+		// match expected_types. Mirrors PostgresMetadataManager::TransformInlinedData
+		// but per-chunk -- peak memory is O(chunk) instead of O(table).
+		auto raw_chunk = stream_result->Fetch();
+		if (!raw_chunk || raw_chunk->size() == 0) {
+			return AsyncResult(SourceResultType::FINISHED);
+		}
+		scan_chunk.Reset();
+		scan_chunk.SetCardinality(raw_chunk->size());
+		for (idx_t col_idx = 0; col_idx < raw_chunk->ColumnCount(); col_idx++) {
+			auto &source_vector = raw_chunk->data[col_idx];
+			auto &target_vector = scan_chunk.data[col_idx];
+			if (source_vector.GetType() == target_vector.GetType()) {
+				target_vector.Reference(source_vector);
+			} else if (source_vector.GetType().id() == LogicalTypeId::BLOB &&
+			           target_vector.GetType().id() == LogicalTypeId::VARCHAR) {
+				// Postgres stores VARCHAR as BYTEA in inlined tables -- same binary repr.
+				target_vector.Reinterpret(source_vector);
+			} else {
+				VectorOperations::Cast(context, source_vector, target_vector, raw_chunk->size());
+			}
+		}
+	} else if (!virtual_columns.empty()) {
 		scan_chunk.Reset();
 		data->data->Scan(state, scan_chunk);
+	}
+	if (!virtual_columns.empty()) {
 		idx_t source_idx = 0;
 		for (idx_t c = 0; c < virtual_columns.size(); c++) {
 			switch (virtual_columns[c]) {


### PR DESCRIPTION
## Summary

Follow-up to #195. That PR removed the SPI-side materialization (the SELECT no longer drains the full inlined table into the PG heap), but the DuckDB side still re-buffered every chunk:

- `transaction.Query()` returns a `MaterializedQueryResult`, then
- `DuckLakeMetadataManager::TransformInlinedData` drains the result into a fresh `ColumnDataCollection` that `COPY_TO_FILE` only starts consuming after the CDC is fully built.

So peak memory was still O(table) modulo `BufferManager` spill. This PR makes the flush truly streaming end-to-end.

### Changes

1. **`PgDuckLakeMetadataManager::ReadAllInlinedDataForFlush`** -- switch from `transaction.Query()` to `Connection::PendingQuery(ALLOW_STREAMING) -> Execute()` so the result is a `StreamQueryResult` instead of being materialized.

2. **`DuckLakeInlinedDataReader`** (upstream subtree) -- detect `QueryResultType::STREAM_RESULT` in `TryInitializeScan`; when streaming, skip `TransformInlinedData` / CDC build / `InitializeScan` entirely. In `Scan()`, pull one chunk at a time directly from the stream and apply per-column casts (`BLOB->VARCHAR` reinterpret + general `Cast`) that previously ran inside `TransformInlinedData`. Streaming is rejected if a `deletion_filter` is set, since that path needs a 2-pass scan to map row_ids to ordinals.

3. **`ORDER BY row_id` is kept** in the flush SQL. Without it, parquet rows would come out in PG heap order, which no longer matches `row_id` order once any DELETE has run on the inlined table (PG MVCC relocates the tombstoned tuples). Finalize computes deleted-row `output_position` via `ROW_NUMBER() OVER (ORDER BY row_id)`, so the parquet must be sorted by `row_id` or the deletion file marks the wrong positions. DuckDB's sort spills to `duckdb.temporary_directory` under memory pressure, so peak resident memory is bounded by `duckdb.memory_limit`, not table size.

4. **Regression test** in `data_inlining_row_limit` covering delete-then-flush. This case was uncovered by existing tests and caught the `output_position` correctness bug when `ORDER BY` was first dropped (sum of remaining rows was 17286 vs the expected 17258 -- exactly off by the deleted-row count).

5. **`chore: scope post-edit clang-format hook to project files`** -- aligns the project's PostToolUse Edit hook with the Makefile's `FORMAT_FILES` (`src/` + `include/` only). Without this guard the hook would reformat `third_party/` on edit, which mangles the upstream subtree diffs.

## Test plan
- [x] `make installcheck` (PG 18) -- 45 regression + 3 isolation tests pass, including the new `data_inlining_row_limit` delete-then-flush case.
- [ ] CI green on PG 14/15/16/17/18.
- [ ] Manual: re-run the reproduction from #194 (~19 GB inlined table) and confirm `flush_inlined_data()` completes without OOM and that `duckdb.temporary_directory` shows sort spill activity rather than the backend dying.