### PR TITLE
chore: macOS build compatibility (Postgres.app, SDK libcurl, single-arch)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ ifeq ($(shell uname -s),Darwin)
     ifneq ($(MACOS_SDK_PATH),)
         EXTRA_DUCKDB_CMAKE_VARS += -DCURL_INCLUDE_DIR=$(MACOS_SDK_PATH)/usr/include -DCURL_LIBRARY=$(MACOS_SDK_PATH)/usr/lib/libcurl.tbd
     endif
+    # libpgduckdb's pgddb_duckdb.cpp uses std::filesystem (macOS 10.15+).
+    # Postgres.app ships pgxs with -mmacosx-version-min=10.13, so re-append
+    # 10.15 here (clang takes the last -mmacosx-version-min on the cmdline).
+    override PG_CPPFLAGS += -mmacosx-version-min=10.15
+    override PG_CXXFLAGS += -mmacosx-version-min=10.15
 endif
 
 DUCKDB_CMAKE_VARS = -DCXX_EXTRA=-fvisibility=default -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0 -DOVERRIDE_GIT_DESCRIBE=$(DUCKDB_VERSION) $(EXTRA_DUCKDB_CMAKE_VARS)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,21 @@ PGDDB_OBJS := $(PGDDB_CPP_SRCS:.cpp=.o) $(PGDDB_C_SRCS:.c=.o)
 DUCKDB_GEN ?= ninja
 DUCKDB_VERSION = v1.5.4
 
-DUCKDB_CMAKE_VARS = -DCXX_EXTRA=-fvisibility=default -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0 -DOVERRIDE_GIT_DESCRIBE=$(DUCKDB_VERSION)
+# Escape hatch for extra cmake vars to forward to the DuckDB build (e.g. to
+# pin the SDK libcurl when /Library/Frameworks/ shadows it on macOS).
+EXTRA_DUCKDB_CMAKE_VARS ?=
+
+# On macOS, alternative libcurl installations under /Library/Frameworks
+# can shadow the SDK libcurl that DuckDB-httpfs's find_package(CURL)
+# expects (e.g. missing CURLSSLOPT_NATIVE_CA). Auto-pin the SDK copy.
+ifeq ($(shell uname -s),Darwin)
+    MACOS_SDK_PATH := $(shell xcrun --show-sdk-path 2>/dev/null)
+    ifneq ($(MACOS_SDK_PATH),)
+        EXTRA_DUCKDB_CMAKE_VARS += -DCURL_INCLUDE_DIR=$(MACOS_SDK_PATH)/usr/include -DCURL_LIBRARY=$(MACOS_SDK_PATH)/usr/lib/libcurl.tbd
+    endif
+endif
+
+DUCKDB_CMAKE_VARS = -DCXX_EXTRA=-fvisibility=default -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0 -DOVERRIDE_GIT_DESCRIBE=$(DUCKDB_VERSION) $(EXTRA_DUCKDB_CMAKE_VARS)
 DUCKDB_DISABLE_ASSERTIONS ?= 0
 
 # Optional compiler cache (e.g. sccache) for the DuckDB build.

--- a/pg_duckdb/Makefile
+++ b/pg_duckdb/Makefile
@@ -70,6 +70,19 @@ SHLIB_LINK += $(PG_DUCKDB_LINK_FLAGS)
 
 include $(ROOT_DIR)/Makefile.pgxs
 
+# On macOS, Postgres.app's pgxs requests a universal binary
+# (-arch arm64 -arch x86_64). When the DuckDB bundle and brew libs
+# are single-arch (host = x86_64 under Rosetta), the arm64 slice has
+# no symbols and ld fails. Strip -arch arm64 from pgxs's flags so the
+# build is single-arch x86_64.
+ifeq ($(shell uname -s),Darwin)
+    override CFLAGS := $(subst -arch arm64,,$(CFLAGS))
+    override CXXFLAGS := $(subst -arch arm64,,$(CXXFLAGS))
+    override LDFLAGS := $(subst -arch arm64,,$(LDFLAGS))
+    override LDFLAGS_SL := $(subst -arch arm64,,$(LDFLAGS_SL))
+    override CFLAGS_SL := $(subst -arch arm64,,$(CFLAGS_SL))
+endif
+
 # Only pass the version define to the one file that needs it, so that ccache
 # doesn't invalidate everything on every commit.
 src/pgduckdb.o: PG_CPPFLAGS += -DPG_DUCKDB_VERSION="\"$(PG_DUCKDB_VERSION)\""


### PR DESCRIPTION
## What

Three independent macOS-only knobs that together unblock local builds
against Postgres.app on macOS (verified on Sequoia / Postgres.app v15 /
x86_64-under-Rosetta). None of these affect Linux builds.

## Changes

### 1. Auto-pin SDK libcurl (root `Makefile`)

Adds an `EXTRA_DUCKDB_CMAKE_VARS ?=` escape hatch for forwarding extra
cmake variables to the DuckDB build. On Darwin, auto-pin
`CURL_INCLUDE_DIR` / `CURL_LIBRARY` to the SDK copy discovered via
`xcrun --show-sdk-path`. This defeats shadowing by alternative libcurl
installations under `/Library/Frameworks/` that may lack symbols the
duckdb-httpfs bundle expects (e.g. `CURLSSLOPT_NATIVE_CA`).

### 2. Bump deployment target to 10.15 (root `Makefile`)

`libpgduckdb/pgddb_duckdb.cpp` uses `std::filesystem::create_directories`,
introduced in macOS 10.15. Postgres.app ships pgxs with
`-mmacosx-version-min=10.13`, which makes those symbols "unavailable"
and breaks compilation of the kernel. Append `-mmacosx-version-min=10.15`
to `PG_CPPFLAGS` / `PG_CXXFLAGS` on Darwin via `override` — clang takes
the *last* `-mmacosx-version-min` on the command line, so the explicit
10.15 wins over pgxs's 10.13.

### 3. Strip `-arch arm64` to match single-arch bundle (`pg_duckdb/Makefile`)

Postgres.app's pgxs requests a universal binary (`-arch arm64 -arch x86_64`).
When the DuckDB bundle is single-arch (cmake defaults to host arch,
x86_64 under Rosetta) and brew libs are also x86_64-only, the arm64
slice of `pg_duckdb.so` cannot resolve any symbols and `ld` fails with
"symbol(s) not found for architecture arm64". Strip `-arch arm64` from
`CFLAGS` / `CXXFLAGS` / `LDFLAGS` / `LDFLAGS_SL` / `CFLAGS_SL` via
`$(subst -arch arm64,,$(...))` after the PGXS include on Darwin so the
build matches the bundle. Users with fat brew libs can revert this hunk
to build universal.

## Verification

- Clean build against Postgres.app v15 produces a working
  `pg_duckdb.so` x86_64 (~57 MB).
- Manual smoke test: `CREATE EXTENSION pg_duckdb` → 1.2.0,
  `duckdb_extensions()` shows nanoarrow loaded,
  `read_arrow()` round-trip succeeds.

## Caveat

This PR is offered for review but is reasonably contained to Darwin
guards; it may not be of broad upstream interest. Happy to drop or
narrow if upstream prefers users handle macOS build quirks externally.