### PR TITLE
fix: bypass third-party executor hooks for internal PG scan

### DIFF
--- a/libpgduckdb/scan/postgres_table_reader.cpp
+++ b/libpgduckdb/scan/postgres_table_reader.cpp
@@ -70,7 +70,7 @@ PostgresTableReader::InitUnsafe(const char *table_scan_query, bool count_tuples_
 	table_scan_query_desc = CreateQueryDesc(planned_stmt, table_scan_query, GetActiveSnapshot(), InvalidSnapshot,
 	                                        None_Receiver, nullptr, nullptr, 0);
 
-	ExecutorStart(table_scan_query_desc, 0);
+	standard_ExecutorStart(table_scan_query_desc, 0);
 
 	table_scan_planstate = ExecInitNode(planned_stmt->planTree, table_scan_query_desc->estate, 0);
 
@@ -181,8 +181,8 @@ PostgresTableReader::CleanupUnsafe() {
 	}
 
 	if (table_scan_query_desc) {
-		ExecutorFinish(table_scan_query_desc);
-		ExecutorEnd(table_scan_query_desc);
+		standard_ExecutorFinish(table_scan_query_desc);
+		standard_ExecutorEnd(table_scan_query_desc);
 		FreeQueryDesc(table_scan_query_desc);
 		table_scan_query_desc = nullptr;
 	}


### PR DESCRIPTION
## Problem

When a libpgduckdb-based extension (pg_duckdb / pg_ducklake) is loaded alongside a pgrx-based extension and a query offloaded to DuckDB scans a PostgreSQL heap table, the backend can abort with:

```
postgres FFI may not be called from multiple threads.
fatal runtime error: Rust panics must be rethrown, aborting
... terminated by signal 6: Abort trap: 6
```

Tracked as https://github.com/qsliu2017/libpgduckdb/issues/15 (and upstream https://github.com/duckdb/pg_duckdb/issues/926).

## Root cause

`PostgresTableReader` runs its internal scan sub-query on DuckDB worker threads. It drives that sub-query through the hookable `ExecutorStart` / `ExecutorFinish` / `ExecutorEnd` wrappers, which invoke any installed executor hooks. pgrx-based extensions wrap their callbacks in a thread guard that records the backend main thread and aborts the process when a guarded function is entered from any other thread. Running the executor hooks on a DuckDB worker thread trips that guard.

## Fix

Call `standard_ExecutorStart` / `standard_ExecutorFinish` / `standard_ExecutorEnd` directly for the internal sub-query, bypassing third-party executor-lifecycle hooks. This sub-query is pg_duckdb's own machinery and should not be observed by instrumentation hooks (auto_explain, pgaudit, pg_stat_statements-style, etc.) in any case.

## Testing

Reproduced with a minimal pgrx extension that installs `ExecutorFinish`/`ExecutorEnd` hooks, preloaded alongside pg_duckdb. A join that offloads a heap-table scan onto DuckDB worker threads aborted the backend before this change; with the change applied it runs cleanly.

## Scope / limitations

This closes the executor-lifecycle-hook vector, which is the most common one. It does not make off-main-thread PostgreSQL execution universally safe: planner path-hooks (`set_rel_pathlist_hook`), index access methods, custom scans, FDWs, and quals (e.g. RLS policy expressions) reached inside the inner plan still run on worker threads. Those remain follow-up work if/when another well-known extension surfaces such a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)