### PR TITLE
fix: plan direct insert against MAX inlined schema_version (#197)

### DIFF
--- a/src/pgducklake_metadata_manager.cpp
+++ b/src/pgducklake_metadata_manager.cpp
@@ -649,30 +649,34 @@ TableInliningState GetTableInliningState(Oid table_oid, uint64_t *table_id_out, 
 
   /* Single SPI query that returns all the information we need:
    *   col 0: table_id          -- from ducklake_table
-   *   col 1: inlined schema_version -- from ducklake_inlined_data_tables
+   *   col 1: inlined schema_version -- MAX over ducklake_inlined_data_tables
    *   col 2: data_inlining_row_limit -- from ducklake_metadata (NULL if unset)
-   *   col 3: max per-table schema_version -- from ducklake_schema_versions
    *
-   * Returns 0 rows when the table doesn't exist or has no inlined
-   * data entry.  A NULL in col 2 means the limit was not explicitly
-   * set; a NULL in col 3 means no ALTER has ever been performed on
-   * this table (safe to proceed). */
+   * On a schema-bumping DDL (ADD COLUMN, SET PARTITION KEY, ...)
+   * DuckLake's commit path inserts a new ducklake_inlined_data_tables
+   * row at the new schema_version *and* keeps the old one, then routes
+   * subsequent inlined writes to the latest by selecting the row with
+   * MAX(schema_version) for the table_id (see DuckLakeMetadataManager::
+   * WriteNewInlinedData in third_party/ducklake).  We mirror that here:
+   * always read the row with MAX(schema_version) so we plan against the
+   * inlined heap table DuckLake itself would write to.  An earlier
+   * version also compared this against MAX(ducklake_schema_versions.
+   * schema_version) and rejected with TI_SCHEMA_VERSION_MISMATCH, but
+   * that was stricter than DuckLake's own contract and broke every
+   * direct insert after any schema-bumping ALTER (issue #197). */
   StringInfoData query;
   initStringInfo(&query);
   appendStringInfo(&query,
                    "SELECT dt.table_id, "
-                   "       idt.schema_version, "
+                   "       (SELECT MAX(idt.schema_version) "
+                   "        FROM ducklake.ducklake_inlined_data_tables idt "
+                   "        WHERE idt.table_id = dt.table_id), "
                    "       (SELECT m.value::bigint "
                    "        FROM ducklake.ducklake_metadata m "
                    "        WHERE m.key = 'data_inlining_row_limit' "
-                   "        AND m.scope IS NULL), "
-                   "       (SELECT MAX(sv.schema_version) "
-                   "        FROM ducklake.ducklake_schema_versions sv "
-                   "        WHERE sv.table_id = dt.table_id) "
+                   "        AND m.scope IS NULL) "
                    "FROM ducklake.ducklake_table dt "
                    "JOIN ducklake.ducklake_schema ds ON dt.schema_id = ds.schema_id "
-                   "LEFT JOIN ducklake.ducklake_inlined_data_tables idt "
-                   "  ON idt.table_id = dt.table_id "
                    "WHERE dt.table_name = '%s' "
                    "AND ds.schema_name = '%s' "
                    "AND dt.end_snapshot IS NULL "
@@ -693,7 +697,7 @@ TableInliningState GetTableInliningState(Oid table_oid, uint64_t *table_id_out, 
     }
     uint64_t table_id = DatumGetInt64(table_id_datum);
 
-    /* col 1: inlined schema_version (NULL if no inlined_data_tables row) */
+    /* col 1: MAX inlined schema_version (NULL if no inlined_data_tables row) */
     Datum sv_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 2, &isnull);
     if (isnull) {
       state = TI_NO_INLINED_TABLE;
@@ -708,20 +712,6 @@ TableInliningState GetTableInliningState(Oid table_oid, uint64_t *table_id_out, 
       goto done;
     }
     int64_t row_limit = DatumGetInt64(limit_datum);
-
-    /* col 3: per-table schema version check.
-     * NULL means no ALTER has been performed -- safe to proceed.
-     * Non-NULL must match the inlined table's schema_version.
-     *
-     * Previously this compared against the global schema_version in
-     * ducklake_snapshot, which caused false negatives: a DDL on any
-     * other table would bump the global version and block direct
-     * insert for all unrelated tables. */
-    Datum max_sv_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 4, &isnull);
-    if (!isnull && (uint64_t)DatumGetInt64(max_sv_datum) != schema_version) {
-      state = TI_SCHEMA_VERSION_MISMATCH;
-      goto done;
-    }
 
     *table_id_out = table_id;
     *schema_version_out = schema_version;

--- a/test/regression/expected/alter_partition_inlining.out
+++ b/test/regression/expected/alter_partition_inlining.out
@@ -1,0 +1,188 @@
+-- Regression for GitHub issue #197:
+-- ALTER on a DuckLake table that bumps per-table schema_version
+-- (set_partition, ADD COLUMN, ...) must not permanently block direct
+-- insert into the inlined data table.
+--
+-- Pre-fix: GetTableInliningState() compared idt.schema_version against
+-- MAX(ducklake_schema_versions.schema_version) and rejected with
+-- TI_SCHEMA_VERSION_MISMATCH whenever any schema-bumping DDL ran,
+-- forcing every subsequent INSERT into the slow path.
+--
+-- Post-fix: pg_ducklake aligns with DuckLake's own contract -- the
+-- inlined table's schema_version names the heap table we write to,
+-- regardless of ducklake_schema_versions.  Direct insert keeps working.
+CALL ducklake.set_option('data_inlining_row_limit', 100);
+CREATE OR REPLACE VIEW direct_insert_stats_nonzero AS
+    SELECT pattern, reason, count FROM ducklake.direct_insert_stats()
+    WHERE count > 0 ORDER BY pattern, reason;
+-- ------------------------------------------------------------------
+-- 1. set_partition -- DuckLake bumps per-table schema_version
+-- ------------------------------------------------------------------
+CREATE TABLE api_part (a INT, b INT) USING ducklake;
+INSERT INTO api_part VALUES (1, 1), (2, 2);                  -- seeds inlined table
+-- After seeding: api_part has 2 rows, single inlined heap table holds them.
+SELECT a, b FROM api_part ORDER BY a;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+(2 rows)
+
+SELECT count(*) AS idt_rows
+FROM ducklake.ducklake_inlined_data_tables idt
+JOIN ducklake.ducklake_table dt USING (table_id)
+WHERE dt.table_name = 'api_part' AND dt.end_snapshot IS NULL;
+ idt_rows 
+----------
+        1
+(1 row)
+
+SELECT idt.table_name AS seed_inlined
+FROM ducklake.ducklake_inlined_data_tables idt
+JOIN ducklake.ducklake_table dt USING (table_id)
+WHERE dt.table_name = 'api_part' AND dt.end_snapshot IS NULL
+\gset
+SELECT row_id, a, b FROM ducklake.:"seed_inlined" ORDER BY row_id;
+ row_id | a | b 
+--------+---+---
+      0 | 1 | 1
+      1 | 2 | 2
+(2 rows)
+
+CALL ducklake.set_partition('api_part'::regclass, 'a');      -- bumps schema_version
+SELECT ducklake.reset_direct_insert_stats();
+ reset_direct_insert_stats 
+---------------------------
+ 
+(1 row)
+
+INSERT INTO api_part VALUES (3, 3);
+-- Pre-fix:  unmatched / schema_version_mismatch = 1
+-- Post-fix: matched_values / ok = 1
+SELECT * FROM direct_insert_stats_nonzero;
+    pattern     | reason | count 
+----------------+--------+-------
+ matched_values | ok     |     1
+(1 row)
+
+SELECT a, b FROM api_part ORDER BY a;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+(3 rows)
+
+-- After ALTER + INSERT: two inlined heap tables exist; the new row
+-- landed in the one DuckLake created at the bumped schema_version
+-- while the seed rows stay in the old one.
+SELECT count(*) AS idt_rows
+FROM ducklake.ducklake_inlined_data_tables idt
+JOIN ducklake.ducklake_table dt USING (table_id)
+WHERE dt.table_name = 'api_part' AND dt.end_snapshot IS NULL;
+ idt_rows 
+----------
+        2
+(1 row)
+
+SELECT idt.table_name AS old_inlined
+FROM ducklake.ducklake_inlined_data_tables idt
+JOIN ducklake.ducklake_table dt USING (table_id)
+WHERE dt.table_name = 'api_part' AND dt.end_snapshot IS NULL
+ORDER BY idt.schema_version ASC LIMIT 1
+\gset
+SELECT idt.table_name AS new_inlined
+FROM ducklake.ducklake_inlined_data_tables idt
+JOIN ducklake.ducklake_table dt USING (table_id)
+WHERE dt.table_name = 'api_part' AND dt.end_snapshot IS NULL
+ORDER BY idt.schema_version DESC LIMIT 1
+\gset
+-- Old (seed-sv) heap table: still holds the pre-ALTER rows, no new row here.
+SELECT 'old' AS which, row_id, a, b FROM ducklake.:"old_inlined" ORDER BY row_id;
+ which | row_id | a | b 
+-------+--------+---+---
+ old   |      0 | 1 | 1
+ old   |      1 | 2 | 2
+(2 rows)
+
+-- New (bumped-sv) heap table: receives the post-ALTER row only.
+SELECT 'new' AS which, row_id, a, b FROM ducklake.:"new_inlined" ORDER BY row_id;
+ which | row_id | a | b 
+-------+--------+---+---
+ new   |      2 | 3 | 3
+(1 row)
+
+DROP TABLE api_part;
+-- ------------------------------------------------------------------
+-- 2. set_sort -- DuckLake does NOT bump per-table schema_version,
+--    so direct insert already works pre-fix.  Regression guard only.
+-- ------------------------------------------------------------------
+CREATE TABLE api_sort (a INT, b INT) USING ducklake;
+INSERT INTO api_sort VALUES (1, 1), (2, 2);
+CALL ducklake.set_sort('api_sort'::regclass, 'a ASC');
+SELECT ducklake.reset_direct_insert_stats();
+ reset_direct_insert_stats 
+---------------------------
+ 
+(1 row)
+
+INSERT INTO api_sort VALUES (3, 3);
+-- Both pre-fix and post-fix: matched_values / ok = 1
+SELECT * FROM direct_insert_stats_nonzero;
+    pattern     | reason | count 
+----------------+--------+-------
+ matched_values | ok     |     1
+(1 row)
+
+SELECT a, b FROM api_sort ORDER BY a;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+(3 rows)
+
+DROP TABLE api_sort;
+-- ------------------------------------------------------------------
+-- 3. ADD COLUMN -- bumps schema_version (same trigger as case 1).
+--    direct_insert_stats.sql already asserts the counter; here we
+--    additionally verify the row makes it into the table.
+-- ------------------------------------------------------------------
+CREATE TABLE api_add (a INT, b INT) USING ducklake;
+INSERT INTO api_add VALUES (1, 1), (2, 2);
+ALTER TABLE api_add ADD COLUMN c INT DEFAULT 0;
+SELECT ducklake.reset_direct_insert_stats();
+ reset_direct_insert_stats 
+---------------------------
+ 
+(1 row)
+
+INSERT INTO api_add (a, b, c) VALUES (3, 3, 3);
+-- Pre-fix:  unmatched / schema_version_mismatch = 1
+-- Post-fix: matched_values / ok = 1
+SELECT * FROM direct_insert_stats_nonzero;
+    pattern     | reason | count 
+----------------+--------+-------
+ matched_values | ok     |     1
+(1 row)
+
+SELECT a, b, c FROM api_add ORDER BY a;
+ a | b | c 
+---+---+---
+ 1 | 1 | 0
+ 2 | 2 | 0
+ 3 | 3 | 3
+(3 rows)
+
+DROP TABLE api_add;
+-- ------------------------------------------------------------------
+-- Cleanup
+-- ------------------------------------------------------------------
+DROP VIEW direct_insert_stats_nonzero;
+SELECT ducklake.reset_direct_insert_stats();
+ reset_direct_insert_stats 
+---------------------------
+ 
+(1 row)
+
+CALL ducklake.set_option('data_inlining_row_limit', 0);

--- a/test/regression/expected/direct_insert_stats.out
+++ b/test/regression/expected/direct_insert_stats.out
@@ -124,7 +124,10 @@ SELECT count(*) AS gated_count FROM direct_insert_stats_nonzero;
 (1 row)
 
 -- ------------------------------------------------------------------
--- unmatched / schema_version_mismatch
+-- ALTER that bumps schema_version must NOT trip schema_version_mismatch.
+-- DuckLake creates a new ducklake_inlined_data_tables row at the new
+-- schema_version on commit; we plan against MAX(sv) and stay matched.
+-- (Regression guard for issue #197.)
 -- ------------------------------------------------------------------
 CREATE TABLE dis_sv (i INT) USING ducklake;
 INSERT INTO dis_sv VALUES (0);          -- inlined at sv=N
@@ -137,9 +140,9 @@ SELECT ducklake.reset_direct_insert_stats();
 
 INSERT INTO dis_sv VALUES (1, 'x');
 SELECT * FROM direct_insert_stats_nonzero;
-  pattern  |         reason          | count 
------------+-------------------------+-------
- unmatched | schema_version_mismatch |     1
+    pattern     | reason | count 
+----------------+--------+-------
+ matched_values | ok     |     1
 (1 row)
 
 DROP TABLE dis_sv;

--- a/test/regression/expected/insert_values.out
+++ b/test/regression/expected/insert_values.out
@@ -418,9 +418,11 @@ SELECT id, val FROM iv_target ORDER BY id;
 DROP TABLE iv_other;
 DROP TABLE iv_target;
 -- ============================================================
--- Test 16: DDL on the SAME table must disable direct insert
--- ALTER TABLE on iv_self bumps its per-table schema_version,
--- so EXPLAIN must NOT show the DuckLakeDirectInsert plan.
+-- Test 16: DDL on the SAME table must NOT disable direct insert.
+-- DuckLake creates a new ducklake_inlined_data_tables row at the
+-- bumped schema_version, and pg_ducklake now plans against
+-- MAX(idt.schema_version) (issue #197).  EXPLAIN must still show
+-- the DuckLakeDirectInsert plan after the ALTER.
 -- ============================================================
 CREATE TABLE iv_self (id int, val text) USING ducklake;
 SELECT count(*) FROM ducklake.ensure_inlined_data_table('iv_self'::regclass);
@@ -442,43 +444,18 @@ EXPLAIN INSERT INTO iv_self VALUES (1, 'before');
 INSERT INTO iv_self VALUES (1, 'before');
 -- ALTER the same table
 ALTER TABLE iv_self ADD COLUMN extra int;
--- Direct insert must NOT be used (schema version mismatch)
+-- Direct insert is still used after ALTER (writes go to the new
+-- ducklake_inlined_data_<id>_<new_sv> heap table that DuckLake creates
+-- on the schema bump).
 EXPLAIN INSERT INTO iv_self (id, val, extra) VALUES (2, 'after', 42);
-                         QUERY PLAN                         
-------------------------------------------------------------
- Custom Scan (DuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
-   DuckDB Execution Plan: 
- 
- ┌───────────────────────────┐
- │      DUCKLAKE_INSERT      │
- │    ────────────────────   │
- │    Table Name: iv_self    │
- └─────────────┬─────────────┘
- ┌─────────────┴─────────────┐
- │        COPY_TO_FILE       │
- └─────────────┬─────────────┘
- ┌─────────────┴─────────────┐
- │    DUCKLAKE_INLINE_DATA   │
- └─────────────┬─────────────┘
- ┌─────────────┴─────────────┐
- │         PROJECTION        │
- │    ────────────────────   │
- │             #0            │
- │             #1            │
- │             #2            │
- │                           │
- │           ~1 row          │
- └─────────────┬─────────────┘
- ┌─────────────┴─────────────┐
- │      COLUMN_DATA_SCAN     │
- │    ────────────────────   │
- │           ~1 row          │
- └───────────────────────────┘
- 
- 
-(30 rows)
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Custom Scan (DuckLakeDirectInsert)  (cost=0.00..0.00 rows=0 width=0)
+   Custom Scan: DuckLakeDirectInsert
+   Pattern: VALUES
+   Expected Rows: 1
+(4 rows)
 
--- Data still works via the DuckDB path
 INSERT INTO iv_self (id, val, extra) VALUES (2, 'after', 42);
 SELECT id, val, extra FROM iv_self ORDER BY id;
  id |  val   | extra 

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -20,6 +20,7 @@ test: options
 test: data_inlining_row_limit
 test: direct_insert_stats
 test: inlined_data_schema_change
+test: alter_partition_inlining
 test: types
 test: decimal_precision
 test: variant

--- a/test/regression/sql/alter_partition_inlining.sql
+++ b/test/regression/sql/alter_partition_inlining.sql
@@ -1,0 +1,119 @@
+-- Regression for GitHub issue #197:
+-- ALTER on a DuckLake table that bumps per-table schema_version
+-- (set_partition, ADD COLUMN, ...) must not permanently block direct
+-- insert into the inlined data table.
+--
+-- Pre-fix: GetTableInliningState() compared idt.schema_version against
+-- MAX(ducklake_schema_versions.schema_version) and rejected with
+-- TI_SCHEMA_VERSION_MISMATCH whenever any schema-bumping DDL ran,
+-- forcing every subsequent INSERT into the slow path.
+--
+-- Post-fix: pg_ducklake aligns with DuckLake's own contract -- the
+-- inlined table's schema_version names the heap table we write to,
+-- regardless of ducklake_schema_versions.  Direct insert keeps working.
+
+CALL ducklake.set_option('data_inlining_row_limit', 100);
+
+CREATE OR REPLACE VIEW direct_insert_stats_nonzero AS
+    SELECT pattern, reason, count FROM ducklake.direct_insert_stats()
+    WHERE count > 0 ORDER BY pattern, reason;
+
+-- ------------------------------------------------------------------
+-- 1. set_partition -- DuckLake bumps per-table schema_version
+-- ------------------------------------------------------------------
+CREATE TABLE api_part (a INT, b INT) USING ducklake;
+INSERT INTO api_part VALUES (1, 1), (2, 2);                  -- seeds inlined table
+
+-- After seeding: api_part has 2 rows, single inlined heap table holds them.
+SELECT a, b FROM api_part ORDER BY a;
+SELECT count(*) AS idt_rows
+FROM ducklake.ducklake_inlined_data_tables idt
+JOIN ducklake.ducklake_table dt USING (table_id)
+WHERE dt.table_name = 'api_part' AND dt.end_snapshot IS NULL;
+SELECT idt.table_name AS seed_inlined
+FROM ducklake.ducklake_inlined_data_tables idt
+JOIN ducklake.ducklake_table dt USING (table_id)
+WHERE dt.table_name = 'api_part' AND dt.end_snapshot IS NULL
+\gset
+SELECT row_id, a, b FROM ducklake.:"seed_inlined" ORDER BY row_id;
+
+CALL ducklake.set_partition('api_part'::regclass, 'a');      -- bumps schema_version
+
+SELECT ducklake.reset_direct_insert_stats();
+INSERT INTO api_part VALUES (3, 3);
+
+-- Pre-fix:  unmatched / schema_version_mismatch = 1
+-- Post-fix: matched_values / ok = 1
+SELECT * FROM direct_insert_stats_nonzero;
+SELECT a, b FROM api_part ORDER BY a;
+
+-- After ALTER + INSERT: two inlined heap tables exist; the new row
+-- landed in the one DuckLake created at the bumped schema_version
+-- while the seed rows stay in the old one.
+SELECT count(*) AS idt_rows
+FROM ducklake.ducklake_inlined_data_tables idt
+JOIN ducklake.ducklake_table dt USING (table_id)
+WHERE dt.table_name = 'api_part' AND dt.end_snapshot IS NULL;
+
+SELECT idt.table_name AS old_inlined
+FROM ducklake.ducklake_inlined_data_tables idt
+JOIN ducklake.ducklake_table dt USING (table_id)
+WHERE dt.table_name = 'api_part' AND dt.end_snapshot IS NULL
+ORDER BY idt.schema_version ASC LIMIT 1
+\gset
+SELECT idt.table_name AS new_inlined
+FROM ducklake.ducklake_inlined_data_tables idt
+JOIN ducklake.ducklake_table dt USING (table_id)
+WHERE dt.table_name = 'api_part' AND dt.end_snapshot IS NULL
+ORDER BY idt.schema_version DESC LIMIT 1
+\gset
+
+-- Old (seed-sv) heap table: still holds the pre-ALTER rows, no new row here.
+SELECT 'old' AS which, row_id, a, b FROM ducklake.:"old_inlined" ORDER BY row_id;
+-- New (bumped-sv) heap table: receives the post-ALTER row only.
+SELECT 'new' AS which, row_id, a, b FROM ducklake.:"new_inlined" ORDER BY row_id;
+
+DROP TABLE api_part;
+
+-- ------------------------------------------------------------------
+-- 2. set_sort -- DuckLake does NOT bump per-table schema_version,
+--    so direct insert already works pre-fix.  Regression guard only.
+-- ------------------------------------------------------------------
+CREATE TABLE api_sort (a INT, b INT) USING ducklake;
+INSERT INTO api_sort VALUES (1, 1), (2, 2);
+CALL ducklake.set_sort('api_sort'::regclass, 'a ASC');
+
+SELECT ducklake.reset_direct_insert_stats();
+INSERT INTO api_sort VALUES (3, 3);
+
+-- Both pre-fix and post-fix: matched_values / ok = 1
+SELECT * FROM direct_insert_stats_nonzero;
+SELECT a, b FROM api_sort ORDER BY a;
+
+DROP TABLE api_sort;
+
+-- ------------------------------------------------------------------
+-- 3. ADD COLUMN -- bumps schema_version (same trigger as case 1).
+--    direct_insert_stats.sql already asserts the counter; here we
+--    additionally verify the row makes it into the table.
+-- ------------------------------------------------------------------
+CREATE TABLE api_add (a INT, b INT) USING ducklake;
+INSERT INTO api_add VALUES (1, 1), (2, 2);
+ALTER TABLE api_add ADD COLUMN c INT DEFAULT 0;
+
+SELECT ducklake.reset_direct_insert_stats();
+INSERT INTO api_add (a, b, c) VALUES (3, 3, 3);
+
+-- Pre-fix:  unmatched / schema_version_mismatch = 1
+-- Post-fix: matched_values / ok = 1
+SELECT * FROM direct_insert_stats_nonzero;
+SELECT a, b, c FROM api_add ORDER BY a;
+
+DROP TABLE api_add;
+
+-- ------------------------------------------------------------------
+-- Cleanup
+-- ------------------------------------------------------------------
+DROP VIEW direct_insert_stats_nonzero;
+SELECT ducklake.reset_direct_insert_stats();
+CALL ducklake.set_option('data_inlining_row_limit', 0);

--- a/test/regression/sql/direct_insert_stats.sql
+++ b/test/regression/sql/direct_insert_stats.sql
@@ -76,7 +76,10 @@ DROP TABLE dis_heap;
 SELECT count(*) AS gated_count FROM direct_insert_stats_nonzero;
 
 -- ------------------------------------------------------------------
--- unmatched / schema_version_mismatch
+-- ALTER that bumps schema_version must NOT trip schema_version_mismatch.
+-- DuckLake creates a new ducklake_inlined_data_tables row at the new
+-- schema_version on commit; we plan against MAX(sv) and stay matched.
+-- (Regression guard for issue #197.)
 -- ------------------------------------------------------------------
 CREATE TABLE dis_sv (i INT) USING ducklake;
 INSERT INTO dis_sv VALUES (0);          -- inlined at sv=N

--- a/test/regression/sql/insert_values.sql
+++ b/test/regression/sql/insert_values.sql
@@ -243,9 +243,11 @@ DROP TABLE iv_other;
 DROP TABLE iv_target;
 
 -- ============================================================
--- Test 16: DDL on the SAME table must disable direct insert
--- ALTER TABLE on iv_self bumps its per-table schema_version,
--- so EXPLAIN must NOT show the DuckLakeDirectInsert plan.
+-- Test 16: DDL on the SAME table must NOT disable direct insert.
+-- DuckLake creates a new ducklake_inlined_data_tables row at the
+-- bumped schema_version, and pg_ducklake now plans against
+-- MAX(idt.schema_version) (issue #197).  EXPLAIN must still show
+-- the DuckLakeDirectInsert plan after the ALTER.
 -- ============================================================
 CREATE TABLE iv_self (id int, val text) USING ducklake;
 SELECT count(*) FROM ducklake.ensure_inlined_data_table('iv_self'::regclass);
@@ -257,10 +259,11 @@ INSERT INTO iv_self VALUES (1, 'before');
 -- ALTER the same table
 ALTER TABLE iv_self ADD COLUMN extra int;
 
--- Direct insert must NOT be used (schema version mismatch)
+-- Direct insert is still used after ALTER (writes go to the new
+-- ducklake_inlined_data_<id>_<new_sv> heap table that DuckLake creates
+-- on the schema bump).
 EXPLAIN INSERT INTO iv_self (id, val, extra) VALUES (2, 'after', 42);
 
--- Data still works via the DuckDB path
 INSERT INTO iv_self (id, val, extra) VALUES (2, 'after', 42);
 SELECT id, val, extra FROM iv_self ORDER BY id;
 


### PR DESCRIPTION
## Summary

- Fixes #197. Any schema-bumping ALTER (ADD COLUMN, SET PARTITION KEY, ...) used to permanently push every subsequent direct insert onto the slow path with `unmatched / schema_version_mismatch`.
- `GetTableInliningState()` joined `ducklake_inlined_data_tables` with no `ORDER BY`, picked an arbitrary row, then compared its `schema_version` against `MAX(ducklake_schema_versions.schema_version)`. This was stricter than DuckLake's own contract: standalone DuckLake (`DuckLakeMetadataManager::WriteNewInlinedData`) routes inlined writes to the row with `MAX(schema_version)` for the table_id, ignoring `ducklake_schema_versions`.
- Replace the join with `(SELECT MAX(idt.schema_version) ...)` and drop the comparison. Direct insert now plans against the same heap table DuckLake itself would write to.

## Test plan

- [x] New regression `test/regression/sql/alter_partition_inlining.sql` covers `set_partition`, `set_sort` (no-op for this bug), and `ADD COLUMN DEFAULT`. Pre-fix, two of three cases tripped `schema_version_mismatch`; post-fix all three go through `matched_values`.
- [x] Bonus: the new test exposes (and the fix resolves) a side-effect projection bug where pre-ALTER rows read back as `c=256` instead of the `DEFAULT 0` -- caused by the same arbitrary-row pick.
- [x] `direct_insert_stats.sql` and `insert_values.sql` previously asserted the buggy behavior as the contract; their comments + expected outputs are updated.
- [x] `make check-format`, `make check-regression` (46/46 passing), `make installcheck` including isolation (3/3 passing) on PG 18.

## Notes

- Verified against standalone DuckLake (`/tmp/dl_repro`): after `ALTER TABLE t SET PARTITIONED BY (a)`, `ducklake_inlined_data_tables` holds rows at both old and new `schema_version`; DuckLake writes to the MAX one. We now do the same.
- `TI_SCHEMA_VERSION_MISMATCH` is left in the enum + stats bucket for stability of any dashboards consuming `ducklake.direct_insert_stats()`; it is no longer reachable.