### PR TITLE
feat: accept ducklake.table_path in CREATE TABLE WITH (#191)

### DIFF
--- a/include/pgducklake/pgducklake_create_options.hpp
+++ b/include/pgducklake/pgducklake_create_options.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+/*
+ * pgducklake_create_options.hpp -- WITH (ducklake.*) clause support for
+ * CREATE TABLE ... USING ducklake.
+ *
+ * The ducklake.* namespace is not accepted by stock PG (HEAP_RELOPT_NAMESPACES
+ * only allows "toast"). To support it, the utility hook strips the
+ * ducklake.* entries from the parsetree's options list before the standard
+ * ProcessUtility runs, stashes them in a per-process scratchpad, and the
+ * CREATE TABLE event trigger drains the scratchpad to apply them against
+ * the DuckLake session/catalog.
+ *
+ * v1 options:
+ *   ducklake.table_path -- per-table data path override (set via the
+ *                          ducklake_default_table_path DuckDB session
+ *                          option, which DuckLake's CreateTable reads).
+ *
+ * Per-table options that go through ducklake_set_option (e.g.
+ * data_inlining_row_limit) are intentionally NOT supported here: the
+ * upstream set_option refuses transaction-local table_ids, and inside the
+ * CREATE TABLE event trigger the new table is still transaction-local.
+ * Those options can be set via CALL ducklake.set_option(..., scope) in a
+ * separate statement after CREATE TABLE.
+ */
+
+#include <string>
+
+/* Forward-declare PG types so this header does NOT pull in postgres.h.
+ * Pulling postgres.h here would force every TU that uses this header to
+ * include PG headers before DuckDB headers, which triggers the well-known
+ * FATAL macro collision (PG's elog.h defines FATAL, DuckDB has
+ * ExceptionType::FATAL). */
+struct List;
+
+namespace pgducklake {
+
+struct PendingCreateOptions {
+  bool present = false;
+  bool has_table_path = false;
+  std::string table_path;
+};
+
+/*
+ * Walk a CREATE TABLE options list (DefElem nodes from CreateStmt->options
+ * or CreateTableAsStmt->into->options), validate any defnamespace=="ducklake"
+ * entries against the v1 allow-list, stash them in the per-process scratchpad,
+ * and rewrite *options_ref to the remainder. Returns true if any ducklake.*
+ * option was stripped (caller then forwards to standard_ProcessUtility with
+ * the stripped list). Raises ereport(ERROR) on unknown ducklake.* names or
+ * invalid values.
+ */
+bool StripDucklakeCreateOptions(List **options_ref);
+
+/* Snapshot + clear the scratchpad. Returned struct has present=false if
+ * nothing was stashed. Safe to call multiple times; second call returns the
+ * cleared value. */
+PendingCreateOptions TakePendingCreateOptions();
+
+/* Discard any pending scratchpad entry without applying it. Called from the
+ * hook's error path so a failed CREATE doesn't poison the next one. */
+void ClearPendingCreateOptions();
+
+/* Set ducklake_default_table_path in the DuckDB session to opts.table_path
+ * before issuing the generated CREATE TABLE DDL. No-op when
+ * !opts.has_table_path. */
+void ApplyTablePathBeforeCreate(const PendingCreateOptions &opts);
+
+/* Restore ducklake_default_table_path to the value of the
+ * ducklake.default_table_path PG GUC (empty when the GUC is unset). Always
+ * called after the generated CREATE TABLE DDL when opts.has_table_path so
+ * subsequent CREATE TABLEs in the same session see a clean slate. */
+void RestoreTablePathAfterCreate(const PendingCreateOptions &opts);
+
+} // namespace pgducklake

--- a/src/pgducklake_create_options.cpp
+++ b/src/pgducklake_create_options.cpp
@@ -1,0 +1,132 @@
+/*
+ * pgducklake_create_options.cpp -- Implementation of WITH (ducklake.*)
+ * clause stripping + application for CREATE TABLE ... USING ducklake.
+ *
+ * @scope backend: per-process g_pending scratchpad
+ *
+ * Design rationale: PG core rejects WITH (ns.opt=...) for any namespace
+ * other than "toast" (HEAP_RELOPT_NAMESPACES). The utility hook calls
+ * StripDucklakeCreateOptions() before standard_ProcessUtility runs to
+ * peel the ducklake.* DefElems off the options list and stash them in
+ * g_pending; the create-table event trigger then consumes the stash.
+ */
+
+#include "pgducklake/pgducklake_create_options.hpp"
+
+#include "pgducklake/pgducklake_duckdb_query.hpp"
+
+#include <duckdb/parser/keyword_helper.hpp>
+
+#include <cstring>
+#include <string>
+
+extern "C" {
+#include "postgres.h"
+
+#include "commands/defrem.h"
+#include "nodes/parsenodes.h"
+}
+
+namespace pgducklake {
+
+namespace {
+
+PendingCreateOptions g_pending;
+
+constexpr const char *kNamespace = "ducklake";
+constexpr const char *kTablePath = "table_path";
+
+[[noreturn]] void RejectUnknown(const char *name) {
+  ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                  errmsg("unrecognized ducklake create option \"ducklake.%s\"", name),
+                  errhint("Supported options: ducklake.%s", kTablePath)));
+}
+
+bool IsDucklakeNamespace(const DefElem *def) {
+  return def->defnamespace != NULL && strcmp(def->defnamespace, kNamespace) == 0;
+}
+
+void ParseTablePath(DefElem *def, PendingCreateOptions &out) {
+  if (def->arg == NULL)
+    ereport(ERROR,
+            (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("ducklake.%s requires a string value", kTablePath)));
+  char *val = defGetString(def);
+  if (val == NULL || val[0] == '\0')
+    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("ducklake.%s cannot be empty", kTablePath),
+                    errhint("Omit the option to use the catalog default path.")));
+  out.has_table_path = true;
+  out.table_path = val;
+}
+
+} // namespace
+
+bool StripDucklakeCreateOptions(List **options_ref) {
+  if (options_ref == NULL || *options_ref == NIL)
+    return false;
+
+  List *options = *options_ref;
+  PendingCreateOptions parsed;
+
+  ListCell *lc;
+  foreach (lc, options) {
+    DefElem *def = lfirst_node(DefElem, lc);
+    if (!IsDucklakeNamespace(def))
+      continue;
+
+    if (strcmp(def->defname, kTablePath) == 0) {
+      if (parsed.has_table_path)
+        ereport(ERROR,
+                (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("ducklake.%s specified more than once", kTablePath)));
+      ParseTablePath(def, parsed);
+    } else {
+      RejectUnknown(def->defname);
+    }
+
+    options = foreach_delete_current(options, lc);
+  }
+
+  if (!parsed.has_table_path) {
+    *options_ref = options;
+    return false;
+  }
+
+  parsed.present = true;
+  g_pending = std::move(parsed);
+  *options_ref = options;
+  return true;
+}
+
+PendingCreateOptions TakePendingCreateOptions() {
+  PendingCreateOptions out = std::move(g_pending);
+  g_pending = PendingCreateOptions {};
+  return out;
+}
+
+void ClearPendingCreateOptions() {
+  g_pending = PendingCreateOptions {};
+}
+
+void ApplyTablePathBeforeCreate(const PendingCreateOptions &opts) {
+  if (!opts.has_table_path)
+    return;
+  std::string sql = "SET ducklake_default_table_path = " + duckdb::KeywordHelper::WriteQuoted(opts.table_path);
+  const char *duck_err = nullptr;
+  if (ExecuteDuckDBQuery(sql.c_str(), &duck_err) != 0)
+    ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+                    errmsg("failed to apply ducklake.%s: %s", kTablePath, duck_err ? duck_err : "unknown error")));
+}
+
+void RestoreTablePathAfterCreate(const PendingCreateOptions &opts) {
+  if (!opts.has_table_path)
+    return;
+  // RESET back to DuckDB's default (empty) so the WITH-clause value does not
+  // leak to subsequent CREATE TABLEs in this session. If the user has the PG
+  // GUC set, re-apply it via Sync (which is a no-op when the GUC is empty).
+  const char *duck_err = nullptr;
+  if (ExecuteDuckDBQuery("RESET ducklake_default_table_path", &duck_err) != 0)
+    elog(WARNING, "failed to reset ducklake_default_table_path after CREATE TABLE: %s",
+         duck_err ? duck_err : "unknown error");
+  SyncDefaultTablePathToDuckDB();
+}
+
+} // namespace pgducklake

