### PR TITLE
feat: pg_duckdb read_arrow() via bundled nanoarrow extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,11 @@ $(FULL_DUCKDB_LIB): $(PGDDB_DIR)/.git/modules/duckdb/HEAD $(EXTENSION_CONFIGS)
 		$(foreach n,$(EXTENSION_BUNDLE_EXCLUDE),-not -name 'lib$(n)_extension.a' -not -name 'lib$(n)_duckdb.a') \
 		-exec cp {} $(DUCKDB_BUILD_DIR)/bundle/. \;
 	find $(DUCKDB_BUILD_DIR)/vcpkg_installed -name '*.a' -exec cp {} $(DUCKDB_BUILD_DIR)/bundle/. \;
+	# Extensions vendored via cmake FetchContent (e.g. nanoarrow's libnanoarrow,
+	# libnanoarrow_ipc, libflatccrt) land under _deps/; bundle their archives too.
+	if [ -d $(DUCKDB_BUILD_DIR)/_deps ]; then \
+		find $(DUCKDB_BUILD_DIR)/_deps -name 'lib*.a' -exec cp {} $(DUCKDB_BUILD_DIR)/bundle/. \;; \
+	fi
 	cd $(DUCKDB_BUILD_DIR)/bundle && \
 		find . -name '*.a' -exec mkdir -p {}.objects \; -exec mv {} {}.objects \; && \
 		find . -name '*.a' -execdir $(AR) -x {} \;

--- a/pg_duckdb/pg_duckdb.control
+++ b/pg_duckdb/pg_duckdb.control
@@ -1,4 +1,4 @@
 comment = 'DuckDB Embedded in Postgres'
-default_version = '1.1.0'
+default_version = '1.2.0'
 module_pathname = '$libdir/pg_duckdb'
 relocatable = false

--- a/pg_duckdb/sql/pg_duckdb--1.1.0--1.2.0.sql
+++ b/pg_duckdb/sql/pg_duckdb--1.1.0--1.2.0.sql
@@ -1,0 +1,14 @@
+-- Apache Arrow IPC reader backed by the bundled paleolimbot/duckdb-nanoarrow
+-- extension. Mirrors read_parquet: planner-routed duckdb_only_function stubs.
+
+CREATE FUNCTION @extschema@.read_arrow(path text)
+RETURNS SETOF duckdb.row
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.read_arrow(path text[])
+RETURNS SETOF duckdb.row
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;

--- a/pg_duckdb/src/pgduckdb_hooks.cpp
+++ b/pg_duckdb/src/pgduckdb_hooks.cpp
@@ -415,7 +415,8 @@ static bool
 ContainsDuckdbRowReturningFunction(const char *query_string) {
 	return strstr(query_string, "read_parquet") || strstr(query_string, "read_csv") ||
 	       strstr(query_string, "read_json") || strstr(query_string, "delta_scan") ||
-	       strstr(query_string, "iceberg_scan") || strstr(query_string, "duckdb.query");
+	       strstr(query_string, "iceberg_scan") || strstr(query_string, "read_arrow") ||
+	       strstr(query_string, "duckdb.query");
 }
 
 static void

