### PR TITLE
fix: enable maintenance test, fix rewrite and cleanup_orphaned_files

### DIFF
--- a/pg_ducklake/include/pgducklake/duckdb_manager.hpp
+++ b/pg_ducklake/include/pgducklake/duckdb_manager.hpp
@@ -30,6 +30,10 @@ protected:
 	// GetConnection so a runtime SET / catalog change reaches the next statement;
 	// OnPostInit runs once per instance and would miss it.
 	void RefreshConnectionState(duckdb::ClientContext &context) override;
+	// Also begin a DuckDB transaction while a ducklake-only function statement is
+	// planned/executed, so its bind and execute share one transaction (DuckLake
+	// compaction binds a weak_ptr to the bind-time transaction it reads at execute).
+	bool ShouldBeginTransaction() override;
 
 private:
 	void DropSecrets(duckdb::ClientContext &context);
@@ -67,5 +71,9 @@ namespace pgducklake {
 /* Allow opening a PG subtransaction while DuckDB has an active transaction
  * (SUBXACT_EVENT_START_SUB guard; e.g. DuckLake FlushChanges retry loop). */
 void SetAllowSubtransaction(bool allow);
+
+/* Set per-statement in the planner hook: force a DuckDB transaction for queries
+ * that call a ducklake-only function, so bind and execute share one. */
+void SetForceScanTransaction(bool force);
 
 } // namespace pgducklake

--- a/pg_ducklake/src/duckdb_manager.cpp
+++ b/pg_ducklake/src/duckdb_manager.cpp
@@ -338,6 +338,18 @@ SetAllowSubtransaction(bool allow) {
 	allow_subtransaction = allow;
 }
 
+static bool force_scan_transaction = false;
+
+void
+SetForceScanTransaction(bool force) {
+	force_scan_transaction = force;
+}
+
+bool
+DuckDBManager::ShouldBeginTransaction() {
+	return ::pgddb::DuckDBManager::ShouldBeginTransaction() || force_scan_transaction;
+}
+
 /*
  * SAVEPOINT guard: while DuckDB holds an active transaction, a SAVEPOINT (or
  * BeginInternalSubTransaction without the allow_subtransaction gate) throws so

--- a/pg_ducklake/src/hooks.cpp
+++ b/pg_ducklake/src/hooks.cpp
@@ -388,7 +388,9 @@ DucklakePlannerHook(Query *parse, const char *query_string, int cursor_options, 
 
 	/* Any ducklake-AM table or ducklake-only function routes the whole
 	 * query to DuckDB via libpgddb's CustomScan. */