--- a/src/pgducklake_hooks.cpp
+++ b/src/pgducklake_hooks.cpp
@@ -22,6 +22,7 @@
 #include "pgducklake/pgducklake_hooks.hpp"
 #include "pgducklake/pgducklake_call_handler.hpp"
 #include "pgducklake/pgducklake_copy_from.hpp"
+#include "pgducklake/pgducklake_create_options.hpp"
 #include "pgducklake/pgducklake_defs.hpp"
 #include "pgducklake/pgducklake_direct_insert.hpp"
 #include "pgducklake/pgducklake_duckdb.hpp"
@@ -476,7 +477,54 @@ void DucklakeUtilityHook(PlannedStmt *pstmt, const char *query_string, bool read
 
   bool dropping_extension = IsDropDucklakeExtensionStmt(pstmt);
 
-  prev_process_utility_hook(pstmt, query_string, read_only_tree, context, params, query_env, dest, qc);
+  /* CREATE TABLE ... USING ducklake WITH (ducklake.*) -- strip the
+   * ducklake.* DefElems before standard_ProcessUtility validates the
+   * remaining options. The create-table event trigger drains the stash. */
+  bool stripped_ducklake_options = false;
+  if (IsA(parsetree, CreateStmt) || IsA(parsetree, CreateTableAsStmt)) {
+    List **options_ref = NULL;
+    const char *access_method = NULL;
+    if (IsA(parsetree, CreateStmt)) {
+      CreateStmt *stmt = castNode(CreateStmt, parsetree);
+      access_method = stmt->accessMethod;
+      options_ref = &stmt->options;
+    } else {
+      CreateTableAsStmt *cstmt = castNode(CreateTableAsStmt, parsetree);
+      if (cstmt->into) {
+        access_method = cstmt->into->accessMethod;
+        options_ref = &cstmt->into->options;
+      }
+    }
+
+    if (access_method && strcmp(access_method, "ducklake") == 0 && options_ref && *options_ref != NIL) {
+      /* If the parsetree is shared (read_only_tree), copy pstmt before we
+       * rewrite the options list so we don't poison a cached plan. */
+      if (read_only_tree) {
+        /* Use copyObjectImpl directly: the copyObject macro uses typeof
+         * which expands poorly under our C++ build flags. */
+        pstmt = (PlannedStmt *)copyObjectImpl(pstmt);
+        parsetree = pstmt->utilityStmt;
+        if (IsA(parsetree, CreateStmt))
+          options_ref = &castNode(CreateStmt, parsetree)->options;
+        else
+          options_ref = &castNode(CreateTableAsStmt, parsetree)->into->options;
+        read_only_tree = false;
+      }
+      stripped_ducklake_options = pgducklake::StripDucklakeCreateOptions(options_ref);
+    }
+  }
+
+  PG_TRY();
+  {
+    prev_process_utility_hook(pstmt, query_string, read_only_tree, context, params, query_env, dest, qc);
+  }
+  PG_CATCH();
+  {
+    if (stripped_ducklake_options)
+      pgducklake::ClearPendingCreateOptions();
+    PG_RE_THROW();
+  }
+  PG_END_TRY();
 
   pgducklake::HandleDropSortedIndex(sorted_drops);
 

--- a/src/pgducklake_table.cpp
+++ b/src/pgducklake_table.cpp
@@ -11,6 +11,7 @@
  * PostgreSQL to DuckDB.
  */
 
+#include "pgducklake/pgducklake_create_options.hpp"
 #include "pgducklake/pgducklake_defs.hpp"
 #include "pgducklake/pgducklake_duckdb.hpp"
 #include "pgducklake/pgducklake_duckdb_query.hpp"
@@ -592,9 +593,15 @@ DECLARE_PG_FUNCTION(ducklake_create_table_trigger) {
   AtEOXact_GUC(false, save_nestlevel);
   SPI_finish();
 
+  // Drain the WITH (ducklake.*) scratchpad set by the utility hook. When
+  // empty (no WITH clause), the calls below are no-ops.
+  pgducklake::PendingCreateOptions pending = pgducklake::TakePendingCreateOptions();
+
   // Sync ducklake.default_table_path GUC to DuckDB extension option so
-  // DuckLake's CreateTable uses the custom path for data files.
+  // DuckLake's CreateTable uses the custom path for data files. The WITH
+  // override (if any) is applied after Sync so it takes precedence.
   pgducklake::SyncDefaultTablePathToDuckDB();
+  pgducklake::ApplyTablePathBeforeCreate(pending);
 
   // Generate CREATE TABLE DDL for DuckDB
   std::string create_table_ddl(pgduckdb_get_tabledef(relid));
@@ -607,6 +614,10 @@ DECLARE_PG_FUNCTION(ducklake_create_table_trigger) {
     ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
                     errmsg("failed to create DuckLake table: %s", error_msg ? error_msg : "unknown error")));
   }
