### PR TITLE
feat: cloud storage secret management

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,24 @@ ATTACH 'ducklake:postgres:dbname=postgres host=localhost' AS my_ducklake (METADA
 SELECT * FROM my_ducklake.public.my_table;
 ```
 
-For cloud storage (AWS S3 or Azure Blob Storage), see the [DuckLake connection and secrets guide](https://ducklake.select/docs/stable/duckdb/usage/connecting).
+### Cloud storage credentials
+
+Register an S3 (or GCS/R2/Azure) secret so DuckLake can read and write data files
+on object storage:
+
+```sql
+SELECT ducklake.create_s3_secret(
+    's3', 'AKIA...', 'secret...',
+    region => 'us-east-1', endpoint => 's3.amazonaws.com');
+
+SET ducklake.default_table_path = 's3://my-bucket/prefix/';
+```
+
+Credentials are stored in the PostgreSQL catalog (a `FOREIGN SERVER` + per-user
+`USER MAPPING` on the `ducklake_secret` foreign data wrapper) and applied to
+DuckDB automatically. See [SQL objects -> Secrets](pg_ducklake/docs/sql_objects.md#secrets)
+for the full reference and the raw `CREATE SERVER` / `CREATE USER MAPPING` form,
+or the upstream [DuckLake connection and secrets guide](https://ducklake.select/docs/stable/duckdb/usage/connecting).
 
 ## Quick Start
 

--- a/pg_ducklake/docs/sql_objects.md
+++ b/pg_ducklake/docs/sql_objects.md
@@ -46,8 +46,10 @@ Default operator classes are registered for common types (bool, int2, int4, int8
 | FDW | Handler | Validator |
 |-----|---------|-----------|
 | `ducklake_fdw` | `ducklake._fdw_handler()` | `ducklake._fdw_validator(text[], oid)` |
+| `ducklake_secret` | `ducklake._secret_fdw_handler()` | `ducklake._secret_fdw_validator(text[], oid)` |
 
-See [Foreign Data Wrapper](foreign_data_wrapper.md) for usage guide.
+See [Foreign Data Wrapper](foreign_data_wrapper.md) for usage guide. `ducklake_secret`
+carries cloud-storage credentials (see [Secrets](#secrets) below), not foreign tables.
 
 ## Functions & Procedures
 
@@ -98,6 +100,8 @@ See [Foreign Data Wrapper](foreign_data_wrapper.md) for usage guide.
 | Variant | [`-> / ->> operators`](#variant_operators) | passthrough | - |
 | File Readers | [`ducklake.read_csv(text, ...)`](#read_csv) | passthrough | `(text[], ...)` |
 | | [`ducklake.read_parquet(text, ...)`](#read_parquet) | passthrough | `(text[], ...)` |
+| Secrets | [`ducklake.create_s3_secret(...)`](#create_s3_secret) | native | - |
+| | [`ducklake.create_azure_secret(text, text)`](#create_azure_secret) | native | - |
 | Admin | [`ducklake.query(text)`](#query) | passthrough | - |
 | | [`ducklake.raw_query(text)`](#raw_query) | native | - |
 | | [`ducklake.recycle_ddb()`](#recycle_ddb) | native proc | - |
@@ -553,6 +557,45 @@ Reads one or more Parquet files through DuckDB's Parquet reader. Like
 
 ```sql
 SELECT * FROM ducklake.read_parquet('s3://bucket/prefix/*.parquet');
+```
+
+### <a id="secrets"></a>Secrets (cloud storage credentials)
+
+Credentials for S3/GCS/R2/Azure live in the PostgreSQL catalog as a `FOREIGN
+SERVER` (public options such as `endpoint`/`region`) plus a `USER MAPPING`
+(secret options such as `key_id`/`secret`, hidden from other roles by PostgreSQL
+ACLs) on the `ducklake_secret` FDW. On each DuckDB connection pg_ducklake drops
+and re-emits the matching DuckDB `CREATE SECRET` statements, so credentials are
+per-user, transactional, and survive dump/restore. The `httpfs` extension is
+autoinstalled on first use.
+
+A `USER MAPPING FOR PUBLIC` shares its credentials with every role (standard
+PostgreSQL FDW semantics): each backend loads the mapping for the current user,
+falling back to the `PUBLIC` mapping. Prefer per-user mappings, and do not
+`GRANT USAGE ON FOREIGN DATA WRAPPER ducklake_secret TO PUBLIC` -- creating
+secret servers should stay restricted to trusted roles.
+
+#### <a name="create_s3_secret"></a>`ducklake.create_s3_secret(type text, key_id text, secret text, session_token text DEFAULT '', region text DEFAULT '', url_style text DEFAULT '', provider text DEFAULT '', endpoint text DEFAULT '', scope text DEFAULT '', validation text DEFAULT '', use_ssl text DEFAULT '')` -> `text`
+
+Convenience wrapper for an `s3`, `gcs`, or `r2` secret: creates the SERVER (from
+the non-secret options) and a USER MAPPING for the current user (from `key_id` /
+`secret` / `session_token`), and returns the generated server name. Empty-string
+arguments are omitted. For other secret types or providers, create the SERVER and
+USER MAPPING directly on the `ducklake_secret` FDW.
+
+```sql
+SELECT ducklake.create_s3_secret(
+  's3', 'AKIA...', 'secret...',
+  region => 'us-east-1', endpoint => 's3.amazonaws.com');
+```
+
+#### <a name="create_azure_secret"></a>`ducklake.create_azure_secret(connection_string text, scope text DEFAULT '')` -> `text`
+
+Convenience wrapper for an Azure Blob Storage secret built from a connection
+string; returns the generated server name.
+
+```sql
+SELECT ducklake.create_azure_secret('DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;');
 ```
 
 #### <a name="query"></a>`ducklake.query(query text)` -> `SETOF ducklake.row`

--- a/pg_ducklake/include/pgducklake/create_options.hpp
+++ b/pg_ducklake/include/pgducklake/create_options.hpp
@@ -43,13 +43,17 @@ PendingCreateOptions TakePendingCreateOptions();
 /* Discard any pending scratchpad entry without applying it (hook error path). */
 void ClearPendingCreateOptions();
 
-/* Push opts.table_path into the DuckDB session as ducklake_default_table_path
- * before the generated CREATE TABLE DDL. No-op when !opts.has_table_path. */
-void ApplyTablePathBeforeCreate(const PendingCreateOptions &opts);
-
-/* RESET ducklake_default_table_path after the DDL so the override does not leak
- * to later CREATE TABLEs (RefreshConnectionState re-pushes the GUC next
- * statement). No-op when !opts.has_table_path. */
-void RestoreTablePathAfterCreate(const PendingCreateOptions &opts);
+/* Scoped per-table table_path override around the generated CREATE TABLE DDL:
+ * sets the override on construction and clears it on destruction (so it is
+ * cleared on both the success and exception paths). RefreshConnectionState
+ * applies the override -- which wins over ducklake.default_table_path -- and
+ * self-corrects once it is cleared. No-op when !opts.has_table_path. */
+struct TablePathOverrideGuard {
+	bool active_;
+	explicit TablePathOverrideGuard(const PendingCreateOptions &opts);
+	~TablePathOverrideGuard();
+	TablePathOverrideGuard(const TablePathOverrideGuard &) = delete;
+	TablePathOverrideGuard &operator=(const TablePathOverrideGuard &) = delete;
+};
 
 } // namespace pgducklake

--- a/pg_ducklake/include/pgducklake/duckdb_manager.hpp
+++ b/pg_ducklake/include/pgducklake/duckdb_manager.hpp
@@ -13,13 +13,35 @@ public:
 	static DuckDBManager &Get();
 	static void Reset();
 
+	// Mark cached secrets stale (next GetConnection reloads them). No-op if the
+	// instance is not yet initialized. Called from syscache invalidation.
+	static void InvalidateSecretsIfInitialized();
+
+	// Per-table CREATE ... WITH (ducklake.table_path=...) override. While set, it
+	// takes precedence over the ducklake.default_table_path session GUC in
+	// RefreshConnectionState (which would otherwise re-push the default on the
+	// next GetConnection and clobber the override before the CREATE runs).
+	void SetTablePathOverride(const std::string &path);
+	void ClearTablePathOverride();
+
 protected:
 	void OnPostInit(duckdb::ClientContext &context) override;
-	// Syncs ducklake.default_table_path to DuckDB per GetConnection so a runtime SET
-	// reaches the next CREATE TABLE; OnPostInit runs once per instance and would miss it.
+	// Syncs ducklake.default_table_path and reloads S3/Azure secrets per
+	// GetConnection so a runtime SET / catalog change reaches the next statement;
+	// OnPostInit runs once per instance and would miss it.
 	void RefreshConnectionState(duckdb::ClientContext &context) override;
 
 private:
+	void DropSecrets(duckdb::ClientContext &context);
+	void LoadSecrets(duckdb::ClientContext &context);
+
+	bool secrets_valid_ = false;
+	bool has_table_path_override_ = false;
+	std::string table_path_override_;
+	// Last value pushed to DuckDB's ducklake_default_table_path, so
+	// RefreshConnectionState only issues SET/RESET when it actually changes
+	// (and self-corrects after an override is cleared, even on the error path).
+	std::string last_pushed_table_path_;
 	static duckdb::unique_ptr<DuckDBManager> instance_;
 };
 

--- a/pg_ducklake/include/pgducklake/ducklake_secret.hpp
+++ b/pg_ducklake/include/pgducklake/ducklake_secret.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "pgddb/pg/declarations.hpp"
+
+namespace pgducklake {
+
+// CREATE SECRET statements for every server on the ducklake_secret FDW, applied
+// to each DuckDB connection by DuckDBManager::RefreshConnectionState.
+List *ListCreateSecretQueries();
+
+// Validate a secret defined by a SERVER (type + options) and an optional USER
+// MAPPING by creating it on a throwaway connection; throws a PG error if invalid.
+void ValidateSecret(const char *type, List *server_options, List *mapping_options = nullptr);
+
+// Stash the target server's type/oid from a CREATE/ALTER FOREIGN SERVER or USER
+// MAPPING node so the FDW validator (which only receives options) can reach them.
+// No-op for statements unrelated to the ducklake_secret FDW.
+void CaptureSecretServer(Node *parsetree);
+
+// Register syscache callbacks that invalidate cached secrets on SERVER / USER
+// MAPPING changes.
+void InitSecrets();
+
+} // namespace pgducklake

--- a/pg_ducklake/sql/pg_ducklake--1.0.0.sql
+++ b/pg_ducklake/sql/pg_ducklake--1.0.0.sql
@@ -291,6 +291,48 @@ CREATE FOREIGN DATA WRAPPER ducklake_fdw
     VALIDATOR ducklake._fdw_validator;
 
 -- ============================================================
+-- Secrets (cloud storage credentials)
+-- A FOREIGN SERVER (public options) + USER MAPPING (secret options) on the
+-- ducklake_secret FDW becomes a DuckDB CREATE SECRET on each connection.
+-- ============================================================
+
+CREATE FUNCTION ducklake._secret_fdw_handler()
+    RETURNS fdw_handler
+    AS 'MODULE_PATHNAME', 'ducklake_secret_fdw_handler'
+    LANGUAGE C STRICT;
+
+CREATE FUNCTION ducklake._secret_fdw_validator(text[], oid)
+    RETURNS void
+    AS 'MODULE_PATHNAME', 'ducklake_secret_fdw_validator'
+    LANGUAGE C STRICT PARALLEL SAFE;
+
+CREATE FOREIGN DATA WRAPPER ducklake_secret
+    HANDLER ducklake._secret_fdw_handler
+    VALIDATOR ducklake._secret_fdw_validator;
+
+-- Convenience wrapper: creates the SERVER + USER MAPPING for an s3/gcs/r2 secret
+-- and returns the generated server name.
+CREATE FUNCTION ducklake.create_s3_secret(
+    type          TEXT,
+    key_id        TEXT,
+    secret        TEXT,
+    session_token TEXT DEFAULT '',
+    region        TEXT DEFAULT '',
+    url_style     TEXT DEFAULT '',
+    provider      TEXT DEFAULT '',
+    endpoint      TEXT DEFAULT '',
+    scope         TEXT DEFAULT '',
+    validation    TEXT DEFAULT '',
+    use_ssl       TEXT DEFAULT ''
+)
+RETURNS TEXT
+LANGUAGE C AS 'MODULE_PATHNAME', 'ducklake_create_s3_secret';
+
+CREATE FUNCTION ducklake.create_azure_secret(connection_string TEXT, scope TEXT DEFAULT '')
+RETURNS TEXT
+LANGUAGE C AS 'MODULE_PATHNAME', 'ducklake_create_azure_secret';
+
+-- ============================================================
 -- Functions & Procedures
 -- Kinds: passthrough (routed to DuckDB as-is), rewrite (regclass ->
 -- (schema, table) then routed), duckdb-only (CALL run in DuckDB),

--- a/pg_ducklake/src/create_options.cpp
+++ b/pg_ducklake/src/create_options.cpp
@@ -103,22 +103,14 @@ ClearPendingCreateOptions() {
 	g_pending = PendingCreateOptions {};
 }
 
-void
-ApplyTablePathBeforeCreate(const PendingCreateOptions &opts) {
-	if (!opts.has_table_path)
-		return;
-	// RefreshConnectionState is a no-op when the session GUC is empty (common case),
-	// so this override survives to the CREATE TABLE.
-	DuckDBQueryOrThrow("SET ducklake_default_table_path = " + duckdb::KeywordHelper::WriteQuoted(opts.table_path));
+TablePathOverrideGuard::TablePathOverrideGuard(const PendingCreateOptions &opts) : active_(opts.has_table_path) {
+	if (active_)
+		DuckDBManager::Get().SetTablePathOverride(opts.table_path);
 }
 
-void
-RestoreTablePathAfterCreate(const PendingCreateOptions &opts) {
-	if (!opts.has_table_path)
-		return;
-	// RESET so the WITH value does not leak to later CREATE TABLEs; the session
-	// GUC (if set) is re-pushed by RefreshConnectionState on the next statement.
-	DuckDBQueryOrThrow("RESET ducklake_default_table_path");
+TablePathOverrideGuard::~TablePathOverrideGuard() {
+	if (active_)
+		DuckDBManager::Get().ClearTablePathOverride();
 }
 
 } // namespace pgducklake

--- a/pg_ducklake/src/duckdb_manager.cpp
+++ b/pg_ducklake/src/duckdb_manager.cpp
@@ -1,4 +1,5 @@
 #include "pgducklake/constants.hpp"
+#include "pgducklake/ducklake_secret.hpp"
 #include "pgducklake/duckdb_manager.hpp"
 #include "pgducklake/functions.hpp"
 #include "pgducklake/guc.hpp"
@@ -110,17 +111,75 @@ DuckDBManager::OnPostInit(duckdb::ClientContext &context) {
 
 void
 DuckDBManager::RefreshConnectionState(duckdb::ClientContext &context) {
-	// Push ducklake.default_table_path to DuckDB on every GetConnection so a
-	// runtime SET is observed by the next CREATE TABLE. The (context, query)
-	// overload avoids recursing back into GetConnection.
-	if (default_table_path && default_table_path[0] != '\0') {
+	// Reconcile ducklake_default_table_path on every GetConnection: a per-table
+	// WITH override wins over the ducklake.default_table_path session GUC. Only
+	// issue SET/RESET when the desired value changes, so the common (no path)
+	// case is free and a cleared override self-corrects on the next connection.
+	std::string desired_table_path;
+	if (has_table_path_override_) {
+		desired_table_path = table_path_override_;
+	} else if (default_table_path && default_table_path[0] != '\0') {
+		desired_table_path = default_table_path;
+	}
+	if (desired_table_path != last_pushed_table_path_) {
 		try {
-			DuckDBQueryOrThrow(context, "SET ducklake_default_table_path = " +
-			                                duckdb::KeywordHelper::WriteQuoted(std::string(default_table_path)));
+			if (desired_table_path.empty()) {
+				DuckDBQueryOrThrow(context, "RESET ducklake_default_table_path");
+			} else {
+				DuckDBQueryOrThrow(context, "SET ducklake_default_table_path = " +
+				                                duckdb::KeywordHelper::WriteQuoted(desired_table_path));
+			}
+			last_pushed_table_path_ = desired_table_path;
 		} catch (const std::exception &e) {
-			elog(WARNING, "failed to sync ducklake.default_table_path to DuckDB: %s", DuckDBErrorMessage(e).c_str());
+			elog(WARNING, "failed to sync ducklake table path to DuckDB: %s", DuckDBErrorMessage(e).c_str());
 		}
 	}
+
+	// Re-emit S3/Azure secrets from the catalog when a SERVER/USER MAPPING changed.
+	if (!secrets_valid_) {
+		DropSecrets(context);
+		LoadSecrets(context);
+		secrets_valid_ = true;
+	}
+}
+
+void
+DuckDBManager::LoadSecrets(duckdb::ClientContext &context) {
+	auto queries = InvokeCPPFunc(pgducklake::ListCreateSecretQueries);
+	ListCell *lc;
+	foreach (lc, queries) {
+		QueryOrThrow(context, (const char *)lfirst(lc));
+	}
+}
+
+void
+DuckDBManager::DropSecrets(duckdb::ClientContext &context) {
+	auto secrets = QueryOrThrow(context, "SELECT name FROM duckdb_secrets() WHERE name LIKE 'pgducklake_secret_%';");
+	while (auto chunk = secrets->Fetch()) {
+		for (size_t i = 0, s = chunk->size(); i < s; ++i) {
+			QueryOrThrow(context, duckdb::StringUtil::Format("DROP SECRET %s;", chunk->GetValue(0, i).ToString()));
+		}
+	}
+}
+
+void
+DuckDBManager::InvalidateSecretsIfInitialized() {
+	if (IsInitialized()) {
+		instance_->secrets_valid_ = false;
+	}
+}
+
+void
+DuckDBManager::SetTablePathOverride(const std::string &path) {
+	// Flag only; RefreshConnectionState applies it on the CREATE's GetConnection.
+	has_table_path_override_ = true;
+	table_path_override_ = path;
+}
+
+void
+DuckDBManager::ClearTablePathOverride() {
+	has_table_path_override_ = false;
+	table_path_override_.clear();
 }
 
 } // namespace pgducklake
@@ -153,6 +212,12 @@ DuckDBManager::Reset() {
 	instance_->connection = nullptr;
 	delete instance_->database;
 	instance_->database = nullptr;
+	// The fresh instance has none of the state we cached for the old one; force
+	// RefreshConnectionState to re-push secrets and the table path next time.
+	instance_->secrets_valid_ = false;
+	instance_->last_pushed_table_path_.clear();
+	instance_->has_table_path_override_ = false;
+	instance_->table_path_override_.clear();
 }
 
 static duckdb::Connection *

--- a/pg_ducklake/src/ducklake_fdw.cpp
+++ b/pg_ducklake/src/ducklake_fdw.cpp
@@ -7,6 +7,7 @@
 
 #include "pgducklake/duckdb_manager.hpp"
 #include "pgducklake/ducklake_fdw.hpp"
+#include "pgducklake/ducklake_secret.hpp"
 
 #include "pgddb/pgddb_types.hpp"
 
@@ -503,6 +504,12 @@ DucklakeFdwUtilityHook(PlannedStmt *pstmt, const char *query_string, bool read_o
 				}
 			}
 		}
+	}
+
+	// Stash the target server's type/oid before the DDL runs, so the
+	// ducklake_secret FDW validator can reach them (it only receives options).
+	if (pstmt->utilityStmt) {
+		pgducklake::CaptureSecretServer(pstmt->utilityStmt);
 	}
 
 	prev_fdw_process_utility_hook(pstmt, query_string, read_only_tree, context, params, query_env, dest, qc);

--- a/pg_ducklake/src/ducklake_secret.cpp
+++ b/pg_ducklake/src/ducklake_secret.cpp
@@ -1,0 +1,471 @@
+/*
+ * S3 / Azure / GCS secret management for pg_ducklake.
+ *
+ * Credentials live in the PostgreSQL catalog as a FOREIGN SERVER (public
+ * options, e.g. endpoint/region) plus a USER MAPPING (secret options, hidden
+ * from other roles by PG ACLs) on the dedicated "ducklake_secret" FDW. On each
+ * DuckDB connection, DuckDBManager drops and re-emits matching DuckDB
+ * CREATE SECRET statements. This mirrors pg_duckdb's secret model, kept separate
+ * from the unrelated "ducklake_fdw" (which attaches DuckLake databases).
+ */
+
+#include "pgducklake/ducklake_secret.hpp"
+#include "pgducklake/duckdb_manager.hpp"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "pgddb/pg/functions.hpp"
+#include "pgddb/pgddb_duckdb.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/parser/keyword_helper.hpp"
+
+extern "C" {
+#include "postgres.h"
+
+#include "access/reloptions.h"
+#include "catalog/pg_foreign_data_wrapper.h"
+#include "catalog/pg_foreign_server.h"
+#include "catalog/pg_foreign_table.h"
+#include "catalog/pg_user_mapping.h"
+#include "commands/defrem.h"
+#include "executor/spi.h"
+#include "fmgr.h"
+#include "foreign/fdwapi.h"
+#include "foreign/foreign.h"
+#include "miscadmin.h"
+#include "nodes/parsenodes.h"
+#include "utils/builtins.h"
+#include "utils/inval.h"
+#include "utils/syscache.h"
+
+#include "pgddb/vendor/pg_list.hpp"
+}
+
+#include "pgddb/utility/cpp_wrapper.hpp"
+
+namespace pgducklake {
+
+static const char *const SECRET_FDW_NAME = "ducklake_secret";
+static const char *const SECRET_PREFIX = "pgducklake_secret_";
+
+namespace {
+
+const char *
+FindOption(List *options_list, const char *name) {
+	foreach_node(DefElem, def, options_list) {
+		if (strcmp(def->defname, name) == 0) {
+			return defGetString(def);
+		}
+	}
+	return nullptr;
+}
+
+/*
+ * Modified version of Postgres' GetUserMapping: returns nullptr instead of
+ * throwing when no mapping exists, and optionally fetches the options.
+ */
+UserMapping *
+FindUserMapping(Oid userid, Oid serverid, bool with_options) {
+	HeapTuple tp = SearchSysCache2(USERMAPPINGUSERSERVER, ObjectIdGetDatum(userid), ObjectIdGetDatum(serverid));
+	if (!HeapTupleIsValid(tp)) {
+		/* Not found for the specific user -- try PUBLIC */
+		tp = SearchSysCache2(USERMAPPINGUSERSERVER, ObjectIdGetDatum(InvalidOid), ObjectIdGetDatum(serverid));
+	}
+	if (!HeapTupleIsValid(tp)) {
+		return nullptr;
+	}
+
+	UserMapping *um = (UserMapping *)palloc(sizeof(UserMapping));
+	um->umid = ((Form_pg_user_mapping)GETSTRUCT(tp))->oid;
+	um->userid = userid;
+	um->serverid = serverid;
+	um->options = NIL;
+
+	if (!with_options) {
+		ReleaseSysCache(tp);
+		return um;
+	}
+
+	bool isnull;
+	Datum datum = SysCacheGetAttr(USERMAPPINGUSERSERVER, tp, Anum_pg_user_mapping_umoptions, &isnull);
+	if (!isnull) {
+		um->options = untransformRelOptions(datum);
+	}
+	ReleaseSysCache(tp);
+	return um;
+}
+
+void
+appendOptions(StringInfoData &buf, List *options) {
+	foreach_node(DefElem, def, options) {
+		// Option names went through PG's validation, no need to sanitize.
+		appendStringInfo(&buf, ", %s %s", def->defname, quote_literal_cstr(defGetString(def)));
+	}
+}
+
+char *
+MakeCreateSecretQuery(const char *server_name, const char *type, List *server_options,
+                      List *mapping_options = nullptr) {
+	StringInfoData buf;
+	initStringInfo(&buf);
+	// Quote the secret name as an identifier: server_name comes from the
+	// catalog and may contain arbitrary characters from a quoted CREATE SERVER.
+	auto secret_name = duckdb::KeywordHelper::WriteOptionallyQuoted(std::string(SECRET_PREFIX) + server_name);
+	appendStringInfo(&buf, "CREATE SECRET %s (", secret_name.c_str());
+	appendStringInfo(&buf, "TYPE %s", type);
+	appendOptions(buf, server_options);
+	if (list_length(mapping_options) > 0) {
+		appendOptions(buf, mapping_options);
+	}
+	appendStringInfoString(&buf, ")");
+	return buf.data;
+}
+
+/*
+ * Find a unique server name for a given prefix by appending an incrementing
+ * suffix until an unused name is found.
+ */
+std::string
+FindServerName(const char *server_prefix) {
+	if (get_foreign_server_oid(server_prefix, true) == InvalidOid) {
+		return server_prefix;
+	}
+	uint32_t i = 0;
+	std::ostringstream oss;
+	oss << server_prefix << "_";
+	const auto len = oss.str().length();
+	while (true) {
+		oss.seekp(len);
+		oss << ++i;
+		auto server_name = oss.str();
+		if (get_foreign_server_oid(server_name.c_str(), true) == InvalidOid) {
+			return server_name;
+		}
+	}
+}
+
+std::string
+ReadOptions(FunctionCallInfo fcinfo, int start, const std::vector<std::string> &names) {
+	std::ostringstream oss;
+	int opt_idx = start;
+	for (const auto &name : names) {
+		if (opt_idx >= PG_NARGS()) {
+			break;
+		}
+		auto value = pgddb::pg::GetArgString(fcinfo, opt_idx++);
+		if (value.empty()) {
+			continue;
+		}
+		if (!oss.str().empty()) {
+			oss << ", ";
+		}
+		oss << name << " " << duckdb::KeywordHelper::WriteQuoted(value);
+	}
+	return oss.str();
+}
+
+/*
+ * Create the secret on a throwaway connection and roll back, so the main
+ * connection's transaction state is untouched. Returns an error string (palloc'd)
+ * or nullptr if the secret is valid. Also rejects redact_keys placed on the
+ * SERVER instead of the USER MAPPING (they would be world-readable).
+ */
+const char *
+GetQueryError(const char *query, List *server_options) {
+	auto con = pgducklake::DuckDBManager::Get().CreateConnection();
+
+	auto tx_query = duckdb::StringUtil::Format("BEGIN; %s", query);
+	auto res = con->Query(tx_query);
+	if (res->HasError()) {
+		con->Query("ROLLBACK;");
+		return pstrdup(res->GetErrorObject().RawMessage().c_str());
+	}
+
+	auto &secret_manager = duckdb::SecretManager::Get(*con->context);
+	auto transaction = duckdb::CatalogTransaction::GetSystemCatalogTransaction(*con->context);
+	auto secret_entry = secret_manager.GetSecretByName(transaction, "pgducklake_secret_validation");
+	if (!secret_entry) {
+		return "FATAL: Failed to get secret";
+	} else if (!secret_entry->secret) {
+		return "FATAL: No secret attached to the entry";
+	}
+
+	auto kv_secret = dynamic_cast<const duckdb::KeyValueSecret *>(secret_entry->secret.get());
+	if (!kv_secret) {
+		return "FATAL: Secret is not a duckdb::KeyValueSecret";
+	}
+
+	std::vector<std::string> restricted_options_in_server;
+	for (const auto &k : kv_secret->redact_keys) {
+		if (FindOption(server_options, k.c_str()) != nullptr) {
+			restricted_options_in_server.push_back(k);
+		}
+	}
+	if (restricted_options_in_server.empty()) {
+		return nullptr;
+	}
+
+	std::ostringstream oss;
+	oss << (restricted_options_in_server.size() == 1 ? "Option " : "Options ");
+	for (size_t i = 0; i < restricted_options_in_server.size(); ++i) {
+		oss << "'" << restricted_options_in_server[i] << "'";
+		if (i != restricted_options_in_server.size() - 1) {
+			oss << ", ";
+		}
+	}
+	oss << " cannot be used in the SERVER's OPTIONS, please move it to the USER MAPPING";
+
+	con->Query("ROLLBACK;");
+	return pstrdup(oss.str().c_str());
+}
+
+// Set by the ProcessUtility hook so the FDW validator (which only receives
+// options) can reach the target server's TYPE / oid.
+const char *CurrentSecretServerType = nullptr;
+Oid CurrentSecretServerOid = InvalidOid;
+
+bool
+IsSecretFdwServer(const char *servername) {
+	ForeignServer *server = GetForeignServerByName(servername, true);
+	if (!server) {
+		return false;
+	}
+	Oid fdw_oid = get_foreign_data_wrapper_oid(SECRET_FDW_NAME, true);
+	return fdw_oid != InvalidOid && server->fdwid == fdw_oid;
+}
+
+bool secret_callback_configured = false;
+
+void
+InvalidateSecretsCallback(Datum, int, uint32) {
+	InvokeCPPFunc(pgducklake::DuckDBManager::InvalidateSecretsIfInitialized);
+}
+
+} // namespace
+
+List *
+ListCreateSecretQueries() {
+	MemoryContext entry_ctx = CurrentMemoryContext;
+	SPI_connect();
+
+	auto query = R"(
+		SELECT fs.oid AS server_oid
+		FROM pg_foreign_server fs
+		INNER JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
+		WHERE fdw.fdwname = 'ducklake_secret';
+	)";
+
+	auto ret = SPI_exec(query, 0);
+	if (ret != SPI_OK_SELECT) {
+		elog(ERROR, "Can't list DuckLake secrets: %s", SPI_result_code_string(ret));
+	}
+
+	List *results = NIL;
+	for (uint64_t i = 0; i < SPI_processed; ++i) {
+		HeapTuple tuple = SPI_tuptable->vals[i];
+		bool is_null = false;
+		Datum server_oid_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 1, &is_null);
+		if (is_null) {
+			elog(ERROR, "Expected server oid to be returned, but found NULL");
+		}
+
+		const Oid server_oid = DatumGetObjectId(server_oid_datum);
+		auto user_mapping = FindUserMapping(GetUserId(), server_oid, true);
+		List *user_mapping_options = user_mapping ? user_mapping->options : NIL;
+
+		auto server = GetForeignServer(server_oid);
+
+		// Build under the pre-SPI context so the result survives SPI_finish.
+		MemoryContext spi_mem_ctx = MemoryContextSwitchTo(entry_ctx);
+		auto secret_query =
+		    MakeCreateSecretQuery(server->servername, server->servertype, server->options, user_mapping_options);
+		results = lappend(results, secret_query);
+		MemoryContextSwitchTo(spi_mem_ctx);
+	}
+
+	SPI_finish();
+	return results;
+}
+
+void
+ValidateSecret(const char *type, List *server_options, List *mapping_options) {
+	if (type == nullptr) {
+		elog(ERROR, "Missing required option: 'type'");
+	}
+	auto query = MakeCreateSecretQuery("validation", type, server_options, mapping_options);
+	auto err = InvokeCPPFunc(GetQueryError, query, server_options);
+	if (err != nullptr) {
+		elog(ERROR, "%s", err);
+	}
+}
+
+void
+CaptureSecretServer(Node *parsetree) {
+	CurrentSecretServerType = nullptr;
+	CurrentSecretServerOid = InvalidOid;
+	if (!parsetree) {
+		return;
+	}
+
+	if (IsA(parsetree, CreateForeignServerStmt)) {
+		// The server does not exist yet; read TYPE straight from the statement.
+		auto *stmt = castNode(CreateForeignServerStmt, parsetree);
+		if (strcmp(stmt->fdwname, SECRET_FDW_NAME) != 0 || stmt->servertype == nullptr) {
+			return;
+		}
+		CurrentSecretServerType = pstrdup(stmt->servertype);
+	} else if (IsA(parsetree, AlterForeignServerStmt)) {
+		auto *stmt = castNode(AlterForeignServerStmt, parsetree);
+		if (!IsSecretFdwServer(stmt->servername)) {
+			return;
+		}
+		ForeignServer *server = GetForeignServerByName(stmt->servername, false);
+		if (server->servertype != nullptr) {
+			CurrentSecretServerType = pstrdup(server->servertype);
+		}
+	} else if (IsA(parsetree, CreateUserMappingStmt)) {
+		auto *stmt = castNode(CreateUserMappingStmt, parsetree);
+		if (!IsSecretFdwServer(stmt->servername)) {
+			return;
+		}
+		CurrentSecretServerOid = GetForeignServerByName(stmt->servername, false)->serverid;
+	} else if (IsA(parsetree, AlterUserMappingStmt)) {
+		auto *stmt = castNode(AlterUserMappingStmt, parsetree);
+		if (!IsSecretFdwServer(stmt->servername)) {
+			return;
+		}
+		CurrentSecretServerOid = GetForeignServerByName(stmt->servername, false)->serverid;
+	}
+}
+
+void
+InitSecrets() {
+	if (secret_callback_configured) {
+		return;
+	}
+	secret_callback_configured = true;
+	CacheRegisterSyscacheCallback(USERMAPPINGOID, InvalidateSecretsCallback, (Datum)0);
+	CacheRegisterSyscacheCallback(FOREIGNSERVEROID, InvalidateSecretsCallback, (Datum)0);
+}
+
+} // namespace pgducklake
+
+extern "C" {
+
+DECLARE_PG_FUNCTION(ducklake_secret_fdw_handler) {
+	// Secrets only; no foreign tables are created on this FDW.
+	PG_RETURN_POINTER(nullptr);
+}
+
+DECLARE_PG_FUNCTION(ducklake_secret_fdw_validator) {
+	Oid catalog = PG_GETARG_OID(1);
+	List *options_list = untransformRelOptions(PG_GETARG_DATUM(0));
+
+	if (catalog == ForeignDataWrapperRelationId) {
+		foreach_node(DefElem, def, options_list) {
+			elog(ERROR, "'ducklake_secret' FDW does not take any option, found '%s'", def->defname);
+		}
+		PG_RETURN_VOID();
+	} else if (catalog == ForeignServerRelationId) {
+		auto server_type = pgducklake::CurrentSecretServerType;
+		pgducklake::CurrentSecretServerType = nullptr;
+		pgducklake::ValidateSecret(server_type, options_list);
+		PG_RETURN_VOID();
+	} else if (catalog == UserMappingRelationId) {
+		Oid server_oid = pgducklake::CurrentSecretServerOid;
+		pgducklake::CurrentSecretServerOid = InvalidOid;
+		if (server_oid == InvalidOid) {
+			elog(ERROR, "USER MAPPING on the 'ducklake_secret' FDW could not resolve its server");
+		}
+		auto server = GetForeignServer(server_oid);
+		pgducklake::ValidateSecret(server->servertype, server->options, options_list);
+		PG_RETURN_VOID();
+	}
+
+	elog(ERROR, "'ducklake_secret' FDW only supports SERVER and USER MAPPING objects");
+	PG_RETURN_VOID();
+}
+
+DECLARE_PG_FUNCTION(ducklake_create_s3_secret) {
+	auto type = pgddb::pg::GetArgString(fcinfo, 0);
+	auto lc_type = duckdb::StringUtil::Lower(type);
+	if (lc_type != "r2" && lc_type != "s3" && lc_type != "gcs") {
+		elog(ERROR,
+		     "Invalid type '%s': this helper only supports 's3', 'gcs' or 'r2'. Use a raw CREATE SERVER / CREATE USER "
+		     "MAPPING on the ducklake_secret FDW for advanced secrets.",
+		     type.c_str());
+	}
+
+	auto key = pgddb::pg::GetArgString(fcinfo, 1);
+	auto secret = pgddb::pg::GetArgString(fcinfo, 2);
+	auto session_token = pgddb::pg::GetArgString(fcinfo, 3);
+	auto secret_name = "simple_" + lc_type + "_secret";
+
+	SPI_connect();
+	auto server_name = pgducklake::FindServerName(secret_name.c_str());
+	{
+		std::ostringstream create_server_query;
+		create_server_query << "CREATE SERVER " << server_name << " TYPE '" << type
+		                    << "' FOREIGN DATA WRAPPER ducklake_secret";
+		auto options = pgducklake::ReadOptions(
+		    fcinfo, 4, {"region", "url_style", "provider", "endpoint", "scope", "validation", "use_ssl"});
+		if (!options.empty()) {
+			create_server_query << " OPTIONS (" << options << ")";
+		}
+		auto ret = SPI_exec(create_server_query.str().c_str(), 0);
+		if (ret != SPI_OK_UTILITY) {
+			elog(ERROR, "Could not create '%s' SERVER: %s", type.c_str(), SPI_result_code_string(ret));
+		}
+	}
+	{
+		std::ostringstream create_mapping_query;
+		create_mapping_query << "CREATE USER MAPPING FOR CURRENT_USER SERVER " << server_name << " OPTIONS (KEY_ID "
+		                     << duckdb::KeywordHelper::WriteQuoted(key) << ", SECRET "
+		                     << duckdb::KeywordHelper::WriteQuoted(secret);
+		if (!session_token.empty()) {
+			create_mapping_query << ", session_token " << duckdb::KeywordHelper::WriteQuoted(session_token);
+		}
+		create_mapping_query << ");";
+		auto ret = SPI_exec(create_mapping_query.str().c_str(), 0);
+		if (ret != SPI_OK_UTILITY) {
+			elog(ERROR, "Could not create '%s' USER MAPPING: %s", type.c_str(), SPI_result_code_string(ret));
+		}
+	}
+	SPI_finish();
+
+	PG_RETURN_TEXT_P(cstring_to_text(server_name.c_str()));
+}
+
+DECLARE_PG_FUNCTION(ducklake_create_azure_secret) {
+	auto connection_string = pgddb::pg::GetArgString(fcinfo, 0);
+	SPI_connect();
+	auto server_name = pgducklake::FindServerName("azure_secret");
+	{
+		std::ostringstream create_server_query;
+		create_server_query << "CREATE SERVER " << server_name << " TYPE 'azure' FOREIGN DATA WRAPPER ducklake_secret";
+		auto options = pgducklake::ReadOptions(fcinfo, 1, {"scope"});
+		if (!options.empty()) {
+			create_server_query << " OPTIONS (" << options << ")";
+		}
+		auto ret = SPI_exec(create_server_query.str().c_str(), 0);
+		if (ret != SPI_OK_UTILITY) {
+			elog(ERROR, "Could not create 'azure' SERVER: %s", SPI_result_code_string(ret));
+		}
+	}
+	auto query = "CREATE USER MAPPING FOR CURRENT_USER SERVER " + server_name + " OPTIONS (connection_string " +
+	             duckdb::KeywordHelper::WriteQuoted(connection_string) + ");";
+	auto ret = SPI_exec(query.c_str(), 0);
+	if (ret != SPI_OK_UTILITY) {
+		elog(ERROR, "Could not create 'azure' USER MAPPING: %s", SPI_result_code_string(ret));
+	}
+	SPI_finish();
+
+	PG_RETURN_TEXT_P(cstring_to_text(server_name.c_str()));
+}
+
+} // extern "C"

--- a/pg_ducklake/src/ducklake_table.cpp
+++ b/pg_ducklake/src/ducklake_table.cpp
@@ -511,18 +511,17 @@ DECLARE_PG_FUNCTION(ducklake_create_table_trigger) {
 		                                                        "access method")));
 	}
 
-	// Apply the WITH (ducklake.*) override after GetConnection syncs the session GUC,
-	// so the WITH value wins for this CREATE; empty options make Apply/Restore no-ops.
 	pgducklake::PendingCreateOptions pending = pgducklake::TakePendingCreateOptions();
-	pgducklake::ApplyTablePathBeforeCreate(pending);
+	{
+		// The WITH (ducklake.table_path) override wins for this CREATE; the guard
+		// clears it (on success or error) before the CTAS INSERT runs below.
+		pgducklake::TablePathOverrideGuard table_path_guard(pending);
 
-	std::string create_table_ddl(pgducklake::Ruleutils().get_tabledef(relid));
-	elog(DEBUG1, "Creating DuckLake table: %s", create_table_ddl.c_str());
+		std::string create_table_ddl(pgducklake::Ruleutils().get_tabledef(relid));
+		elog(DEBUG1, "Creating DuckLake table: %s", create_table_ddl.c_str());
 
-	pgducklake::DuckDBQueryOrThrow(create_table_ddl);
-
-	// Restore the session default before the CTAS INSERT so the override does not leak.
-	pgducklake::RestoreTablePathAfterCreate(pending);
+		pgducklake::DuckDBQueryOrThrow(create_table_ddl);
+	}
 
 	if (IsA(parsetree, CreateTableAsStmt) && !pgducklake::ctas_skip_data) {
 		auto ctas_stmt = castNode(CreateTableAsStmt, parsetree);

--- a/pg_ducklake/src/pgducklake.cpp
+++ b/pg_ducklake/src/pgducklake.cpp
@@ -32,6 +32,7 @@ void InitRuleutilsHooks();
 void InitTypeHooks();
 void RegisterXactCallback();
 void InitFDW();
+void InitSecrets();
 
 } // namespace pgducklake
 
@@ -64,6 +65,7 @@ _PG_init(void) {
 	// Mirror PG transaction events to DuckDB's DuckLake transaction.
 	pgducklake::RegisterXactCallback();
 	pgducklake::InitFDW();
+	pgducklake::InitSecrets();
 }
 
 /*

--- a/pg_ducklake/test/e2e/conftest.py
+++ b/pg_ducklake/test/e2e/conftest.py
@@ -414,8 +414,75 @@ def s3(minio_server, request):
         pass  # best-effort; the container is removed at session end anyway
 
 
+@pytest.fixture
+def s3_second_bucket(minio_server, request):
+    """A second bucket on the same MinIO -- one endpoint secret covers both."""
+    if minio_server is None:
+        skip_or_fail(getattr(request.session, "minio_skip_reason", "no S3 server"))
+
+    from minio import Minio
+
+    client = Minio(
+        minio_server.endpoint,
+        access_key=minio_server.access_key,
+        secret_key=minio_server.secret_key,
+        secure=False,
+    )
+    bucket = f"e2e-alt-{uuid.uuid4().hex[:12]}"
+    client.make_bucket(bucket)
+    ctx = S3(server=minio_server, bucket=bucket, client=client)
+    yield ctx
+    try:
+        for name in ctx.object_names():
+            client.remove_object(bucket, name)
+        client.remove_bucket(bucket)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def s3_wrong_creds(minio_server, request):
+    """The right endpoint with a bad secret key: CREATE SECRET still succeeds
+    (shape-only validation) but S3 access fails."""
+    if minio_server is None:
+        skip_or_fail(getattr(request.session, "minio_skip_reason", "no S3 server"))
+    from dataclasses import replace
+
+    return replace(minio_server, secret_key="wrong-secret-key")
+
+
 # ---------------------------------------------------------------------------
 # Lake: one pg_ducklake database plus its storage backend
+
+
+async def set_inlining(conn, row_limit):
+    """Set DuckLake's data_inlining_row_limit on an existing connection. An
+    INSERT/DELETE of at most row_limit rows is stored inline in the PG metadata
+    catalog; larger changes (or row_limit=0) are written as Parquet/delete files.
+    Takes effect for the file direction without a recycle; enabling inline reads
+    on a table requires the table to have been created while inlining was on."""
+    await conn.execute(
+        f"CALL ducklake.set_option('data_inlining_row_limit', {int(row_limit)})"
+    )
+
+
+async def active_file_counts(conn, table_name):
+    """(active data-file count, active delete-file count) for a ducklake table,
+    read straight from the DuckLake metadata catalog. Inline-resident rows have
+    no data/delete file, so these counts confirm which storage path was used."""
+    row = await conn.fetchrow(
+        """
+        SELECT
+          (SELECT count(*) FROM ducklake.ducklake_data_file df
+             WHERE df.table_id = t.table_id AND df.end_snapshot IS NULL) AS data_files,
+          (SELECT count(*) FROM ducklake.ducklake_delete_file xf
+             WHERE xf.table_id = t.table_id AND xf.end_snapshot IS NULL) AS delete_files
+        FROM ducklake.ducklake_table t
+        WHERE t.table_name = $1 AND t.end_snapshot IS NULL
+        """,
+        table_name,
+    )
+    return row["data_files"], row["delete_files"]
 
 
 class Lake:
@@ -433,17 +500,30 @@ class Lake:
         assert self.s3
         return f"s3://{self.s3.bucket}/lake/"
 
-    async def connect(self, configure=True, **kwargs):
+    async def connect(self, configure=True, user="postgres", inlining=None, **kwargs):
+        """Open an asyncpg connection to this lake's database.
+
+        user:     role to connect as (the throwaway cluster trusts local logins).
+        inlining: when not None, enable DuckLake data inlining at this row limit
+                  and recycle the DuckDB instance, so tables CREATED afterwards
+                  read inlined rows back (the recycle-before-create ordering is
+                  load-bearing). Toggle per-statement later with set_inlining().
+        """
         kwargs.setdefault("password", os.environ.get("PGPASSWORD"))
         conn = await asyncpg.connect(
             host=self.cluster.host,
             port=self.cluster.port,
-            user="postgres",
+            user=user,
             database=self.dbname,
             **kwargs,
         )
         if configure and self.s3:
             await self.configure_s3(conn)
+        if inlining is not None:
+            await set_inlining(conn, inlining)
+            await conn.execute("CALL ducklake.recycle_ddb()")
+            if configure and self.s3:
+                await self.configure_s3(conn)  # recycle dropped the secret
         return conn
 
     async def configure_s3(self, conn):
@@ -535,3 +615,13 @@ async def conn(lake):
         yield c
     finally:
         await c.close()
+
+
+@pytest.fixture(params=["local", "s3"])
+def inlining_lake(request, cluster, db):
+    """Like `lake` but for data-inlining tests: it does NOT force inlining off
+    and has no bucket canary, so a test may legitimately keep data inline (in the
+    PG catalog) and never touch S3. Enable inlining per connection with
+    Lake.connect(inlining=...) and toggle per-statement with set_inlining()."""
+    s3ctx = request.getfixturevalue("s3") if request.param == "s3" else None
+    return Lake(cluster, db, s3ctx)

--- a/pg_ducklake/test/e2e/test_inlining.py
+++ b/pg_ducklake/test/e2e/test_inlining.py
@@ -1,0 +1,58 @@
+# Data-inlining matrix: DuckLake can store an INSERT or a DELETE either inline
+# (in the PostgreSQL metadata catalog) or as Parquet data / delete files,
+# governed by data_inlining_row_limit. The four insert x delete combinations --
+# including the cross cases (file rows removed by an inline delete, inline rows
+# removed by a file delete) -- must all read back correctly and survive a fresh
+# DuckDB instance (data lives in the PG catalog + storage, not in the instance).
+
+import pytest
+
+from conftest import active_file_counts, set_inlining
+
+# A small change (<= this many rows) is inlined; 0 forces Parquet/delete files.
+INLINE_LIMIT = 1000
+
+
+def _limit(mode):
+    return INLINE_LIMIT if mode == "inline" else 0
+
+
+@pytest.mark.parametrize("delete_mode", ["inline", "file"])
+@pytest.mark.parametrize("insert_mode", ["inline", "file"])
+async def test_insert_delete_inline_file_matrix(inlining_lake, insert_mode, delete_mode):
+    # Create the table while inlining is enabled so inline rows read back; then
+    # pick the storage path for the INSERT and the DELETE independently.
+    conn = await inlining_lake.connect(inlining=INLINE_LIMIT)
+    try:
+        await conn.execute("CREATE TABLE t (id int, v text) USING ducklake")
+
+        await set_inlining(conn, _limit(insert_mode))
+        await conn.execute("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')")
+
+        await set_inlining(conn, _limit(delete_mode))
+        await conn.execute("DELETE FROM t WHERE id IN (2, 4)")
+
+        expected = [(1, "a"), (3, "c")]
+        rows = await conn.fetch("SELECT id, v FROM t ORDER BY id")
+        assert [tuple(r) for r in rows] == expected
+        assert await conn.fetchval("SELECT count(*) FROM t") == 2
+
+        # Confirm the storage path actually taken. A file insert writes one data
+        # file; an inline insert writes none. A file delete writes a delete file
+        # only when there is a data file to attach it to -- deleting inline rows
+        # (inline insert) or recording the delete inline (inline delete) leaves
+        # no delete file.
+        data_files, delete_files = await active_file_counts(conn, "t")
+        assert data_files == (1 if insert_mode == "file" else 0)
+        assert delete_files == (1 if insert_mode == "file" and delete_mode == "file" else 0)
+
+        # Durability: a brand-new DuckDB instance must reconstruct the same view
+        # from the catalog + storage (inline rows, parquet, and any delete file).
+        await set_inlining(conn, INLINE_LIMIT)
+        await conn.execute("CALL ducklake.recycle_ddb()")
+        if inlining_lake.s3:
+            await inlining_lake.configure_s3(conn)  # recycle dropped the secret
+        rows2 = await conn.fetch("SELECT id, v FROM t ORDER BY id")
+        assert [tuple(r) for r in rows2] == expected
+    finally:
+        await conn.close()

--- a/pg_ducklake/test/e2e/test_s3.py
+++ b/pg_ducklake/test/e2e/test_s3.py
@@ -2,10 +2,12 @@
 # ducklake.default_table_path plus a DuckDB S3 secret. Skips without S3 infra
 # (unless E2E_REQUIRE_S3=1); storage-agnostic behavior lives in test_crud.py.
 
+import os
+
 import asyncpg
 import pytest
 
-from conftest import Lake
+from conftest import Lake, skip_or_fail
 
 
 @pytest.fixture
@@ -24,6 +26,15 @@ async def s3conn(s3lake):
         yield c
     finally:
         await c.close()
+
+
+async def _load_httpfs(conn):
+    # httpfs is not bundled; INSTALL downloads it on first use. Skip offline.
+    try:
+        await conn.execute("SELECT ducklake.raw_query('INSTALL httpfs')")
+    except asyncpg.PostgresError as e:
+        skip_or_fail(f"backend cannot INSTALL httpfs (offline?): {e}")
+    await conn.execute("SELECT ducklake.raw_query('LOAD httpfs')")
 
 
 async def test_parquet_objects_land_in_bucket(s3lake, s3conn, s3):
@@ -132,6 +143,294 @@ async def test_time_travel_on_s3(s3conn):
         )
         == 1
     )
+
+
+async def test_create_s3_secret_round_trip(s3lake, s3):
+    # Provision the S3 secret via the ducklake.create_s3_secret() wrapper
+    # (a FOREIGN SERVER + USER MAPPING on the ducklake_secret FDW) instead of a
+    # raw CREATE SECRET, then round-trip a table whose data lives in the bucket.
+    conn = await s3lake.connect(configure=False)
+    try:
+        # httpfs is not bundled; install it explicitly to avoid offline flakiness
+        try:
+            await conn.execute("SELECT ducklake.raw_query('INSTALL httpfs')")
+        except asyncpg.PostgresError as e:
+            skip_or_fail(f"backend cannot INSTALL httpfs (offline?): {e}")
+        await conn.execute("SELECT ducklake.raw_query('LOAD httpfs')")
+
+        srv = s3lake.s3.server
+        server_name = await conn.fetchval(
+            "SELECT ducklake.create_s3_secret('s3', $1, $2, "
+            "endpoint => $3, url_style => 'path', use_ssl => 'false')",
+            srv.access_key,
+            srv.secret_key,
+            srv.endpoint,
+        )
+        assert server_name == "simple_s3_secret"
+
+        await conn.execute(
+            f"SET ducklake.default_table_path = '{s3lake.table_path}'"
+        )
+        # disable inlining so the INSERT writes parquet to the bucket immediately
+        await conn.execute("CALL ducklake.set_option('data_inlining_row_limit', 0)")
+        await conn.execute("CREATE TABLE t (id int, name text) USING ducklake")
+        await conn.execute("INSERT INTO t VALUES (1, 'alice'), (2, 'bob')")
+
+        assert any(name.endswith(".parquet") for name in s3.object_names())
+        rows = await conn.fetch("SELECT id, name FROM t ORDER BY id")
+        assert [tuple(r) for r in rows] == [(1, "alice"), (2, "bob")]
+    finally:
+        await conn.close()
+
+
+async def test_create_s3_secret_named_args(s3lake, s3):
+    # create_s3_secret accepts named-arg notation for the optional params and
+    # still round-trips (complements the positional-arg test above).
+    conn = await s3lake.connect(configure=False)
+    try:
+        await _load_httpfs(conn)
+        srv = s3lake.s3.server
+        name = await conn.fetchval(
+            "SELECT ducklake.create_s3_secret(type => 's3', key_id => $1, "
+            "secret => $2, endpoint => $3, url_style => 'path', "
+            "use_ssl => 'false', region => 'us-east-1')",
+            srv.access_key,
+            srv.secret_key,
+            srv.endpoint,
+        )
+        assert name == "simple_s3_secret"
+        await conn.execute(
+            f"SET ducklake.default_table_path = '{s3lake.table_path}'"
+        )
+        await conn.execute("CALL ducklake.set_option('data_inlining_row_limit', 0)")
+        await conn.execute("CREATE TABLE t (id int) USING ducklake")
+        await conn.execute("INSERT INTO t VALUES (1), (2)")
+        assert await conn.fetchval("SELECT count(*) FROM t") == 2
+    finally:
+        await conn.close()
+
+
+async def test_two_s3_secrets_get_unique_names(s3lake):
+    # FindServerName: two create_s3_secret calls of the same type yield distinct
+    # server names rather than colliding.
+    conn = await s3lake.connect(configure=False)
+    try:
+        await _load_httpfs(conn)
+        srv = s3lake.s3.server
+
+        async def mk():
+            return await conn.fetchval(
+                "SELECT ducklake.create_s3_secret('s3', $1, $2, endpoint => $3, "
+                "url_style => 'path', use_ssl => 'false')",
+                srv.access_key,
+                srv.secret_key,
+                srv.endpoint,
+            )
+
+        assert await mk() == "simple_s3_secret"
+        assert await mk() == "simple_s3_secret_1"
+    finally:
+        await conn.close()
+
+
+async def test_drop_server_removes_secret(s3lake):
+    # DROP SERVER invalidates the cached secrets; the next statement's
+    # GetConnection drops the DuckDB secret, so s3 reads then fail.
+    conn = await s3lake.connect(configure=False)
+    try:
+        await _load_httpfs(conn)
+        srv = s3lake.s3.server
+        await conn.fetchval(
+            "SELECT ducklake.create_s3_secret('s3', $1, $2, endpoint => $3, "
+            "url_style => 'path', use_ssl => 'false')",
+            srv.access_key,
+            srv.secret_key,
+            srv.endpoint,
+        )
+        await conn.execute(
+            f"SET ducklake.default_table_path = '{s3lake.table_path}'"
+        )
+        await conn.execute("CALL ducklake.set_option('data_inlining_row_limit', 0)")
+        await conn.execute("CREATE TABLE t (id int) USING ducklake")
+        await conn.execute("INSERT INTO t VALUES (1)")
+        assert await conn.fetchval("SELECT count(*) FROM t") == 1
+
+        await conn.execute("DROP SERVER simple_s3_secret CASCADE")
+        with pytest.raises(asyncpg.PostgresError, match=s3lake.s3.bucket):
+            await conn.fetch("SELECT * FROM t")
+    finally:
+        await conn.close()
+
+
+async def test_helper_secret_reloads_after_recycle(s3lake):
+    # The PG-catalog SERVER+MAPPING persist across ducklake.recycle_ddb(); the
+    # fresh DuckDB instance must reload the secret on the next GetConnection
+    # (regression for DuckDBManager::Reset not clearing secrets_valid_).
+    conn = await s3lake.connect(configure=False)
+    try:
+        await _load_httpfs(conn)
+        srv = s3lake.s3.server
+        await conn.fetchval(
+            "SELECT ducklake.create_s3_secret('s3', $1, $2, endpoint => $3, "
+            "url_style => 'path', use_ssl => 'false')",
+            srv.access_key,
+            srv.secret_key,
+            srv.endpoint,
+        )
+        await conn.execute(
+            f"SET ducklake.default_table_path = '{s3lake.table_path}'"
+        )
+        await conn.execute("CALL ducklake.set_option('data_inlining_row_limit', 0)")
+        await conn.execute("CREATE TABLE t (id int) USING ducklake")
+        await conn.execute("INSERT INTO t VALUES (1), (2)")
+
+        await conn.execute("CALL ducklake.recycle_ddb()")
+        # No re-configuration: the secret must be re-emitted from the catalog.
+        assert await conn.fetchval("SELECT count(*) FROM t") == 2
+    finally:
+        await conn.close()
+
+
+async def test_redact_key_on_server_rejected(s3lake):
+    # A secret option (redact_key) placed on the SERVER instead of the USER
+    # MAPPING is rejected, and the secret VALUE never appears in the error.
+    conn = await s3lake.connect(configure=False)
+    try:
+        await _load_httpfs(conn)
+        with pytest.raises(asyncpg.PostgresError) as ei:
+            await conn.execute(
+                "CREATE SERVER leak_srv TYPE 's3' FOREIGN DATA WRAPPER ducklake_secret "
+                "OPTIONS (secret 'TOPSECRETVALUE')"
+            )
+        msg = str(ei.value)
+        assert "USER MAPPING" in msg
+        assert "TOPSECRETVALUE" not in msg
+    finally:
+        await conn.close()
+
+
+async def test_table_path_option_writes_to_s3_prefix(s3conn, s3):
+    # CREATE TABLE ... WITH (ducklake.table_path = 's3://...') overrides
+    # default_table_path per table; data files land under that prefix.
+    prefix = f"s3://{s3.bucket}/custom_tp/"
+    await s3conn.execute(
+        f"CREATE TABLE tp (id int, v text) USING ducklake "
+        f"WITH (ducklake.table_path = '{prefix}')"
+    )
+    await s3conn.execute("INSERT INTO tp VALUES (1, 'a'), (2, 'b')")
+
+    objs = s3.object_names()
+    assert any(n.startswith("custom_tp/") and n.endswith(".parquet") for n in objs), objs
+    # and nothing leaked under the default lake/ prefix for this table
+    rows = await s3conn.fetch("SELECT id, v FROM tp ORDER BY id")
+    assert [tuple(r) for r in rows] == [(1, "a"), (2, "b")]
+
+
+@pytest.mark.skipif(
+    bool(os.environ.get("E2E_PG_HOST")),
+    reason="local table path needs the PG backend on the test host",
+)
+async def test_local_and_s3_tables_in_one_catalog(s3conn, s3, tmp_path):
+    # One catalog, mixed storage: a table pinned to a local path and a table
+    # routed to the bucket by default_table_path, both readable.
+    local_dir = tmp_path / "local_lake"
+    local_dir.mkdir(parents=True, exist_ok=True)
+    await s3conn.execute(
+        f"CREATE TABLE loc (id int) USING ducklake "
+        f"WITH (ducklake.table_path = '{local_dir}/')"
+    )
+    await s3conn.execute("INSERT INTO loc VALUES (1), (2)")
+    await s3conn.execute("CREATE TABLE rem (id int) USING ducklake")  # -> bucket
+    await s3conn.execute("INSERT INTO rem VALUES (10), (20)")
+
+    assert any(local_dir.rglob("*.parquet")), f"no local parquet under {local_dir}"
+    assert any(n.endswith(".parquet") for n in s3.object_names())
+    assert await s3conn.fetchval("SELECT count(*) FROM loc") == 2
+    assert await s3conn.fetchval("SELECT count(*) FROM rem") == 2
+
+
+async def test_two_buckets_one_secret(s3conn, s3, s3_second_bucket):
+    # A single endpoint secret covers every bucket on that MinIO; a per-table
+    # path can route to a different bucket than default_table_path.
+    await s3conn.execute("CREATE TABLE raw (id int) USING ducklake")  # default bucket
+    await s3conn.execute("INSERT INTO raw VALUES (1), (2)")
+
+    b2 = f"s3://{s3_second_bucket.bucket}/curated/"
+    await s3conn.execute(
+        f"CREATE TABLE curated (id int) USING ducklake "
+        f"WITH (ducklake.table_path = '{b2}')"
+    )
+    await s3conn.execute("INSERT INTO curated SELECT id * 100 FROM raw")
+
+    assert any(n.endswith(".parquet") for n in s3.object_names())
+    assert any(
+        n.startswith("curated/") and n.endswith(".parquet")
+        for n in s3_second_bucket.object_names()
+    )
+    # cross-bucket join, one secret
+    assert (
+        await s3conn.fetchval(
+            "SELECT count(*) FROM raw r JOIN curated c ON c.id = r.id * 100"
+        )
+        == 2
+    )
+
+
+async def test_inline_then_flush_to_s3(s3lake, s3):
+    # Inlining is ON by default: INSERT lands in PG, not the bucket, until
+    # flush_inlined_data writes parquet out to S3.
+    conn = await s3lake.connect()  # configured; inlining left ON
+    try:
+        await conn.execute("CREATE TABLE inl (id int, name text) USING ducklake")
+        await conn.execute("INSERT INTO inl VALUES (1, 'a'), (2, 'b')")
+        assert not any(n.endswith(".parquet") for n in s3.object_names())
+
+        await conn.fetchval("SELECT count(*) FROM ducklake.flush_inlined_data('inl'::regclass)")
+        assert any(n.endswith(".parquet") for n in s3.object_names())
+
+        rows = await conn.fetch("SELECT id, name FROM inl ORDER BY id")
+        assert [tuple(r) for r in rows] == [(1, "a"), (2, "b")]
+    finally:
+        await conn.close()
+
+
+async def test_merge_adjacent_files_on_s3(s3conn):
+    # Small-file compaction: many single-row inserts produce many parquet files;
+    # merge_adjacent_files compacts them without losing rows.
+    await s3conn.execute("CREATE TABLE m (a int, b text) USING ducklake")
+    for i in range(1, 6):
+        await s3conn.execute(f"INSERT INTO m VALUES ({i}, 'v{i}')")
+    n_before = await s3conn.fetchval("SELECT count(*) FROM ducklake.list_files('public', 'm')")
+    assert n_before >= 5
+
+    await s3conn.fetchval("SELECT count(*) FROM ducklake.merge_adjacent_files('m'::regclass)")
+    n_after = await s3conn.fetchval("SELECT count(*) FROM ducklake.list_files('public', 'm')")
+    assert n_after <= n_before
+    assert await s3conn.fetchval("SELECT count(*) FROM m") == 5
+
+
+async def test_wrong_creds_fail_at_s3_access(cluster, db, s3, s3_wrong_creds):
+    # create_s3_secret validates shape only (on a throwaway connection); bad
+    # credentials must surface at S3 access time, not at creation.
+    lake = Lake(cluster, db, s3)
+    conn = await lake.connect(configure=False)
+    try:
+        await _load_httpfs(conn)
+        await conn.fetchval(
+            "SELECT ducklake.create_s3_secret('s3', $1, $2, endpoint => $3, "
+            "url_style => 'path', use_ssl => 'false')",
+            s3_wrong_creds.access_key,
+            s3_wrong_creds.secret_key,
+            s3_wrong_creds.endpoint,
+        )
+        await conn.execute(f"SET ducklake.default_table_path = '{lake.table_path}'")
+        await conn.execute("CALL ducklake.set_option('data_inlining_row_limit', 0)")
+        await conn.execute("CREATE TABLE t (id int) USING ducklake")
+        # the INSERT is the first real write to S3
+        with pytest.raises(asyncpg.PostgresError):
+            await conn.execute("INSERT INTO t VALUES (1)")
+    finally:
+        await conn.close()
 
 
 async def test_duckdb_client_reads_s3_lake(s3lake, s3conn):

--- a/pg_ducklake/test/regression/expected/secrets.out
+++ b/pg_ducklake/test/regression/expected/secrets.out
@@ -1,0 +1,50 @@
+-- S3 / Azure secret management surface (ducklake_secret FDW).
+--
+-- The real S3 round-trip (create_s3_secret + reading/writing s3:// data) needs
+-- the httpfs extension, which pg_ducklake autoinstalls at runtime (network).
+-- That is covered by the e2e MinIO suite. Here we cover only the hermetic
+-- surface: object existence, signatures, and validator paths that reject
+-- BEFORE any DuckDB CREATE SECRET runs (so no httpfs load is triggered).
+-- Convenience function signatures + defaults are locked.
+SELECT proname, pg_get_function_arguments(p.oid) AS args
+FROM pg_proc p
+WHERE pronamespace = 'ducklake'::regnamespace
+  AND proname IN ('create_s3_secret', 'create_azure_secret')
+ORDER BY proname;
+       proname       |                                                                                                                                                 args                                                                                                                                                  
+---------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ create_azure_secret | connection_string text, scope text DEFAULT ''::text
+ create_s3_secret    | type text, key_id text, secret text, session_token text DEFAULT ''::text, region text DEFAULT ''::text, url_style text DEFAULT ''::text, provider text DEFAULT ''::text, endpoint text DEFAULT ''::text, scope text DEFAULT ''::text, validation text DEFAULT ''::text, use_ssl text DEFAULT ''::text
+(2 rows)
+
+-- The dedicated secret FDW is registered and distinct from ducklake_fdw.
+SELECT f.fdwname, h.proname AS handler, v.proname AS validator
+FROM pg_foreign_data_wrapper f
+LEFT JOIN pg_proc h ON h.oid = f.fdwhandler
+LEFT JOIN pg_proc v ON v.oid = f.fdwvalidator
+WHERE f.fdwname LIKE 'ducklake%'
+ORDER BY f.fdwname;
+     fdwname     |       handler       |       validator       
+-----------------+---------------------+-----------------------
+ ducklake_fdw    | _fdw_handler        | _fdw_validator
+ ducklake_secret | _secret_fdw_handler | _secret_fdw_validator
+(2 rows)
+
+-- Validator: a secret SERVER must specify TYPE (errors before any CREATE SECRET).
+CREATE SERVER notype_secret FOREIGN DATA WRAPPER ducklake_secret
+  OPTIONS (region 'us-east-1');
+ERROR:  Missing required option: 'type'
+-- Validator: an unknown secret type is rejected by DuckDB without loading httpfs.
+CREATE SERVER bad_secret TYPE 'not_a_type' FOREIGN DATA WRAPPER ducklake_secret;
+ERROR:  Secret type 'not_a_type' not found
+-- Validator: the FDW object itself takes no options.
+ALTER FOREIGN DATA WRAPPER ducklake_secret OPTIONS (ADD anything 'x');
+ERROR:  'ducklake_secret' FDW does not take any option, found 'anything'
+-- Helper: create_s3_secret rejects types outside {s3,gcs,r2} before any DDL.
+SELECT ducklake.create_s3_secret('invalid_type', 'k', 's');
+ERROR:  Invalid type 'invalid_type': this helper only supports 's3', 'gcs' or 'r2'. Use a raw CREATE SERVER / CREATE USER MAPPING on the ducklake_secret FDW for advanced secrets.
+SELECT ducklake.create_s3_secret('azure', 'k', 's');
+ERROR:  Invalid type 'azure': this helper only supports 's3', 'gcs' or 'r2'. Use a raw CREATE SERVER / CREATE USER MAPPING on the ducklake_secret FDW for advanced secrets.
+-- DROP of an absent secret server gives a clean PG error (no secret-hook interference).
+DROP SERVER no_such_secret_server;
+ERROR:  server "no_such_secret_server" does not exist

--- a/pg_ducklake/test/regression/schedule
+++ b/pg_ducklake/test/regression/schedule
@@ -47,5 +47,6 @@ test: fdw
 test: frozen_fdw
 test: connection_string
 test: import_foreign_schema
+test: secrets
 test: access_control
 test: quoted_names

--- a/pg_ducklake/test/regression/sql/secrets.sql
+++ b/pg_ducklake/test/regression/sql/secrets.sql
@@ -1,0 +1,39 @@
+-- S3 / Azure secret management surface (ducklake_secret FDW).
+--
+-- The real S3 round-trip (create_s3_secret + reading/writing s3:// data) needs
+-- the httpfs extension, which pg_ducklake autoinstalls at runtime (network).
+-- That is covered by the e2e MinIO suite. Here we cover only the hermetic
+-- surface: object existence, signatures, and validator paths that reject
+-- BEFORE any DuckDB CREATE SECRET runs (so no httpfs load is triggered).
+
+-- Convenience function signatures + defaults are locked.
+SELECT proname, pg_get_function_arguments(p.oid) AS args
+FROM pg_proc p
+WHERE pronamespace = 'ducklake'::regnamespace
+  AND proname IN ('create_s3_secret', 'create_azure_secret')
+ORDER BY proname;
+
+-- The dedicated secret FDW is registered and distinct from ducklake_fdw.
+SELECT f.fdwname, h.proname AS handler, v.proname AS validator
+FROM pg_foreign_data_wrapper f
+LEFT JOIN pg_proc h ON h.oid = f.fdwhandler
+LEFT JOIN pg_proc v ON v.oid = f.fdwvalidator
+WHERE f.fdwname LIKE 'ducklake%'
+ORDER BY f.fdwname;
+
+-- Validator: a secret SERVER must specify TYPE (errors before any CREATE SECRET).
+CREATE SERVER notype_secret FOREIGN DATA WRAPPER ducklake_secret
+  OPTIONS (region 'us-east-1');
+
+-- Validator: an unknown secret type is rejected by DuckDB without loading httpfs.
+CREATE SERVER bad_secret TYPE 'not_a_type' FOREIGN DATA WRAPPER ducklake_secret;
+
+-- Validator: the FDW object itself takes no options.
+ALTER FOREIGN DATA WRAPPER ducklake_secret OPTIONS (ADD anything 'x');
+
+-- Helper: create_s3_secret rejects types outside {s3,gcs,r2} before any DDL.
+SELECT ducklake.create_s3_secret('invalid_type', 'k', 's');
+SELECT ducklake.create_s3_secret('azure', 'k', 's');
+
+-- DROP of an absent secret server gives a clean PG error (no secret-hook interference).
+DROP SERVER no_such_secret_server;


### PR DESCRIPTION
## Summary

Adds first-class cloud-storage credential management to pg_ducklake, plus a fix for per-table data placement that the new mixed-location tests uncovered.

## Secret management

Credentials for S3 / GCS / R2 / Azure live in the PostgreSQL catalog on a dedicated `ducklake_secret` foreign data wrapper:

- a `FOREIGN SERVER` holds the public options (endpoint, region, ...)
- a `USER MAPPING` holds the secret options (`key_id`, `secret`, ...), which PostgreSQL's own ACLs hide from other roles

On every DuckDB connection the matching `CREATE SECRET` statements are dropped and re-emitted, so credentials are per-user, transactional, and survive dump/restore. Two convenience wrappers mirror pg_duckdb:

```sql
SELECT ducklake.create_s3_secret('s3', 'AKIA...', 'secret...',
    region => 'us-east-1', endpoint => 's3.amazonaws.com');
SELECT ducklake.create_azure_secret('DefaultEndpointsProtocol=...;');
```

The raw `CREATE SERVER` / `CREATE USER MAPPING` path is also supported for advanced/other providers. The model is self-contained in pg_ducklake (separate from the existing `ducklake_fdw`, which attaches DuckLake databases) and is not added to the libpgduckdb kernel, since the FDW-based storage policy is an extension choice. `httpfs` is autoinstalled on first use (it is not bundled).

## Bug fix: per-table `table_path` vs `default_table_path`

`CREATE TABLE ... WITH (ducklake.table_path = 's3://...')` was silently ignored whenever `ducklake.default_table_path` was set: `RefreshConnectionState` re-pushes the session default on every `GetConnection`, clobbering the per-table override before the `CREATE` ran. The override now takes precedence and is reconciled idempotently (only issuing `SET`/`RESET` when the value changes), and `DuckDBManager::Reset()` invalidates the cached secret and table-path state so a recycled instance re-pushes them.

## Tests

- **Regression** (`secrets`, hermetic): function signatures, FDW registration, and validator rejection paths that do not require `httpfs`.
- **e2e** (MinIO): secret lifecycle (create/named-args/unique-names/drop/recycle-reload/redact-key rejection/wrong-creds-fail-at-access), per-table S3 path, mixed local + S3 in one catalog, two buckets via one endpoint secret, inline -> flush, and small-file compaction.
- **e2e inline/file matrix** (`test_inlining.py`): the `[inline|file] insert x [inline|file] delete` matrix on both local and S3, asserting both result correctness and the actual data/delete file counts read from the DuckLake metadata catalog.

Reusable e2e infrastructure was added (`Lake.connect(inlining=, user=)`, `set_inlining`, `active_file_counts`, `inlining_lake`, `s3_second_bucket`, `s3_wrong_creds`).

Generated with [Claude Code](https://claude.com/claude-code)