--- a/pg_duckdb/src/pgduckdb_metadata_cache.cpp
+++ b/pg_duckdb/src/pgduckdb_metadata_cache.cpp
@@ -153,6 +153,7 @@ BuildDuckdbOnlyFunctions() {
 	                                "iceberg_snapshots",
 	                                "delta_scan",
 	                                "read_json",
+	                                "read_arrow",
 	                                "approx_count_distinct",
 	                                "query",
 	                                "view",

--- a/pg_duckdb/test/regression/expected/arrow.out
+++ b/pg_duckdb/test/regression/expected/arrow.out
@@ -1,0 +1,51 @@
+-- Apache Arrow support via the bundled nanoarrow extension.
+-- Verifies that nanoarrow is loaded by default and that read_arrow() works
+-- for both Arrow IPC stream (.arrows) and Arrow IPC file (.arrow) formats.
+SET duckdb.force_execution = true;
+-- Sanity: nanoarrow is loaded as a built-in (no install required).
+SET duckdb.force_execution = false;
+SELECT * FROM duckdb.query($$ SELECT extension_name, loaded FROM duckdb_extensions() WHERE extension_name = 'nanoarrow' $$);
+ extension_name | loaded 
+----------------+--------
+ nanoarrow      | t
+(1 row)
+
+SET duckdb.force_execution = true;
+-- Set up a small dataset and round-trip it through Arrow IPC stream.
+\set pwd `pwd`
+\set arrow_stream_path '\'' :pwd '/tmp_check/pg_duckdb_arrow.arrows' '\''
+\set arrow_file_path   '\'' :pwd '/tmp_check/pg_duckdb_arrow.arrow'  '\''
+CREATE TABLE t_arrow(i INT, label TEXT);
+INSERT INTO t_arrow SELECT g, 'row_' || g FROM generate_series(1, 5) g;
+-- Arrow IPC stream round-trip.
+COPY t_arrow TO :arrow_stream_path (FORMAT ARROWS);
+SELECT r['i'], r['label'] FROM read_arrow(:arrow_stream_path) r ORDER BY r['i'];
+ i | label 
+---+-------
+ 1 | row_1
+ 2 | row_2
+ 3 | row_3
+ 4 | row_4
+ 5 | row_5
+(5 rows)
+
+-- Arrow IPC file round-trip.
+COPY t_arrow TO :arrow_file_path (FORMAT ARROW);
+SELECT r['i'], r['label'] FROM read_arrow(:arrow_file_path) r ORDER BY r['i'];
+ i | label 
+---+-------
+ 1 | row_1
+ 2 | row_2
+ 3 | row_3
+ 4 | row_4
+ 5 | row_5
+(5 rows)
+
+-- Array variant: union the two files.
+SELECT count(*) FROM read_arrow(ARRAY[:arrow_stream_path, :arrow_file_path]);
+ count 
+-------
+    10
+(1 row)
+
+DROP TABLE t_arrow;

--- a/pg_duckdb/test/regression/expected/extensions.out
+++ b/pg_duckdb/test/regression/expected/extensions.out
@@ -9,9 +9,10 @@ SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installe
  httpfs         | t      | t         | 
  icu            | t      | t         | 
  json           | t      | t         | 
+ nanoarrow      | t      | t         | 
  parquet        | t      | t         | 
  pgduckdb       | t      | f         | 
-(6 rows)
+(7 rows)
 
 SELECT last_value FROM duckdb.extensions_table_seq;
  last_value 
@@ -41,9 +42,10 @@ SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installe
  httpfs         | t      | t         | 
  icu            | t      | t         | core
  json           | t      | t         | 
+ nanoarrow      | t      | t         | 
  parquet        | t      | t         | 
  pgduckdb       | t      | f         | 
-(6 rows)
+(7 rows)
 
 -- Check that we can rerun this without issues
 SELECT duckdb.install_extension('icu');
@@ -67,9 +69,10 @@ SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installe
  httpfs         | t      | t         | 
  icu            | t      | t         | core
  json           | t      | t         | 
+ nanoarrow      | t      | t         | 
  parquet        | t      | t         | 
  pgduckdb       | t      | f         | 
-(6 rows)
+(7 rows)
 
 SELECT duckdb.install_extension('aws');
  install_extension 
@@ -91,9 +94,10 @@ SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installe
  httpfs         | t      | t         | 
  icu            | t      | t         | core
  json           | t      | t         | 
+ nanoarrow      | t      | t         | 
  parquet        | t      | t         | 
  pgduckdb       | t      | f         | 
-(7 rows)
+(8 rows)
 
 -- autoload_extension and load_extension function should work as expected
 SELECT * FROM duckdb.query($$ FROM duckdb_extensions() SELECT installed, loaded WHERE extension_name = 'aws' $$);
@@ -160,9 +164,10 @@ SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installe
  httpfs         | t      | t         | 
  icu            | t      | t         | core
  json           | t      | t         | 
+ nanoarrow      | t      | t         | 
  parquet        | t      | t         | 
  pgduckdb       | t      | f         | 
-(7 rows)
+(8 rows)
 
 -- Reconnecting should cause the extension not to be loaded anymore
 CALL duckdb.recycle_ddb();
@@ -173,9 +178,10 @@ SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installe
  httpfs         | t      | t         | 
  icu            | t      | t         | core
  json           | t      | t         | 
+ nanoarrow      | t      | t         | 
  parquet        | t      | t         | 
  pgduckdb       | t      | f         | 
-(6 rows)
+(7 rows)
 
 -- TODO: re-enable when community extensions are published for v1.5.2
 -- SELECT duckdb.install_extension('quack', 'community');
@@ -192,9 +198,10 @@ SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installe
  httpfs         | t      | t         | 
  icu            | t      | t         | core
  json           | t      | t         | 
+ nanoarrow      | t      | t         | 
  parquet        | t      | t         | 
  pgduckdb       | t      | f         | 
-(6 rows)
+(7 rows)
 
 -- cleanup
 TRUNCATE duckdb.extensions;

--- a/pg_duckdb/test/regression/schedule
+++ b/pg_duckdb/test/regression/schedule
@@ -3,6 +3,7 @@ test: altered_tables
 test: approx_count_distinct
 test: array_problems
 test: array_type_support
+test: arrow
 test: basic
 test: case_insensitivity
 test: concurrency

--- a/pg_duckdb/test/regression/sql/arrow.sql
+++ b/pg_duckdb/test/regression/sql/arrow.sql
@@ -1,0 +1,31 @@
+-- Apache Arrow support via the bundled nanoarrow extension.
+-- Verifies that nanoarrow is loaded by default and that read_arrow() works
+-- for both Arrow IPC stream (.arrows) and Arrow IPC file (.arrow) formats.
+
+SET duckdb.force_execution = true;
+
+-- Sanity: nanoarrow is loaded as a built-in (no install required).
+SET duckdb.force_execution = false;
+SELECT * FROM duckdb.query($$ SELECT extension_name, loaded FROM duckdb_extensions() WHERE extension_name = 'nanoarrow' $$);
+SET duckdb.force_execution = true;
+
+-- Set up a small dataset and round-trip it through Arrow IPC stream.
+\set pwd `pwd`
+\set arrow_stream_path '\'' :pwd '/tmp_check/pg_duckdb_arrow.arrows' '\''
+\set arrow_file_path   '\'' :pwd '/tmp_check/pg_duckdb_arrow.arrow'  '\''
+
+CREATE TABLE t_arrow(i INT, label TEXT);
+INSERT INTO t_arrow SELECT g, 'row_' || g FROM generate_series(1, 5) g;
+
+-- Arrow IPC stream round-trip.
+COPY t_arrow TO :arrow_stream_path (FORMAT ARROWS);
+SELECT r['i'], r['label'] FROM read_arrow(:arrow_stream_path) r ORDER BY r['i'];
+
+-- Arrow IPC file round-trip.
+COPY t_arrow TO :arrow_file_path (FORMAT ARROW);
+SELECT r['i'], r['label'] FROM read_arrow(:arrow_file_path) r ORDER BY r['i'];
+
+-- Array variant: union the two files.
+SELECT count(*) FROM read_arrow(ARRAY[:arrow_stream_path, :arrow_file_path]);
+
+DROP TABLE t_arrow;

--- a/pg_duckdb/third_party/pg_duckdb_extensions.cmake
+++ b/pg_duckdb/third_party/pg_duckdb_extensions.cmake
@@ -4,3 +4,7 @@ duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG 9de3296f40ed03e8e063394887f0d6a46144e847
 )