+
+  // Restore DuckDB's ducklake_default_table_path to the PG GUC value so the
+  // WITH override does not leak to later CREATE TABLE statements.
+  pgducklake::RestoreTablePathAfterCreate(pending);
 
   // Handle CREATE TABLE AS (CTAS) - populate data via DuckDB
   if (IsA(parsetree, CreateTableAsStmt) && !pgducklake::ctas_skip_data) {

--- a/test/regression/expected/create_with_options.out
+++ b/test/regression/expected/create_with_options.out
@@ -1,0 +1,72 @@
+-- Test CREATE TABLE ... USING ducklake WITH (ducklake.*) options.
+-- Disable data inlining so inserts write parquet files immediately.
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+-- 1. ducklake.table_path basic: data files land at the per-table path.
+CREATE TABLE cwo_t1 (id int, val text) USING ducklake
+  WITH (ducklake.table_path = '/tmp/cwo_t1/');
+INSERT INTO cwo_t1 VALUES (1, 'a'), (2, 'b');
+SELECT * FROM cwo_t1 ORDER BY id;
+ id | val 
+----+-----
+  1 | a
+  2 | b
+(2 rows)
+
+SELECT * FROM duckdb.query($$
+  SELECT bool_and(starts_with(data_file, '/tmp/cwo_t1/')) AS path_ok
+  FROM ducklake_list_files('pgducklake', 'cwo_t1', schema => 'public')
+$$);
+ path_ok 
+---------
+ t
+(1 row)
+
+-- 2. No leak: a table created right after without WITH must NOT land
+--    under /tmp/cwo_t1/.
+CREATE TABLE cwo_t2 (id int) USING ducklake;
+INSERT INTO cwo_t2 VALUES (1);
+SELECT * FROM duckdb.query($$
+  SELECT bool_and(NOT starts_with(data_file, '/tmp/cwo_t1/')) AS no_leak
+  FROM ducklake_list_files('pgducklake', 'cwo_t2', schema => 'public')
+$$);
+ no_leak 
+---------
+ t
+(1 row)
+
+-- 3. CTAS path: WITH on the new table, files land at the requested path.
+CREATE TABLE cwo_ctas USING ducklake
+  WITH (ducklake.table_path = '/tmp/cwo_ctas/')
+  AS SELECT i AS id, ('row_' || i) AS val FROM generate_series(1, 3) t(i);
+SELECT count(*) FROM cwo_ctas;
+ count 
+-------
+     3
+(1 row)
+
+SELECT * FROM duckdb.query($$
+  SELECT bool_and(starts_with(data_file, '/tmp/cwo_ctas/')) AS path_ok
+  FROM ducklake_list_files('pgducklake', 'cwo_ctas', schema => 'public')
+$$);
+ path_ok 
+---------
+ t
+(1 row)
+
+-- 4. Error: unknown ducklake.* option.
+CREATE TABLE cwo_bad_opt (id int) USING ducklake WITH (ducklake.bogus = 'x');
+ERROR:  unrecognized ducklake create option "ducklake.bogus"
+HINT:  Supported options: ducklake.table_path
+-- 5. Error: empty table_path.
+CREATE TABLE cwo_empty (id int) USING ducklake WITH (ducklake.table_path = '');
+ERROR:  ducklake.table_path cannot be empty
+HINT:  Omit the option to use the catalog default path.
+-- 6. Error: duplicate option.
+CREATE TABLE cwo_dup (id int) USING ducklake
+  WITH (ducklake.table_path = '/tmp/a/', ducklake.table_path = '/tmp/b/');
+ERROR:  ducklake.table_path specified more than once
+-- 7. PG core rejects the ducklake.* namespace on non-ducklake tables.
+CREATE TABLE cwo_not_ducklake (id int) WITH (ducklake.table_path = '/tmp/x/');
+ERROR:  unrecognized parameter namespace "ducklake"
+-- Cleanup
+DROP TABLE cwo_t1, cwo_t2, cwo_ctas;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -18,6 +18,7 @@ test: gucs
 test: default_table_path
 test: options
 test: data_inlining_row_limit
+test: create_with_options
 test: direct_insert_stats
 test: inlined_data_schema_change
 test: types

--- a/test/regression/sql/create_with_options.sql
+++ b/test/regression/sql/create_with_options.sql
@@ -1,0 +1,49 @@
+-- Test CREATE TABLE ... USING ducklake WITH (ducklake.*) options.
+
+-- Disable data inlining so inserts write parquet files immediately.
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+
+-- 1. ducklake.table_path basic: data files land at the per-table path.
+CREATE TABLE cwo_t1 (id int, val text) USING ducklake
+  WITH (ducklake.table_path = '/tmp/cwo_t1/');
+INSERT INTO cwo_t1 VALUES (1, 'a'), (2, 'b');
+SELECT * FROM cwo_t1 ORDER BY id;
+SELECT * FROM duckdb.query($$
+  SELECT bool_and(starts_with(data_file, '/tmp/cwo_t1/')) AS path_ok
+  FROM ducklake_list_files('pgducklake', 'cwo_t1', schema => 'public')
+$$);
+
+-- 2. No leak: a table created right after without WITH must NOT land
+--    under /tmp/cwo_t1/.
+CREATE TABLE cwo_t2 (id int) USING ducklake;
+INSERT INTO cwo_t2 VALUES (1);
+SELECT * FROM duckdb.query($$
+  SELECT bool_and(NOT starts_with(data_file, '/tmp/cwo_t1/')) AS no_leak
+  FROM ducklake_list_files('pgducklake', 'cwo_t2', schema => 'public')
+$$);
+
+-- 3. CTAS path: WITH on the new table, files land at the requested path.
+CREATE TABLE cwo_ctas USING ducklake
+  WITH (ducklake.table_path = '/tmp/cwo_ctas/')
+  AS SELECT i AS id, ('row_' || i) AS val FROM generate_series(1, 3) t(i);
+SELECT count(*) FROM cwo_ctas;
+SELECT * FROM duckdb.query($$
+  SELECT bool_and(starts_with(data_file, '/tmp/cwo_ctas/')) AS path_ok
+  FROM ducklake_list_files('pgducklake', 'cwo_ctas', schema => 'public')
+$$);
+
+-- 4. Error: unknown ducklake.* option.
+CREATE TABLE cwo_bad_opt (id int) USING ducklake WITH (ducklake.bogus = 'x');
+
+-- 5. Error: empty table_path.
+CREATE TABLE cwo_empty (id int) USING ducklake WITH (ducklake.table_path = '');
+
+-- 6. Error: duplicate option.
+CREATE TABLE cwo_dup (id int) USING ducklake
+  WITH (ducklake.table_path = '/tmp/a/', ducklake.table_path = '/tmp/b/');
+
+-- 7. PG core rejects the ducklake.* namespace on non-ducklake tables.
+CREATE TABLE cwo_not_ducklake (id int) WITH (ducklake.table_path = '/tmp/x/');
+
+-- Cleanup
+DROP TABLE cwo_t1, cwo_t2, cwo_ctas;


### PR DESCRIPTION
## Summary

- New: `CREATE TABLE ... USING ducklake WITH (ducklake.table_path = '...')` (and the CTAS form) lets users override the per-table data path inline instead of having to `SET ducklake.default_table_path` before every CREATE -- closes the silent-misplacement footgun and lets ORM-emitted CREATE TABLEs land on the right tier.
- Mechanism: PG core rejects the `ducklake.*` reloption namespace (only `toast` is allowed in `HEAP_RELOPT_NAMESPACES`), so the `ProcessUtility_hook` peels `ducklake.*` `DefElem`s out of `CreateStmt` / `CreateTableAsStmt->into` into a per-process scratchpad and forwards the stripped list to `standard_ProcessUtility`. The existing `ducklake_create_table_trigger` drains the scratchpad, sets `ducklake_default_table_path` in DuckDB before the generated DDL, then explicitly RESETs + re-syncs the PG GUC so the WITH value does not leak to later tables in the session. `PG_TRY/PG_CATCH` at the hook site clears the stash on error.
- v1 scope: `ducklake.table_path` only. `data_inlining_row_limit` (and other per-table options that route through `ducklake_set_option(table_name => ...)`) is intentionally deferred -- upstream `set_option` rejects transaction-local table_ids, and the new table is still transaction-local inside the create-table event trigger. Users can still `CALL ducklake.set_option(opt, val, 'schema.table'::regclass)` in a separate statement.

Closes #191.

## Test plan

- New regression test `create_with_options` (added to the schedule): basic per-table path lands files under that path; subsequent CREATE TABLE without WITH does NOT leak to that path; CTAS path; error cases (unknown ducklake.* option, empty path, duplicate option, ducklake.* on a non-ducklake table rejected by PG core).
- Full regression suite (46 tests) + isolation suite (3 tests) pass on PG 18; PG 17 builds clean.
- One scheduling note in the PR: `create_with_options` is placed after `data_inlining_row_limit` in the schedule. Running it earlier exposes a pre-existing latent bug in DuckLake's inlined-row projection -- a plain `CREATE TABLE`/`INSERT`/`DROP` sequence in the same slot reproduces it without any of the new code (inlined rows return `begin_snapshot` in place of the user `i` column once snapshot_id grows past a threshold). Worth a separate issue.