### PR TITLE
chore: bump duckdb to v1.5.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PGDDB_OBJS := $(PGDDB_CPP_SRCS:.cpp=.o) $(PGDDB_C_SRCS:.c=.o)
 # tagged build dir, statically linked into the extension's .so.
 
 DUCKDB_GEN ?= ninja
-DUCKDB_VERSION = v1.5.3
+DUCKDB_VERSION = v1.5.4
 
 DUCKDB_CMAKE_VARS = -DCXX_EXTRA=-fvisibility=default -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0 -DOVERRIDE_GIT_DESCRIBE=$(DUCKDB_VERSION)
 DUCKDB_DISABLE_ASSERTIONS ?= 0


### PR DESCRIPTION
## Summary

Bumps the `duckdb` submodule from **v1.5.3** to **v1.5.4** (pure upstream upgrade) and updates the matching `DUCKDB_VERSION` in the root `Makefile`.

## Changes

- `duckdb` gitlink: `9a64d338` -> `08e34c44` (v1.5.4)
- `Makefile`: `DUCKDB_VERSION = v1.5.3` -> `v1.5.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)