-	if (QueryReferencesRegisteredTableAm((Node *)parse, NULL) || QueryReferencesDucklakeOnlyFunc((Node *)parse, NULL) ||
+	bool refs_ducklake_only_func = QueryReferencesDucklakeOnlyFunc((Node *)parse, NULL);
+	pgducklake::SetForceScanTransaction(refs_ducklake_only_func);
+	if (QueryReferencesRegisteredTableAm((Node *)parse, NULL) || refs_ducklake_only_func ||
 	    pgducklake::QueryReferencesDucklakeForeignTable(parse)) {
 		return pgddb::PlanNode(parse, cursor_options, /*throw_error=*/true);
 	}

--- a/pg_ducklake/test/regression/schedule
+++ b/pg_ducklake/test/regression/schedule
@@ -28,11 +28,7 @@ test: variant
 test: readme_examples
 test: ddl
 test: vacuum
-# FIXME: maintenance (ducklake.rewrite_data_files) fails with "Scanning a
-# DuckLake table after the transaction has ended" -- a DuckLake transaction
-# lifecycle issue unrelated to the DuckDBManager singleton extraction.
-# Disabled until diagnosed separately.
-# test: maintenance
+test: maintenance
 test: commit_message
 test: partition
 test: sorted_table

--- a/pg_ducklake/third_party/ducklake-001-metadata-manager-virtualization.patch
+++ b/pg_ducklake/third_party/ducklake-001-metadata-manager-virtualization.patch
@@ -634,7 +634,7 @@ index f44f9b90..7cefeec1 100644
  SELECT REPLACE(
             CASE
                 WHEN NOT file_relative THEN file_path
-@@ -4537,19 +4564,44 @@ SELECT REPLACE(
+@@ -4537,19 +4564,45 @@ SELECT REPLACE(
             '{SEPARATOR}'
  ) AS full_path
  FROM {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion f
@@ -658,12 +658,14 @@ index f44f9b90..7cefeec1 100644
 +	// Get active files from metadata
 +	auto active_files = GetActiveFiles(separator);
 +
-+	// Get all files from filesystem using DuckDB's read_blob.
-+	// Use transaction.Query() (DuckDB connection) instead of Query() (metadata
-+	// path) because read_blob is a DuckDB-native function that cannot run
-+	// through external metadata backends (e.g. PostgreSQL SPI).
-+	auto query = "SELECT filename FROM read_blob({DATA_PATH} || '**') WHERE true " + filter;
- 	auto res = transaction.Query(query);
++	// Get all files from filesystem using DuckDB's read_blob. Substitute
++	// placeholders and run on the DuckDB connection (ExecuteRaw), not the metadata
++	// Query() path, since read_blob is DuckDB-native and a metadata override may
++	// route Query() through an external backend (e.g. PostgreSQL SPI).
++	string query = "SELECT filename FROM read_blob({DATA_PATH} || '**') WHERE true " + filter;
++	SubstituteCatalogPlaceholders(query);
++	auto res = transaction.ExecuteRaw(query);
+-	auto res = transaction.Query(query);
  	if (res->HasError()) {
 -		res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
 +		res->GetErrorObject().Throw("Failed to get files from filesystem: ");


### PR DESCRIPTION
## Summary

Re-enables the `maintenance` regression test (previously disabled by a FIXME) and fixes the two bugs that kept it failing. Scoped entirely to pg_ducklake -- no kernel (libpgduckdb) changes, so pg_duckdb is unaffected.

## Bug 1: `ducklake.rewrite_data_files` -- "Scanning a DuckLake table after the transaction has ended"

An offloaded ducklake-only function is bound (prepared) at executor start-up and executed a moment later. For a bare auto-commit statement those ran in two separate short-lived DuckDB transactions; DuckLake's compaction code captured a `weak_ptr` to the bind-time transaction, which was already gone by execute time (it only manifested for rewrite-with-deletes, whose multi-file reader reaches `GetTransaction()` at execute).

**Fix:** force a single DuckDB transaction spanning prepare+execute, but only for statements that call a ducklake-only function. `pgducklake::DuckDBManager::ShouldBeginTransaction()` now ORs in a per-statement `force_scan_transaction` flag that `DucklakePlannerHook` sets from `QueryReferencesDucklakeOnlyFunc(parse)`. Normal ducklake table reads/writes match `QueryReferencesRegisteredTableAm` instead and are **not** forced into a transaction; inside an explicit `BEGIN..COMMIT` the kernel already begins one, so the flag only matters in autocommit.

## Bug 2: `cleanup_orphaned_files` -- "function read_blob(text) does not exist"

Surfaced only once Bug 1 let execution reach it. `GetOrphanFilesForCleanup` sent the `read_blob` filesystem glob through `transaction.Query()`, which for pg_ducklake's `PgDuckLakeMetadataManager` routes to PostgreSQL via SPI -- where `read_blob` (a DuckDB-native function) does not exist.

**Fix (in `third_party/ducklake-001-metadata-manager-virtualization.patch`):** substitute the catalog placeholders and run the glob on the DuckDB connection via `transaction.ExecuteRaw()` instead. `GetActiveFiles` correctly keeps `Query()`/SPI since it reads the PG metadata tables. Verified the full patch series still applies cleanly onto a pristine submodule checkout.

## Testing

- `make -C pg_ducklake check-regression` -> **48/48** (was 47; `maintenance` now included)
- `make -C pg_ducklake check-isolation` -> **3/3**
- `make -C pg_ducklake check-format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)