+duckdb_extension_load(nanoarrow
+    GIT_URL https://github.com/paleolimbot/duckdb-nanoarrow
+    GIT_TAG 42e4199a67c4cd0789087562a025e87e7130fdc3
+)


### PR DESCRIPTION
## What

Adds first-class Apache Arrow IPC reading to pg_duckdb, mirroring the read_parquet() pattern. New SQL function `read_arrow(text)` and `read_arrow(text[])` accept Arrow IPC stream and file formats and are routed to DuckDB by the existing planner hook.

## Changes

- `pg_duckdb/third_party/pg_duckdb_extensions.cmake`: statically link paleolimbot/duckdb-nanoarrow PR #47 (commit 42e4199), the DuckDB-1.5-compatible branch. Auto-registered via DuckDB's LinkedExtensions() -- no runtime LOAD needed.
- `pg_duckdb/pg_duckdb.control`: bump default_version 1.1.0 -> 1.2.0.
- `pg_duckdb/sql/pg_duckdb--1.1.0--1.2.0.sql`: register read_arrow(text) and read_arrow(text[]) as duckdb_only_function stubs.
- `pg_duckdb/src/pgduckdb_hooks.cpp`: add read_arrow to the strstr filter in ContainsDuckdbRowReturningFunction so the planner reroutes queries containing read_arrow() to DuckDB without requiring duckdb.force_execution = true.
- `pg_duckdb/src/pgduckdb_metadata_cache.cpp`: add read_arrow to the known-function list so duckdb_only_function lookups cache its OID.
- Root `Makefile`: also bundle archives under `_deps/` (cmake FetchContent output). nanoarrow's vendored `libnanoarrow.a`, `libnanoarrow_ipc.a`, and `libflatccrt.a` live there and were not picked up by the existing `extension/` + `vcpkg_installed/` scans, causing undefined `DuckDBExtnanoarrow*` symbols at link time.

## Tests

- `pg_duckdb/test/regression/sql/arrow.sql` + `pg_duckdb/test/regression/expected/arrow.out`: round-trips both Arrow IPC stream (.arrows) and Arrow IPC file (.arrow) formats through COPY ... TO + read_arrow(), plus the array-variant union.
- `pg_duckdb/test/regression/schedule`: register the arrow test.

## Notes

The nanoarrow C library rejects Arrow files containing Dictionary-encoded columns. JavaScript producers commonly hit this via apache-arrow's tableFromArrays(), which auto-builds Dictionary<Int32, Utf8> for string columns. Emit plain Utf8 vectors via vectorFromArray() and stream-format IPC to interoperate.