### PR TITLE
Shared per-database DuckDB worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ PGDDB_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 PGDDB_INCLUDE := -I$(PGDDB_DIR)/libpgduckdb/include
 PGDDB_DUCKDB_INCLUDE := -isystem $(PGDDB_DIR)/duckdb/src/include \
                         -isystem $(PGDDB_DIR)/duckdb/third_party/re2
-PGDDB_CPP_SRCS := $(wildcard $(PGDDB_DIR)/libpgduckdb/*.cpp $(PGDDB_DIR)/libpgduckdb/*/*.cpp)
-PGDDB_C_SRCS := $(wildcard $(PGDDB_DIR)/libpgduckdb/*.c $(PGDDB_DIR)/libpgduckdb/*/*.c)
+PGDDB_CPP_SRCS := $(wildcard $(PGDDB_DIR)/libpgduckdb/*.cpp $(PGDDB_DIR)/libpgduckdb/*/*.cpp $(PGDDB_DIR)/libpgduckdb/*/*/*.cpp)
+PGDDB_C_SRCS := $(wildcard $(PGDDB_DIR)/libpgduckdb/*.c $(PGDDB_DIR)/libpgduckdb/*/*.c $(PGDDB_DIR)/libpgduckdb/*/*/*.c)
 PGDDB_SRCS := $(PGDDB_CPP_SRCS) $(PGDDB_C_SRCS)
 PGDDB_OBJS := $(PGDDB_CPP_SRCS:.cpp=.o) $(PGDDB_C_SRCS:.c=.o)
 

--- a/libpgduckdb/catalog/pgddb_table.cpp
+++ b/libpgduckdb/catalog/pgddb_table.cpp
@@ -14,14 +14,11 @@
 namespace pgddb {
 
 PostgresTable::PostgresTable(duckdb::Catalog &_catalog, duckdb::SchemaCatalogEntry &_schema,
-                             duckdb::CreateTableInfo &_info, Relation _rel, Cardinality _cardinality,
-                             Snapshot _snapshot)
-    : duckdb::TableCatalogEntry(_catalog, _schema, _info), rel(_rel), cardinality(_cardinality), snapshot(_snapshot) {
+                             duckdb::CreateTableInfo &_info, RelationDesc _desc, Snapshot _snapshot)
+    : duckdb::TableCatalogEntry(_catalog, _schema, _info), desc(std::move(_desc)), snapshot(_snapshot) {
 }
 
 PostgresTable::~PostgresTable() {
-	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
-	pgddb::CloseRelation(rel);
 }
 
 Relation
@@ -31,19 +28,17 @@ PostgresTable::OpenRelation(Oid relid) {
 }
 
 void
-PostgresTable::SetTableInfo(duckdb::CreateTableInfo &info, Relation rel) {
-	auto tupleDesc = pgddb::RelationGetDescr(rel);
+PostgresTable::CloseRelation(Relation rel) {
+	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+	pgddb::CloseRelation(rel);
+}
 
-	const auto n = pgddb::GetTupleDescNatts(tupleDesc);
-	for (int i = 0; i < n; ++i) {
-		Form_pg_attribute attr = pgddb::GetAttr(tupleDesc, i);
-		if (pgddb::AttIsDropped(attr))
-			continue;
-		auto col_name = duckdb::string(pgddb::GetAttName(attr));
-		auto duck_type = ConvertPostgresToDuckColumnType(attr);
-		info.columns.AddColumn(duckdb::ColumnDefinition(col_name, duck_type));
-		pd_log(DEBUG2, "(DuckDB/SetTableInfo) Column name: '%s', Type: %s", col_name.c_str(),
-		       duck_type.ToString().c_str());
+void
+PostgresTable::SetTableInfo(duckdb::CreateTableInfo &info, const RelationDesc &desc) {
+	for (const auto &col : desc.columns) {
+		info.columns.AddColumn(duckdb::ColumnDefinition(col.name, col.type));
+		pd_log(DEBUG2, "(DuckDB/SetTableInfo) Column name: '%s', Type: %s", col.name.c_str(),
+		       col.type.ToString().c_str());
 	}
 }
 
@@ -54,7 +49,7 @@ PostgresTable::GetStatistics(duckdb::ClientContext &, duckdb::column_t) {
 
 duckdb::TableFunction
 PostgresTable::GetScanFunction(duckdb::ClientContext &, duckdb::unique_ptr<duckdb::FunctionData> &bind_data) {
-	bind_data = duckdb::make_uniq<PostgresScanFunctionData>(rel, cardinality, snapshot);
+	bind_data = duckdb::make_uniq<PostgresScanFunctionData>(desc, snapshot);
 	return PostgresScanTableFunction();
 }
 

--- a/libpgduckdb/catalog/pgddb_transaction.cpp
+++ b/libpgduckdb/catalog/pgddb_transaction.cpp
@@ -2,8 +2,12 @@
 #include "pgddb/catalog/pgddb_schema.hpp"
 #include "pgddb/catalog/pgddb_transaction.hpp"
 #include "pgddb/catalog/pgddb_table.hpp"
+#include "pgddb/catalog/relation_desc.hpp"
 #include "pgddb/scan/postgres_scan.hpp"
 #include "pgddb/pg/relations.hpp"
+#include "pgddb/worker/duckdb_worker.hpp"
+#include "pgddb/worker/transport/session_channel.hpp"
+#include "pgddb/worker/transport/session_protocol.hpp"
 
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
@@ -31,10 +35,27 @@ SchemaItems::SchemaItems(duckdb::unique_ptr<PostgresSchema> &&_schema, const duc
 }
 
 duckdb::optional_ptr<duckdb::CatalogEntry>
-SchemaItems::GetTable(const duckdb::string &entry_name) {
+SchemaItems::GetTable(const duckdb::string &entry_name, duckdb::ClientContext *context) {
 	auto it = tables.find(entry_name);
 	if (it != tables.end()) {
 		return it->second.get();
+	}
+
+	// In a duckdb worker session, the relation lives in the requesting backend; RPC it to
+	// describe the relation rather than opening it here. Resolved through the context as
+	// well: a nested query (e.g. DuckLake inlined-data reads) binds on a DuckDB scheduler
+	// thread, where the session thread-local is invisible.
+	if (auto *session = pgddb::worker::EffectiveWorkerSession(context)) {
+		RelationDesc desc = pgddb::WorkerDescribeRelation(*session, name, entry_name);
+		if (desc.oid == 0 /* InvalidOid */) {
+			return nullptr; // Table could not be found
+		}
+		duckdb::CreateTableInfo info;
+		info.table = entry_name;
+		PostgresTable::SetTableInfo(info, desc);
+		tables.emplace(entry_name, duckdb::make_uniq<PostgresTable>(schema->catalog, *schema, info, std::move(desc),
+		                                                            schema->snapshot));
+		return tables[entry_name].get();
 	}
 
 	Oid rel_oid = pgddb::GetRelidFromSchemaAndTable(name.c_str(), entry_name.c_str());
@@ -44,14 +65,15 @@ SchemaItems::GetTable(const duckdb::string &entry_name) {
 	}
 
 	Relation rel = PostgresTable::OpenRelation(rel_oid);
+	RelationDesc desc = pgddb::BuildRelationDesc(rel);
+	PostgresTable::CloseRelation(rel);
 
 	duckdb::CreateTableInfo info;
 	info.table = entry_name;
-	PostgresTable::SetTableInfo(info, rel);
+	PostgresTable::SetTableInfo(info, desc);
 
-	auto cardinality = pgddb::EstimateRelSize(rel);
-	tables.emplace(entry_name, duckdb::make_uniq<PostgresTable>(schema->catalog, *schema, info, rel, cardinality,
-	                                                            schema->snapshot));
+	tables.emplace(entry_name,
+	               duckdb::make_uniq<PostgresTable>(schema->catalog, *schema, info, std::move(desc), schema->snapshot));
 	return tables[entry_name].get();
 }
 
@@ -89,7 +111,8 @@ PostgresTransaction::GetCatalogEntry(duckdb::CatalogType type, const duckdb::str
                                      const duckdb::string &name) {
 	switch (type) {
 	case duckdb::CatalogType::TABLE_ENTRY: {
-		auto context_state = context.lock()->registered_state->GetOrCreate<PostgresContextState>("pgduckdb");
+		auto ctx = context.lock();
+		auto context_state = ctx->registered_state->GetOrCreate<PostgresContextState>("pgduckdb");
 		auto schemas = &context_state->schemas;
 		auto it = schemas->find(schema);
 		if (it == schemas->end()) {
@@ -97,7 +120,7 @@ PostgresTransaction::GetCatalogEntry(duckdb::CatalogType type, const duckdb::str
 		}
 
 		auto &schema_entry = it->second;
-		return schema_entry.GetTable(name);
+		return schema_entry.GetTable(name, ctx.get());
 	}
 	case duckdb::CatalogType::SCHEMA_ENTRY: {
 		return GetSchema(schema);

--- a/libpgduckdb/catalog/pgddb_transaction_manager.cpp
+++ b/libpgduckdb/catalog/pgddb_transaction_manager.cpp
@@ -3,6 +3,7 @@
 #include "pgddb/catalog/pgddb_transaction.hpp"
 #include "pgddb/pg/snapshots.hpp"
 #include "pgddb/pgddb_process_lock.hpp"
+#include "pgddb/worker/duckdb_worker.hpp"
 
 #include "duckdb/main/attached_database.hpp"
 
@@ -16,7 +17,12 @@ PostgresTransactionManager::PostgresTransactionManager(duckdb::AttachedDatabase 
 
 duckdb::Transaction &
 PostgresTransactionManager::StartTransaction(duckdb::ClientContext &context) {
-	auto transaction = duckdb::make_uniq<PostgresTransaction>(*this, context, catalog, GetActiveSnapshot());
+	// In the PG-free worker (a worker session is active) there is no active snapshot; the
+	// transaction's snapshot is unused there (catalog is RPC'd, heap scans are inverted),
+	// so avoid GetActiveSnapshot() which asserts without one. Context-resolved because a
+	// nested query can start this transaction on a DuckDB scheduler thread.
+	Snapshot snap = pgddb::worker::EffectiveWorkerSession(&context) ? nullptr : GetActiveSnapshot();
+	auto transaction = duckdb::make_uniq<PostgresTransaction>(*this, context, catalog, snap);
 	auto &result = *transaction;
 	duckdb::lock_guard<duckdb::mutex> l(transaction_lock);
 	transactions[result] = std::move(transaction);

--- a/libpgduckdb/catalog/relation_desc.cpp
+++ b/libpgduckdb/catalog/relation_desc.cpp
@@ -1,0 +1,110 @@
+#include "pgddb/catalog/relation_desc.hpp"
+
+#include "pgddb/pg/relations.hpp"
+#include "pgddb/pgddb_process_lock.hpp"
+#include "pgddb/pgddb_types.hpp" // ConvertPostgresToDuckColumnType
+#include "pgddb/worker/transport/session_channel.hpp"
+#include "pgddb/worker/transport/session_protocol.hpp"
+
+#include <cstring>
+#include <exception>
+#include <string>
+
+#include <duckdb/common/serializer/memory_stream.hpp>
+#include <duckdb/common/types.hpp>
+
+extern "C" {
+#include "postgres.h"
+
+#include "utils/memutils.h" // TopMemoryContext
+#include "utils/rel.h"      // RelationGetRelid
+}
+
+namespace pgddb {
+
+#undef RelationGetDescr
+
+RelationDesc
+BuildRelationDesc(Relation rel) {
+	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+
+	RelationDesc desc;
+	desc.oid = RelationGetRelid(rel);
+	desc.qualified_name = pgddb::GenerateQualifiedRelationName(rel);
+	desc.name = pgddb::GetRelationName(rel);
+	desc.is_temporary = pgddb::RelationIsTemporary(rel);
+	desc.cardinality = pgddb::EstimateRelSize(rel);
+	// Only relations with physical storage have a main-fork block count; a partitioned
+	// parent (or other storage-less relkind) would crash RelationGetNumberOfBlocksInFork.
+	if (RELKIND_HAS_TABLE_AM(rel->rd_rel->relkind)) {
+		desc.nblocks = pgddb::RelationBlockCount(rel);
+	}
+
+	auto tuple_desc = pgddb::RelationGetDescr(rel);
+	const auto natts = pgddb::GetTupleDescNatts(tuple_desc);
+	for (int i = 0; i < natts; ++i) {
+		Form_pg_attribute attr = pgddb::GetAttr(tuple_desc, i);
+		if (pgddb::AttIsDropped(attr)) {
+			continue;
+		}
+		RelationColumn column;
+		column.attno = static_cast<AttrNumber>(i + 1);
+		column.name = pgddb::GetAttName(attr);
+		column.type = ConvertPostgresToDuckColumnType(attr);
+		desc.columns.emplace_back(std::move(column));
+	}
+
+	return desc;
+}
+
+void
+ServeDescribeRelation(SessionChannel &channel, const char *data, std::size_t len) {
+	std::string payload(data, len);
+	auto nul = payload.find('\0');
+	std::string schema = (nul == std::string::npos) ? payload : payload.substr(0, nul);
+	std::string table = (nul == std::string::npos) ? std::string() : payload.substr(nul + 1);
+
+	std::string error_text;
+	volatile bool found = false;
+	RelationDesc desc;
+	PG_TRY();
+	{
+		try {
+			Oid rel_oid = pgddb::GetRelidFromSchemaAndTable(schema.c_str(), table.c_str());
+			if (pgddb::IsValidOid(rel_oid)) {
+				Relation rel = pgddb::OpenRelation(rel_oid);
+				desc = BuildRelationDesc(rel);
+				pgddb::CloseRelation(rel);
+				found = true;
+			}
+		} catch (const std::exception &e) {
+			error_text = e.what();
+		}
+	}
+	PG_CATCH();
+	{
+		MemoryContext ctx = MemoryContextSwitchTo(TopMemoryContext);
+		ErrorData *edata = CopyErrorData();
+		FlushErrorState();
+		MemoryContextSwitchTo(ctx);
+		error_text = edata->message ? edata->message : "describe-relation error";
+		FreeErrorData(edata);
+	}
+	PG_END_TRY();
+
+	if (!error_text.empty()) {
+		channel.SendControl(FrameTag::DescribeRelError, error_text.c_str(), error_text.size());
+		return;
+	}
+	if (!found) {
+		const char *msg = "relation not found";
+		channel.SendControl(FrameTag::DescribeRelError, msg, std::strlen(msg));
+		return;
+	}
+	duckdb::MemoryStream stream;
+	SerializeRelationDesc(desc, stream);
+	channel.SendControl(FrameTag::DescribeRelResult, reinterpret_cast<const char *>(stream.GetData()),
+	                    stream.GetPosition());
+}
+
+} // namespace pgddb

--- a/libpgduckdb/include/pgddb/catalog/pgddb_table.hpp
+++ b/libpgduckdb/include/pgddb/catalog/pgddb_table.hpp
@@ -3,6 +3,7 @@
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/storage/table_storage_info.hpp"
 
+#include "pgddb/catalog/relation_desc.hpp"
 #include "pgddb/pg/declarations.hpp"
 
 #include "pgddb/utility/cpp_only_file.hpp" // Must be last include.
@@ -12,7 +13,7 @@ namespace pgddb {
 class PostgresTable : public duckdb::TableCatalogEntry {
 public:
 	PostgresTable(duckdb::Catalog &catalog, duckdb::SchemaCatalogEntry &schema, duckdb::CreateTableInfo &info,
-	              Relation rel, Cardinality cardinality, Snapshot snapshot);
+	              RelationDesc desc, Snapshot snapshot);
 
 	virtual ~PostgresTable();
 
@@ -23,11 +24,11 @@ public:
 	duckdb::TableStorageInfo GetStorageInfo(duckdb::ClientContext &context) override;
 
 	static Relation OpenRelation(Oid relid);
-	static void SetTableInfo(duckdb::CreateTableInfo &info, Relation rel);
+	static void CloseRelation(Relation rel);
+	static void SetTableInfo(duckdb::CreateTableInfo &info, const RelationDesc &desc);
 
 protected:
-	Relation rel;
-	Cardinality cardinality;
+	RelationDesc desc;
 	Snapshot snapshot;
 
 private:

--- a/libpgduckdb/include/pgddb/catalog/pgddb_transaction.hpp
+++ b/libpgduckdb/include/pgddb/catalog/pgddb_transaction.hpp
@@ -20,7 +20,7 @@ class SchemaItems {
 public:
 	SchemaItems(duckdb::unique_ptr<PostgresSchema> &&schema, const duckdb::string &name);
 
-	duckdb::optional_ptr<duckdb::CatalogEntry> GetTable(const duckdb::string &name);
+	duckdb::optional_ptr<duckdb::CatalogEntry> GetTable(const duckdb::string &name, duckdb::ClientContext *context);
 
 	duckdb::optional_ptr<duckdb::CatalogEntry> GetSchema() const;
 

--- a/libpgduckdb/include/pgddb/catalog/relation_desc.hpp
+++ b/libpgduckdb/include/pgddb/catalog/relation_desc.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "pgddb/pg/declarations.hpp"
+
+#include <duckdb/common/types.hpp>
+
+namespace pgddb {
+
+// One non-dropped column of a relation, materialized as plain data.
+struct RelationColumn {
+	AttrNumber attno = 0;                                      // 1-based PG attribute number
+	std::string name = {};                                     // attname
+	duckdb::LogicalType type = duckdb::LogicalTypeId::SQLNULL; // ConvertPostgresToDuckColumnType result
+};
+
+// Snapshot of everything the DuckDB catalog + scan path needs from a PG relation,
+// built once from a live Relation; holds no live handle afterwards.
+struct RelationDesc {
+	Oid oid = 0;                     // InvalidOid
+	std::string qualified_name = {}; // GenerateQualifiedRelationName (schema."table")
+	std::string name = {};           // RelationGetRelationName (unqualified)
+	bool is_temporary = false;
+	double cardinality = 0;
+	uint32_t nblocks = 0;                     // RelationBlockCount (main fork)
+	std::vector<RelationColumn> columns = {}; // non-dropped, in attno order
+};
+
+// Fill a RelationDesc from a live relation. Takes the GlobalProcessLock internally.
+RelationDesc BuildRelationDesc(Relation rel);
+
+class SessionChannel;
+
+// Backend side: handle a worker's DescribeRel request. `data`/`len` is the payload
+// `schema\0table`; opens the relation under the backend's catalog, builds a RelationDesc,
+// and ships it back as DescribeRelResult (or DescribeRelError on a missing relation /
+// error).
+void ServeDescribeRelation(SessionChannel &channel, const char *data, std::size_t len);
+
+} // namespace pgddb

--- a/libpgduckdb/include/pgddb/pg/relations.hpp
+++ b/libpgduckdb/include/pgddb/pg/relations.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "pgddb/pg/declarations.hpp"
 
 namespace pgddb {
@@ -27,6 +29,12 @@ void SlotGetAllAttrs(TupleTableSlot *slot);
 TupleTableSlot *ExecStoreMinimalTupleUnsafe(MinimalTuple minmal_tuple, TupleTableSlot *slot, bool shouldFree);
 
 double EstimateRelSize(Relation rel);
+
+// Physical block count of the relation's main fork (current file size).
+uint32_t RelationBlockCount(Relation rel);
+
+// True if the relation is a backend-local temporary table.
+bool RelationIsTemporary(Relation rel);
 
 Oid GetRelidFromSchemaAndTable(const char *, const char *);
 

--- a/libpgduckdb/include/pgddb/pgddb_planner.hpp
+++ b/libpgduckdb/include/pgddb/pgddb_planner.hpp
@@ -17,4 +17,7 @@ PlannedStmt *PlanNode(Query *parse, int cursor_options, bool throw_error);
 duckdb::unique_ptr<duckdb::PreparedStatement> Prepare(const Query *query, const char *explain_prefix = nullptr);
 bool ContainsPostgresTable(Node *node, void *context);
 
+// Deparse `query` back to the DuckDB-dialect SQL string the CustomScan executes.
+std::string DeparseQuery(const Query *query);
+
 } // namespace pgddb

--- a/libpgduckdb/include/pgddb/pgddb_types.hpp
+++ b/libpgduckdb/include/pgddb/pgddb_types.hpp
@@ -41,6 +41,12 @@ bool ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, uint
 void InsertTuplesIntoChunk(duckdb::DataChunk &output, PostgresScanLocalState &scan_local_state, TupleTableSlot **slots,
                            int num_slots);
 
+// Detoast + convert a PG numeric Datum to its DuckDB/Arrow DECIMAL scaled-integer
+// representation, written little-endian into `out` (width_bytes is 4, 8, or 16). The
+// value's own scale must equal the column scale (PG enforces this for typmod'd
+// columns), matching the DuckDB/Arrow decimal scale.
+void NumericToDecimalBytes(Datum value, int width_bytes, void *out);
+
 // Public helpers exposed for consumer-side hook implementations.
 bool IsNestedType(duckdb::LogicalTypeId type_id);
 const duckdb::LogicalType &GetChildType(const duckdb::LogicalType &type);

--- a/libpgduckdb/include/pgddb/scan/postgres_scan.hpp
+++ b/libpgduckdb/include/pgddb/scan/postgres_scan.hpp
@@ -4,17 +4,20 @@
 
 #include "duckdb/common/enums/order_type.hpp"
 
+#include "pgddb/catalog/relation_desc.hpp"
 #include "pgddb/pg/declarations.hpp"
 #include "pgddb/utility/allocator.hpp"
 
 #include "pgddb/scan/postgres_table_reader.hpp"
+#include "pgddb/worker/worker_dispatch.hpp"
 
 #include "pgddb/utility/cpp_only_file.hpp" // Must be last include.
 
 namespace pgddb {
 
 struct PostgresScanGlobalState : public duckdb::GlobalTableFunctionState {
-	explicit PostgresScanGlobalState(Snapshot, Relation rel, const duckdb::TableFunctionInitInput &input);
+	PostgresScanGlobalState(duckdb::ClientContext &context, Snapshot, const RelationDesc &desc,
+	                        const duckdb::TableFunctionInitInput &input);
 	~PostgresScanGlobalState();
 	idx_t
 	MaxThreads() const override {
@@ -32,16 +35,21 @@ private:
 
 public:
 	Snapshot snapshot;
-	Relation rel;
-	TupleDesc table_tuple_desc;
+	const RelationDesc &desc;
 	bool count_tuples_only;
 	duckdb::vector<AttrNumber> output_columns;
 	std::atomic<std::uint32_t> total_row_count;
 	std::atomic<std::int32_t> registered_local_states;
 	std::ostringstream scan_query;
+	// Byte offset in scan_query right after "FROM <relation>", where a remote scan-pool
+	// producer splices a CTID range predicate. 0 until ConstructTableScanQuery runs.
+	uint32_t remote_where_off = 0;
 	duckdb::shared_ptr<PostgresTableReader> table_reader_global_state;
 	MemoryContext duckdb_scan_memory_ctx;
 	idx_t max_threads;
+	// When set (worker session), the scan runs on the requesting backend and yields
+	// DataChunks; table_reader_global_state stays null and no PG is touched here.
+	duckdb::unique_ptr<RemoteScanStream> remote_scan;
 };
 
 #define LOCAL_STATE_SLOT_BATCH_SIZE 32
@@ -73,15 +81,14 @@ struct PostgresOrderBySpec {
 };
 
 struct PostgresScanFunctionData : public duckdb::TableFunctionData {
-	PostgresScanFunctionData(Relation rel, uint64_t cardinality, Snapshot snapshot);
+	PostgresScanFunctionData(RelationDesc desc, Snapshot snapshot);
 	~PostgresScanFunctionData() override;
 	duckdb::vector<duckdb::string> complex_filters;
 	duckdb::vector<PostgresOrderBySpec> order_bys;
 	// Set when a Top-N (ORDER BY + LIMIT) is pushed: emit LIMIT/OFFSET in the scan query.
 	duckdb::optional_idx limit;
 	duckdb::idx_t offset;
-	Relation rel;
-	uint64_t cardinality;
+	RelationDesc desc;
 	Snapshot snapshot;
 
 private:

--- a/libpgduckdb/include/pgddb/worker/duckdb_worker.hpp
+++ b/libpgduckdb/include/pgddb/worker/duckdb_worker.hpp
@@ -1,0 +1,123 @@
+#pragma once
+// The duckdb worker: everything generic about running a per-database DuckDB
+// background worker (registry + spawn, session-pool dispatch, the backend service
+// loop, session threads, the scan-producer pool). An extension subclasses
+// DuckdbWorker with its identity and engine accessors, constructs one instance,
+// and calls Init() from _PG_init.
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "pgddb/worker/transport/session_channel.hpp"
+#include "pgddb/worker/worker_dispatch.hpp"
+
+#include <duckdb/common/shared_ptr.hpp>
+
+namespace duckdb {
+class ClientContext;
+class DuckDB;
+} // namespace duckdb
+
+namespace pgddb {
+
+class DuckdbWorker {
+public:
+	struct Settings {
+		const char *shmem_name;            // unique ShmemInitStruct key prefix per extension
+		const char *bgw_library;           // the extension's shared library name
+		const char *bgw_worker_entrypoint; // extern "C" duckdb-worker entrypoint in the extension
+		const char *bgw_scan_entrypoint;   // extern "C" scan-worker entrypoint; nullptr = no scan pool
+		const char *display_name;          // prefix for bgworker names and log lines
+
+		// GUC value pointers; the extension registers the GUCs, the worker reads the values.
+		int *max_sessions; // session-pool slots = concurrent dispatched queries (PGC_POSTMASTER)
+		int *arrow_pool_pages;
+		int *arrow_page_size;
+		int *scan_pool_size;
+		int *scan_producers;
+	};
+
+	explicit DuckdbWorker(const Settings &settings);
+	virtual ~DuckdbWorker() = default;
+
+	// _PG_init: chain the shmem request/startup hooks, register the backend-side
+	// cleanup callbacks, and publish this instance for the entrypoints.
+	void Init();
+
+	// Backend: open a session to this database's duckdb worker (spawning it on
+	// demand), ship the active snapshot and the SQL, and return the result stream.
+	// When the session pool is full the backend WAITS for a slot (cancellable, so
+	// statement_timeout applies) -- it never falls back to in-process execution,
+	// which would recreate the per-backend engine blow-up under exactly the
+	// overload the shared worker exists to bound.
+	duckdb::unique_ptr<WorkerResultStream> OpenSession(const std::string &sql);
+
+	// Sessions this database's duckdb worker accepted since it started (diagnostics).
+	uint64_t DispatchCount() const;
+
+	// Entrypoint bodies. The extension's extern "C" bgworker functions (PostgreSQL
+	// resolves them by name) just call these.
+	void Main(uint32_t db_oid);
+	void ScanWorkerMain(uint32_t db_oid);
+
+	// True inside this extension's duckdb worker process (dispatch gates use it to
+	// never recurse into dispatch).
+	static bool InWorker();
+
+	// True when the worker is provisioned (max_worker_sessions > 0). When false no
+	// worker shared memory is reserved and dispatch must run in-process.
+	static bool Enabled();
+
+	// Backend side: serve an extension-specific control frame the worker sent (e.g.
+	// pg_ducklake's metadata RPC). Return false if the frame is not handled. Called
+	// by the session's result stream while it services the worker.
+	virtual bool
+	ServeFrame(SessionChannel & /*ch*/, FrameTag /*tag*/, const char * /*data*/, std::size_t /*len*/) {
+		return false;
+	}
+
+protected:
+	// Set per-worker DuckDB config; runs in the worker right after the bgworker's
+	// database connection is initialized, before the engine primes.
+	virtual void
+	Configure() {
+	}
+	// Initialize the engine once at worker startup (inside a transaction).
+	virtual void Prime() = 0;
+	// The shared DuckDB instance each session connects to.
+	virtual duckdb::DuckDB &Database() = 0;
+
+private:
+	friend struct WorkerAccess; // internal: session threads reach the engine accessors
+	Settings settings_;
+};
+
+// Functions in pgddb::worker run only inside the duckdb worker process.
+namespace worker {
+
+// Worker side: the session owning the DuckDB connection `ctx` executes on, or nullptr.
+// Code running on DuckDB scheduler threads (where the thread-local CurrentWorkerSession
+// is invisible) resolves its session through the executing ClientContext.
+SessionChannel *WorkerSessionForContext(duckdb::ClientContext *ctx);
+
+// The session serving the calling thread: the session thread's thread-local, or -- on a
+// DuckDB scheduler thread (e.g. a nested query's bind during execution) -- the session
+// keyed by `ctx`. nullptr outside a worker session.
+SessionChannel *EffectiveWorkerSession(duckdb::ClientContext *ctx);
+
+// Register `ctx` as served by the same session as `primary` (idempotent). A nested
+// connection created during execution (e.g. DuckLake's per-transaction metadata
+// connection running inlined-data reads) is otherwise invisible to the registry.
+// Takes the shared_ptr so the entry holds a weak_ptr: the worker main loop only
+// interrupts a context it can lock, never the raw (possibly stale) map key.
+// The caller MUST Unalias when the nested connection's owner dies, passing the
+// channel the alias was registered under (EffectiveWorkerSession at alias time):
+// the entry is erased only if its channel matches, so a later session whose
+// context reused the freed address is never evicted.
+void AliasWorkerSessionContext(const duckdb::shared_ptr<duckdb::ClientContext> &ctx, duckdb::ClientContext *primary);
+void UnaliasWorkerSessionContext(duckdb::ClientContext *ctx, SessionChannel *channel);
+
+} // namespace worker
+
+} // namespace pgddb

--- a/libpgduckdb/include/pgddb/worker/scan_producer.hpp
+++ b/libpgduckdb/include/pgddb/worker/scan_producer.hpp
@@ -1,0 +1,104 @@
+#pragma once
+// Heap-scan production for the duckdb worker's remote scans (kernel-internal, used by
+// duckdb_worker.cpp and the scan-producer worker main). The backend (scan inversion) and
+// the scan-pool workers share the same producer: a streaming PostgresTableReader whose
+// tuples are encoded as Arrow batches into shared pool pages (COUNT(*) is the one
+// serialized BIGINT chunk).
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "pgddb/pg/declarations.hpp"
+#include "pgddb/worker/transport/arrow_codec.hpp"
+#include "pgddb/worker/transport/scan_queue.hpp"
+#include "pgddb/worker/worker_dispatch.hpp"
+
+#include <duckdb/common/types/data_chunk.hpp>
+
+namespace pgddb {
+
+class PostgresTableReader;
+class SessionChannel;
+
+// A streaming heap-scan producer for one remote scan: runs the inner scan SQL through
+// the PG executor and converts pulled tuples one Arrow batch at a time -- no full
+// materialization, so producer memory stays bounded and the first batch ships as soon
+// as it is filled.
+struct BackendScanState {
+	BackendScanState();
+	BackendScanState(const BackendScanState &) = delete;
+	BackendScanState &operator=(const BackendScanState &) = delete;
+	duckdb::unique_ptr<PostgresTableReader> reader;
+	std::vector<TupleTableSlot *> slots;
+	duckdb::DataChunk chunk; // COUNT(*) only: the single BIGINT count chunk
+	int ncols = 0;
+	bool is_count = false;
+	bool done = false;
+	bool errored = false; // a produce error occurred; reply ScanError to later fetches
+	std::string err_msg;
+
+	// Per-column Arrow encoding (the only data transport; every column must be encodable).
+	std::vector<ArrowColCode> arrow_codes;
+	std::vector<uint8_t> arrow_prec, arrow_scale;
+	TupleTableSlot *carry = nullptr; // a row pulled but deferred to the next page (overflow)
+	bool has_carry = false;
+
+	// Free the reader (and the slots its executor state owns) once the scan is
+	// terminal: an open reader pins executor state and keeps the backend in parallel
+	// mode, which fails metadata servicing interleaved on the channel. Never throws.
+	void ReleaseReader();
+
+	~BackendScanState();
+};
+
+void InitBackendScan(BackendScanState &st, const std::string &sql, bool count_only);
+
+// Build one Arrow record batch into `page` from the reader. Returns the descriptor
+// length written to `desc_out` (>0), or 0 at end of scan. Throws if the column layout
+// cannot fit an empty batch in the page (no serialize fallback by design).
+ssize_t ProduceArrowChunk(BackendScanState &st, char *page, std::size_t capacity, int page_index, char *desc_out,
+                          std::size_t desc_cap);
+
+// COUNT(*): sum the reader's partial counts into st.chunk as one BIGINT. Returns false
+// once already produced.
+bool ProduceCountChunk(BackendScanState &st);
+
+// pgddb::producer runs only in the dedicated scan-producer bgworker processes.
+namespace producer {
+
+// Scan-worker side: run one claimed scan task in its own transaction under the
+// requesting backend's shipped snapshot, pushing pages into the scan's ready-ring.
+void ProcessScanRange(const ScanRange &range);
+
+// Scan-worker side: the range ProcessScanRange is working on (set on the worker's
+// only thread). The scan worker's shmem-exit callback errors it out on FATAL, which
+// runs shmem-exit callbacks but skips PG_CATCH.
+extern ScanRange g_active_range;
+extern bool g_have_active_range;
+// Pool page the producer currently owns (-1 = none); the shmem-exit hook frees it
+// on FATAL, where the PG_CATCH release is skipped.
+extern int g_held_page;
+
+} // namespace producer
+
+// pgddb::worker runs only inside the duckdb worker process.
+namespace worker {
+
+// Worker side: the per-fetch scan-inversion stream over the session channel.
+duckdb::unique_ptr<RemoteScanStream> OpenInversionScanStream(SessionChannel *ch, const std::string &sql,
+                                                             bool count_only);
+
+// Worker side: register the scan with the ready-ring, split it into up to `producers`
+// block-range tasks, and return the pool-fed stream; nullptr if registration or
+// enqueueing failed (caller falls back to the inversion stream). `ch` is the session's
+// channel: the stream polls its cancel flag while waiting for producers.
+duckdb::unique_ptr<RemoteScanStream> OpenPoolScanStream(SessionChannel *ch, uint32_t db_oid,
+                                                        const std::string &scan_sql, bool count_only,
+                                                        const RemoteScanInfo &info, const std::string &snapshot_bytes,
+                                                        int producers);
+
+} // namespace worker
+
+} // namespace pgddb

--- a/libpgduckdb/include/pgddb/worker/transport/arrow_codec.hpp
+++ b/libpgduckdb/include/pgddb/worker/transport/arrow_codec.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "pgddb/pg/declarations.hpp"
+
+#include <duckdb/common/types.hpp>
+
+// The arrow codec: direct PG-heap -> Apache Arrow producer and the matching consumer
+// import, for the duckdb worker's zero-copy scan transport. The producer writes Arrow buffers
+// for a record batch straight into a shared pool page (no DuckDB DataChunk on the
+// backend); the consumer builds an ArrowArray over the page and imports it into a
+// DuckDB DataChunk, referencing the page for fixed-width columns (no per-value copy).
+namespace duckdb {
+class ClientContext;
+class DataChunk;
+} // namespace duckdb
+
+namespace pgddb {
+
+// Arrow physical encoding chosen per column. Fixed-width codes store the value
+// inline; Utf8 uses int32 offsets + a data buffer.
+enum class ArrowColCode : uint8_t {
+	Unsupported = 0,
+	Int16 = 1,
+	Int32 = 2,
+	Int64 = 3,
+	Float = 4,
+	Double = 5,
+	Date32 = 6,
+	Bool = 7, // bit-packed like a validity bitmap
+	Utf8 = 8,
+	Decimal32 = 9,
+	Decimal64 = 10,
+	Decimal128 = 11,
+	TimestampUs = 12,   // microseconds since the unix epoch, no time zone
+	TimestampTzUs = 13, // microseconds since the unix epoch, UTC
+	Binary = 14,        // like Utf8: int32 offsets + a data buffer (bytea / BLOB)
+};
+
+// Per-column entry in the batch descriptor sent over the control queue.
+struct ArrowColDesc {
+	uint8_t code; // ArrowColCode
+	uint8_t precision;
+	uint8_t scale;
+	uint8_t pad;
+	int64_t null_count;
+	uint32_t validity_off, validity_len;
+	uint32_t buf1_off, buf1_len; // fixed values, or utf8 int32 offsets
+	uint32_t buf2_off, buf2_len; // utf8 data (0 otherwise)
+};
+
+struct ArrowBatchHeader {
+	uint32_t page_index;
+	uint32_t nrows;
+	uint32_t ncols;
+};
+
+// Per-column value writer, resolved once per batch (mirrors GetPostgresToDuckValueFn).
+using ArrowAppendValueFn = void (*)(char *values, int row, Datum value);
+
+// Choose the Arrow encoding for a PG column given its type and the DuckDB type the
+// scan bound it to. Returns false (Unsupported) if the column can't take the Arrow
+// fast path, in which case the whole batch falls back to the serialize transport.
+bool ArrowColumnSpec(Oid pg_type, const duckdb::LogicalType &duck_type, ArrowColCode &code, uint8_t &precision,
+                     uint8_t &scale);
+
+// Builds one Arrow record batch into a page. Fixed buffers (validity, values, utf8
+// offsets, bool bitmap) are written directly into the page at reserved offsets;
+// utf8 data is staged and placed contiguously per column at Finalize.
+class ArrowBatchBuilder {
+public:
+	ArrowBatchBuilder(char *page, std::size_t capacity, const std::vector<ArrowColCode> &codes,
+	                  const std::vector<uint8_t> &precisions, const std::vector<uint8_t> &scales, int max_rows);
+	ArrowBatchBuilder(const ArrowBatchBuilder &) = delete;
+	ArrowBatchBuilder &operator=(const ArrowBatchBuilder &) = delete;
+	bool
+	LayoutOk() const {
+		return layout_ok_;
+	}
+	// Append one row (all columns) from a deformed slot (slot_getallattrs already
+	// called). Returns false if the page would overflow -> caller falls back.
+	bool AppendSlot(TupleTableSlot *slot);
+	int
+	Rows() const {
+		return nrows_;
+	}
+	// Place staged utf8 data into the page and write the descriptor (header + col
+	// descs) into `out`; returns descriptor byte length.
+	std::size_t Finalize(int page_index, char *out, std::size_t out_cap);
+
+private:
+	char *page_;
+	std::size_t capacity_;
+	std::vector<ArrowColCode> codes_;
+	std::vector<uint8_t> precisions_;
+	std::vector<uint8_t> scales_;
+	int max_rows_;
+	int nrows_ = 0;
+	bool layout_ok_ = true;
+
+	std::vector<uint32_t> validity_off_, values_off_; // per column, into page
+	std::vector<uint32_t> elem_width_;                // fixed-width element size (bytes)
+	std::vector<ArrowAppendValueFn> append_fn_;       // per-column writer, resolved once
+	std::vector<uint8_t> is_varlen_;
+	std::vector<int64_t> null_count_;
+	std::vector<std::string> utf8_data_; // staged per-column utf8 bytes
+	std::size_t fixed_end_ = 0;          // page offset where utf8 data may be placed
+};
+
+// Consumer: import a batch (page + descriptor) into `out`, typed to `output_types`.
+// `on_release` is invoked (once) when DuckDB drops the last vector referencing the
+// page, so the caller can return the page to the pool.
+void ImportArrowBatch(duckdb::ClientContext &context, char *page, const char *descriptor, std::size_t desc_len,
+                      const duckdb::vector<duckdb::LogicalType> &output_types, duckdb::DataChunk &out,
+                      std::function<void()> on_release);
+
+} // namespace pgddb

--- a/libpgduckdb/include/pgddb/worker/transport/page_pool.hpp
+++ b/libpgduckdb/include/pgddb/worker/transport/page_pool.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cstddef>
+
+// A global fixed-size pool of equal-size shared-memory pages (scan pages): the zero-copy
+// transport area for Arrow record batches. It lives in PostgreSQL main shared memory and
+// is mapped at the same address in every backend and background worker via fork, so a
+// page's address is valid in every process; a scan page travels between processes by its
+// integer index (carried in a scan ring). A spinlock-guarded free stack hands pages out
+// and back: a scan worker (or the backend) Acquires a page, a DuckDB thread Releases it
+// once the chunk referencing it is dropped.
+//
+// Attach once per process at startup (shmem_startup_hook, main thread); after that a
+// PagePool handle is a cheap thin binding to the one shared segment -- many handles may
+// coexist (one per DuckDB thread) and Acquire/Release are thread-safe via the spinlock.
+namespace pgddb {
+
+// A scan page handed out by the pool. `index` identifies it across processes (it is what
+// travels in a scan ring); `data` is its address in this process.
+struct PageSlot {
+	int index;
+	char *data;
+};
+
+class PagePool {
+public:
+	// Bind a handle to the process-global pool (cheap; valid only after Attach). All
+	// handles in a process refer to the one shared segment.
+	PagePool() = default;
+
+	// --- process / segment setup (main thread, under the shmem init lock) ---
+	static std::size_t ShmemSize(int total_pages, int page_size);
+	// Initialize a freshly-created segment (first process only).
+	static void Init(void *shmem, int total_pages, int page_size);
+	// Point this process at the segment and build its page-slot table. Call in every
+	// process at startup, after Init has run in the first.
+	static void Attach(void *shmem);
+
+	// --- handle API ---
+	bool Available() const;
+	int PageSize() const;
+	int TotalPages() const;
+
+	// Acquire a free scan page, or nullptr if the pool is momentarily empty.
+	PageSlot *Acquire();
+	// Return a scan page to the pool.
+	void Release(PageSlot *slot);
+	// The slot for a page index (to release a page drained from a scan ring by index).
+	PageSlot *Slot(int index);
+};
+
+} // namespace pgddb

--- a/libpgduckdb/include/pgddb/worker/transport/scan_queue.hpp
+++ b/libpgduckdb/include/pgddb/worker/transport/scan_queue.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Shared scan task queue: a bounded task ring feeding the scan worker pool, plus the
+// table of scan-worker latches used to wake idle producers when a task is enqueued. The
+// duckdb worker (consumer) enqueues one block-range task per slice; idle scan workers
+// publish their latch, then claim tasks for their database. State lives in PostgreSQL
+// main shared memory (same address in every process via fork). The PostgreSQL/IPC types
+// are confined to the implementation, like page_pool.
+namespace pgddb {
+
+// A claimed unit of work: one block range of one registered scan. The scan-registry slot
+// is the low 8 bits of scan_id (see ScanRing); generation detects teardown/reuse.
+struct ScanRange {
+	uint32_t scan_id;
+	uint32_t generation;
+	uint32_t lo_blk; // inclusive start block (0 = relation start)
+	uint32_t hi_blk; // exclusive end block (0 = relation end / no upper bound)
+};
+
+// Attach once per process at startup (shmem_startup_hook, main thread); after that a
+// ScanQueue handle is a cheap thin binding to the one shared segment.
+class ScanQueue {
+public:
+	ScanQueue() = default;
+
+	static std::size_t ShmemSize();
+	static void Init(void *shmem);
+	static void Attach(void *shmem);
+	static bool Available();
+
+	// Enqueue one block-range task for a registered scan and wake an idle scan worker for
+	// its database. Returns false if the scan is gone or the task ring is full.
+	bool Enqueue(uint32_t db_oid, uint32_t scan_id, uint32_t generation, uint32_t lo_blk, uint32_t hi_blk);
+
+	// Claim the next queued task for `db_oid`, or return false if none is ready now.
+	bool Claim(uint32_t db_oid, ScanRange *out);
+
+	// Publish this worker's latch for `db_oid` so enqueues can wake it; idempotent.
+	void PublishWorker(uint32_t db_oid);
+
+	// Release this worker's published latch slot(s); call on worker exit.
+	void UnpublishWorker();
+};
+
+} // namespace pgddb

--- a/libpgduckdb/include/pgddb/worker/transport/scan_ring.hpp
+++ b/libpgduckdb/include/pgddb/worker/transport/scan_ring.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Per-scan ready-page rings: a table of scan tasks keyed by scan id, each holding the
+// scan's inputs (deparsed SQL + serialized snapshot), task counters, and a ready-ring of
+// produced pages. The duckdb worker (consumer) opens a scan and drains its ring; the
+// scan workers (producers) push pages into it, keyed by (scan_id,
+// generation). State lives in PostgreSQL main shared memory (same address in every
+// process via fork), so pages are shared by index. The PostgreSQL/IPC types are confined
+// to the implementation, like page_pool.
+namespace pgddb {
+
+// Handle to an opened scan. scan_id == 0 means open failed (no slot / inputs too large);
+// the low 8 bits of scan_id encode the registry slot. generation detects teardown/reuse.
+struct ScanHandle {
+	uint32_t scan_id;
+	uint32_t generation;
+};
+
+// Attach once per process at startup (shmem_startup_hook, main thread); after that a
+// ScanRing handle is a cheap thin binding to the one shared segment.
+class ScanRing {
+public:
+	ScanRing() = default;
+
+	static std::size_t ShmemSize();
+	static void Init(void *shmem);
+	static void Attach(void *shmem);
+	static bool Available();
+
+	// Bytes reserved at the front of each pool page for an Arrow batch descriptor; the
+	// producer writes Arrow data after this offset and the descriptor into [0, desc_len).
+	static std::size_t DescReserve();
+
+	// --- Consumer (duckdb worker) ---
+
+	// Open a scan and copy its inputs (deparsed SQL + serialized snapshot) into a slot.
+	// `ntasks` is how many block-range tasks will be enqueued. Returns a handle with a
+	// non-zero scan_id, or scan_id == 0 if no slot is free or the inputs do not fit.
+	ScanHandle Open(uint32_t db_oid, const char *sql, std::size_t sql_len, const char *snap, std::size_t snap_len,
+	                bool count_only, uint32_t where_off, uint32_t ntasks);
+
+	// Try to pop the next ready chunk. Returns 1 (ready: fills page_index and exactly one
+	// of desc_len>0 [Arrow] / byte_len>0 [serialized]), 0 (scan finished and drained),
+	// -1 (error: message copied into errbuf), or 2 (nothing ready yet -- caller waits).
+	int TryNext(uint32_t scan_id, uint32_t *page_index, uint32_t *desc_len, uint32_t *byte_len, char *errbuf,
+	            std::size_t errcap);
+
+	// Tear a scan down: bump its generation so in-flight producers stop, and release any
+	// pages still queued in its ready-ring through `release_page`.
+	void Close(uint32_t scan_id, void (*release_page)(int));
+
+	// --- Producer (scan worker) ---
+
+	// Copy a scan's inputs into caller buffers; false if the slot was torn down.
+	// `where_off` is the CTID-predicate splice offset into `sql` (see RemoteScanInfo).
+	bool GetInputs(uint32_t scan_id, uint32_t generation, char *sql, std::size_t sqlcap, std::size_t *sqllen,
+	               char *snap, std::size_t snapcap, std::size_t *snaplen, bool *count_only, uint32_t *where_off);
+
+	// True while the scan is still alive (generation matches).
+	bool Alive(uint32_t scan_id, uint32_t generation);
+
+	// Push a ready chunk into the scan's ready-ring. Blocks while the ring is full (until
+	// the consumer drains or the scan is torn down). Returns false if the scan was torn
+	// down (caller must free the page itself); the chunk is dropped in that case.
+	bool Push(uint32_t scan_id, uint32_t generation, uint32_t page_index, uint32_t desc_len, uint32_t byte_len);
+
+	// Mark this task finished; the last task of a scan marks the scan finished so the
+	// consumer's drain returns end-of-scan once the ring empties.
+	void TaskDone(uint32_t scan_id, uint32_t generation);
+
+	// Record a producer error for the scan; the consumer's next drain throws it.
+	void SetError(uint32_t scan_id, uint32_t generation, const char *msg);
+};
+
+} // namespace pgddb

--- a/libpgduckdb/include/pgddb/worker/transport/session_channel.hpp
+++ b/libpgduckdb/include/pgddb/worker/transport/session_channel.hpp
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace pgddb {
+
+// Wire frame kinds. The control queue carries Sql/Snapshot (backend -> worker) and the
+// backend's answers to the worker's requests; the result queue carries Chunk/Complete/
+// Error and the worker's requests back to the backend (MetaQuery, ScanFetch).
+enum class FrameTag : uint8_t {
+	Sql = 1,
+	Chunk = 3,
+	Complete = 4,
+	Error = 5,
+	Snapshot = 6,           // control: the requesting backend's serialized MVCC snapshot
+	MetaQuery = 7,          // result-queue: worker asks the backend to run a metadata SQL
+	MetaResult = 8,         // control: backend's serialized result for a MetaQuery
+	MetaError = 9,          // control: backend's error message for a MetaQuery
+	ScanFetch = 10,         // result-queue: worker asks the backend for the next chunk of a heap scan
+	ScanChunk = 11,         // control: backend's next serialized DataChunk for a heap scan (inline bytes)
+	ScanDone = 12,          // control: heap scan exhausted
+	ScanError = 13,         // control: backend error while producing a heap scan
+	ScanChunkArrow = 15,    // control: next chunk is an Arrow batch in a global pool page; payload is the descriptor
+	DescribeRel = 16,       // result-queue: worker asks the backend to describe schema.table
+	DescribeRelResult = 17, // control: backend's serialized RelationDesc
+	DescribeRelError = 18,  // control: backend error (e.g. relation not found)
+	MetaExec = 19,          // result-queue: worker asks the backend to run a metadata write (subtransaction)
+};
+
+enum class FrameResult { Ok, WouldBlock, Detached };
+
+// The shared-memory transport for one duckdb query: a small header (a cooperative
+// cancel flag) plus two shm_mq rings -- a control queue (backend -> worker) and a
+// result queue (worker -> backend) -- laid out in a fixed session-slot region (see
+// SessionPool). The backend opens the slot (creates the rings) and the worker
+// attaches to the same region. The rings are recreated per query, so a slot is reused
+// across queries without allocating shared memory. PostgreSQL/IPC types stay in the impl.
+class SessionChannel {
+public:
+	~SessionChannel();
+
+	// Bytes a slot's channel region needs (header + the two rings).
+	static std::size_t ChannelRegionBytes();
+
+	// Backend side: (re)create the rings in the slot region `base` and bind this
+	// process as control-sender / result-receiver. Returns nullptr on failure.
+	static std::unique_ptr<SessionChannel> OpenSlot(char *base);
+	// Worker side: attach to the rings already created at `base`, as control-receiver /
+	// result-sender. Returns nullptr on failure.
+	static std::unique_ptr<SessionChannel> AttachSlot(char *base);
+
+	// Control queue: backend sends, worker receives. Send blocks (backpressure)
+	// until space is available or the peer detaches.
+	bool SendControl(FrameTag tag, const char *data, std::size_t len);
+	FrameResult RecvControl(FrameTag *tag, const char **data, std::size_t *len, bool nowait);
+
+	// Result queue: worker sends, backend receives.
+	FrameResult RecvResult(FrameTag *tag, const char **data, std::size_t *len, bool nowait);
+
+	// Multi-threaded duckdb-worker transport: serialize each poke under the global
+	// process lock, dropping it between non-blocking attempts so a session thread never
+	// blocks holding it (MyLatch stays owned by the worker main loop). Return false /
+	// Detached on peer detach or cancel.
+	bool SerializedSendResult(FrameTag tag, const char *data, std::size_t len);
+	// Raw serialized receive; only safe for the session handshake (Snapshot + Sql),
+	// before any concurrent requesters exist -- afterwards use the routed receives.
+	FrameResult SerializedRecvControl(FrameTag *tag, const char **data, std::size_t *len);
+
+	// Routed worker-side receives: several threads of one session (scan streams on
+	// DuckDB scheduler threads, metadata RPCs) share the control queue, so incoming
+	// frames are demultiplexed into lanes -- per-scan lanes keyed by the scan_id prefix
+	// of scan replies, and one metadata lane (Meta*/DescribeRel* replies). Each call
+	// returns the next frame of its lane (payload copied out), polling the queue and
+	// routing stray frames to their lanes; Detached on peer detach, cancel, or drain.
+	FrameResult RecvMetaReply(FrameTag *tag, std::string *payload);
+	FrameResult RecvScanReply(uint32_t scan_id, FrameTag *tag, std::string *payload);
+	// Serialize whole metadata round-trips: replies carry no request id, so only one
+	// metadata request may be in flight per channel.
+	std::mutex &MetaRequestMutex();
+	// Drop a scan's lane, handing any still-buffered frames to `on_frame` (so the
+	// caller can free Arrow pages a drained frame owns).
+	void CloseScanLane(uint32_t scan_id, const std::function<void(FrameTag, const std::string &)> &on_frame);
+
+	// Cooperative cancellation: backend sets, worker polls.
+	void RequestCancel();
+	bool IsCancelRequested() const;
+	// Set the cancel flag directly in a slot region (no channel object needed): the
+	// backend's abort path uses it when a longjmp skipped the channel destructor.
+	static void RequestCancelAt(char *base);
+
+private:
+	struct State;
+	std::unique_ptr<State> state_;
+	SessionChannel();
+	FrameResult RoutedRecv(bool meta, uint32_t scan_id, FrameTag *tag, std::string *payload);
+};
+
+// The session the calling worker thread is executing, or nullptr (thread-local; each
+// session runs on its own thread). Set around each query so PG-touching code that runs
+// on the session thread (binding, the DuckLake metadata manager) can route its queries
+// back to the requesting backend instead of doing local SPI. Scheduler threads resolve
+// their session via EffectiveWorkerSession (duckdb_worker.hpp) instead.
+void SetCurrentWorkerSession(SessionChannel *channel);
+SessionChannel *CurrentWorkerSession();
+
+// Signal the multi-threaded worker's session-thread transport polls to bail (shutdown).
+void SetWorkerDraining(bool draining);
+bool IsWorkerDraining();
+
+} // namespace pgddb

--- a/libpgduckdb/include/pgddb/worker/transport/session_pool.hpp
+++ b/libpgduckdb/include/pgddb/worker/transport/session_pool.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// A fixed pool of session slots (one per concurrent dispatched query) in PostgreSQL main shared memory. Each slot
+// holds one SessionChannel's region (control + result rings) at a stable address, reused
+// across queries instead of allocating a dsm segment per query. A backend Acquires a free
+// slot, opens its channel, and hands the slot index to the duckdb worker; the worker
+// attaches to the same slot. The slot returns to the pool only after BOTH ends have
+// detached (an attach refcount), so its rings are never recreated while still mapped.
+namespace pgddb {
+
+class SessionPool {
+public:
+	SessionPool() = default;
+
+	// --- segment setup (main thread, under the shmem init lock) ---
+	static std::size_t ShmemSize(int nslots);
+	static void Init(void *shmem, int nslots);
+	static void Attach(void *shmem);
+
+	static bool Available();
+	static int NumSlots();
+
+	// Backend: claim a free slot (state FREE -> IN_USE, generation bumped), or -1 if
+	// all are occupied.
+	int Acquire();
+	// The slot's current generation (as of Acquire). A pending-session entry carries
+	// it so the worker never attaches a slot that was released and re-acquired after
+	// the entry was queued (TryAttachEnd validates it).
+	uint32_t Generation(int idx);
+	// Base address of slot `idx`'s channel region (for SessionChannel::Open/AttachSlot).
+	char *ChannelBase(int idx);
+	// Mark one end attached (call right after OpenSlot/AttachSlot).
+	void AttachEnd(int idx);
+	// Worker: attach only if the slot is still IN_USE at `generation`; false means the
+	// backend released it (the queued session is stale) and it must not be served.
+	bool TryAttachEnd(int idx, uint32_t generation);
+	// Mark one end detached (call right after the SessionChannel is destroyed). When the
+	// last end detaches, the slot returns to the pool.
+	void DetachEnd(int idx);
+};
+
+} // namespace pgddb

--- a/libpgduckdb/include/pgddb/worker/transport/session_protocol.hpp
+++ b/libpgduckdb/include/pgddb/worker/transport/session_protocol.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include <duckdb/main/query_result.hpp>
+
+#include "pgddb/catalog/relation_desc.hpp"
+
+namespace duckdb {
+class DataChunk;
+class MemoryStream;
+} // namespace duckdb
+
+namespace pgddb {
+
+class SessionChannel;
+
+// Serialize `chunk` into `out`; the resulting bytes (out.GetData(),
+// out.GetPosition()) are position-independent and safe to ship across a process
+// boundary to another process linking the same DuckDB build. DeserializeDataChunk
+// reconstructs the chunk from those bytes.
+void SerializeDataChunk(duckdb::DataChunk &chunk, duckdb::MemoryStream &out);
+void DeserializeDataChunk(const char *data, std::size_t len, duckdb::DataChunk &out);
+
+// Serialize a whole materialized query result (column names + types + all rows)
+// into `out`, and rebuild it as a MaterializedQueryResult on the other side. Used
+// to ship metadata-query results from a backend to the PG-free duckdb worker.
+// SerializeQueryResult drains `result`.
+void SerializeQueryResult(duckdb::QueryResult &result, duckdb::MemoryStream &out);
+duckdb::unique_ptr<duckdb::QueryResult> DeserializeQueryResult(const char *data, std::size_t len);
+
+// Worker side: send `sql` to the requesting backend as a MetaQuery (read) or MetaExec
+// (write, run in a subtransaction on the backend) and wait for the backend's MetaResult,
+// rebuilt as a MaterializedQueryResult (or an error result if the backend reported one /
+// the channel detached). Session-thread-safe (serialized transport). The backend answers
+// with SendMetadataReply.
+duckdb::unique_ptr<duckdb::QueryResult> WorkerMetadataQuery(SessionChannel &channel, const std::string &sql);
+duckdb::unique_ptr<duckdb::QueryResult> WorkerMetadataExec(SessionChannel &channel, const std::string &sql);
+
+// Backend side: ship `result` back as MetaResult, or -- when it carries an error -- as
+// a MetaError that preserves the duckdb exception type (so e.g. a TransactionException
+// from a metadata write conflict is rethrown as one in the worker).
+void SendMetadataReply(SessionChannel &channel, duckdb::QueryResult &result);
+void SendMetadataError(SessionChannel &channel, duckdb::ExceptionType type, const std::string &msg);
+
+// Serialize a RelationDesc into `out` / rebuild one from those bytes, so a relation
+// descriptor can be shipped from a backend to the PG-free duckdb worker.
+void SerializeRelationDesc(const RelationDesc &desc, duckdb::MemoryStream &out);
+RelationDesc DeserializeRelationDesc(const char *data, std::size_t len);
+
+// Worker side: ask the requesting backend to describe `schema`.`table` and block for
+// the backend's DescribeRelResult, rebuilt as a RelationDesc. Throws on a backend error
+// (e.g. relation not found) or a detached channel.
+RelationDesc WorkerDescribeRelation(SessionChannel &channel, const std::string &schema, const std::string &table);
+
+} // namespace pgddb

--- a/libpgduckdb/include/pgddb/worker/worker_dispatch.hpp
+++ b/libpgduckdb/include/pgddb/worker/worker_dispatch.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "pgddb/pg/declarations.hpp"
+
+#include <duckdb/common/types/data_chunk.hpp>
+
+namespace pgddb {
+
+// A pull-based stream of result DataChunks produced by external (shared-worker)
+// execution. Fetch() returns the next chunk, or nullptr at end of stream; it
+// throws a duckdb::Exception on worker-side error or cancellation.
+class WorkerResultStream {
+public:
+	virtual ~WorkerResultStream() = default;
+	virtual duckdb::unique_ptr<duckdb::DataChunk> Fetch() = 0;
+};
+
+// Installed by an extension. Given a query, returns a result stream when the query
+// should run in the shared worker, or nullptr to execute in-process. The CustomScan
+// consults it only for non-EXPLAIN statements; the hook deparses the query itself
+// (via DeparseQuery) only once it has decided to dispatch, so ineligible queries
+// pay no deparse cost.
+using DispatchToWorkerHook = duckdb::unique_ptr<WorkerResultStream> (*)(const Query *query);
+extern DispatchToWorkerHook pgddb_dispatch_to_worker_hook;
+
+// A pull-based stream of DataChunks produced by running a PG-heap scan on the
+// requesting backend (scan inversion). Next() returns the next chunk, or nullptr at
+// end of scan. For a COUNT(*) scan, the first chunk's first cell is the BIGINT count.
+// `context` and `output_types` (the scan's projected DuckDB column types) let an
+// Arrow-backed implementation import a record batch into a chunk of the right types.
+class RemoteScanStream {
+public:
+	virtual ~RemoteScanStream() = default;
+	virtual duckdb::unique_ptr<duckdb::DataChunk> Next(duckdb::ClientContext &context,
+	                                                   const duckdb::vector<duckdb::LogicalType> &output_types) = 0;
+};
+
+// Extra information the kernel scan supplies for a remote scan, computed once during
+// init_global (main thread, relation open). Lets a scan worker pool split the scan
+// into disjoint CTID block ranges. `nblocks` is the relation's current block count,
+// `where_off` is the byte offset in `scan_sql` right after the FROM <relation> clause
+// (where a CTID predicate is spliced), and `rangeable` is true when the scan has no
+// ORDER BY/LIMIT (Top-N) and is not a COUNT(*), so block-range splitting is safe.
+struct RemoteScanInfo {
+	uint32_t nblocks;
+	uint32_t where_off;
+	bool rangeable;
+	// True if the relation is backend-local (temporary): such a scan must run on the
+	// requesting backend (inversion), never in separate scan-pool processes that
+	// cannot see another backend's temp tables.
+	bool local_relation;
+};
+
+// Installed by an extension running inside the shared worker. When set, a PG-heap
+// scan runs its inner SQL (`scan_sql`, referencing the real relation) on the
+// requesting backend (or a scan worker pool) instead of via PostgresTableReader, so
+// the worker's execution threads make no PostgreSQL calls. nullptr means "run in-process".
+// `context` is the executing connection's ClientContext: the scan's init_global runs on a
+// DuckDB scheduler thread (not the session thread), so the worker keys the session's
+// channel + shipped snapshot by this context rather than by thread-local state.
+using OpenRemoteScanHook = duckdb::unique_ptr<RemoteScanStream> (*)(duckdb::ClientContext &context,
+                                                                    const std::string &scan_sql, bool count_only,
+                                                                    const RemoteScanInfo &info);
+extern OpenRemoteScanHook pgddb_open_remote_scan_hook;
+
+} // namespace pgddb

--- a/libpgduckdb/include/pgddb/worker/worker_session.hpp
+++ b/libpgduckdb/include/pgddb/worker/worker_session.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+
+namespace duckdb {
+class Connection;
+}
+
+namespace pgddb {
+
+class SessionChannel;
+
+// Runs only inside the duckdb worker process.
+namespace worker {
+
+// Execute `sql` on `con` and stream the result to `channel`: one Chunk frame per
+// result DataChunk, then a Complete frame; on failure, a single Error frame whose
+// payload is the message text. Polls the channel's cancel flag between chunks and
+// interrupts the running query if cancellation was requested.
+void RunWorkerSession(duckdb::Connection &con, SessionChannel &channel, const std::string &sql);
+
+} // namespace worker
+
+} // namespace pgddb

--- a/libpgduckdb/pg/relations.cpp
+++ b/libpgduckdb/pg/relations.cpp
@@ -8,6 +8,7 @@ extern "C" {
 #include "access/relation.h"     // relation_open and relation_close
 #include "catalog/namespace.h"   // makeRangeVarFromNameList, RangeVarGetRelid
 #include "optimizer/plancat.h"   // estimate_rel_size
+#include "storage/bufmgr.h"      // RelationGetNumberOfBlocks
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
@@ -102,6 +103,16 @@ CloseRelation(Relation rel) {
 	PostgresFunctionGuard(relation_close, rel, NoLock);
 
 	CurrentResourceOwner = saveResourceOwner;
+}
+
+uint32_t
+RelationBlockCount(Relation rel) {
+	return (uint32_t)PostgresFunctionGuard(RelationGetNumberOfBlocksInFork, rel, MAIN_FORKNUM);
+}
+
+bool
+RelationIsTemporary(Relation rel) {
+	return rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP;
 }
 
 double

--- a/libpgduckdb/pgddb_node.cpp
+++ b/libpgduckdb/pgddb_node.cpp
@@ -4,6 +4,7 @@
 
 #include "pgddb/pgddb_planner.hpp"
 #include "pgddb/pgddb_types.hpp"
+#include "pgddb/worker/worker_dispatch.hpp"
 #include "pgddb/vendor/pg_explain.hpp"
 #include "pgddb/pg/explain.hpp"
 
@@ -29,6 +30,9 @@ duckdb::ExplainFormat explain_format = duckdb::ExplainFormat::DEFAULT;
 
 CustomScanMethods scan_methods;
 
+DispatchToWorkerHook pgddb_dispatch_to_worker_hook = nullptr;
+OpenRemoteScanHook pgddb_open_remote_scan_hook = nullptr;
+
 static CustomExecMethods scan_exec_methods;
 
 typedef struct DuckdbScanState {
@@ -44,6 +48,7 @@ typedef struct DuckdbScanState {
 	duckdb::idx_t column_count;
 	duckdb::unique_ptr<duckdb::DataChunk> current_data_chunk;
 	duckdb::idx_t current_row;
+	duckdb::unique_ptr<WorkerResultStream> worker_stream;
 } DuckdbScanState;
 
 static void
@@ -53,6 +58,7 @@ CleanupDuckdbScanState(DuckdbScanState *state) {
 
 	state->query_results.reset();
 	state->current_data_chunk.reset();
+	state->worker_stream.reset();
 
 	if (state->prepared_statement) {
 		delete state->prepared_statement;
@@ -142,8 +148,22 @@ Duckdb_BeginCustomScan_Cpp(CustomScanState *cscanstate, EState *estate, int /*ef
 		}
 	}
 
-	duckdb_scan_state->duckdb_connection = pgddb::GetConnection();
-	duckdb_scan_state->prepared_statement = prepared_query.release();
+	// Dispatch to the shared worker when an extension opts in; else execute in-process.
+	if (!is_explain_query && pgddb::pgddb_dispatch_to_worker_hook != nullptr) {
+		auto stream = pgddb::pgddb_dispatch_to_worker_hook(duckdb_scan_state->query);
+		if (stream) {
+			duckdb_scan_state->worker_stream = std::move(stream);
+		}
+	}
+
+	if (duckdb_scan_state->worker_stream) {
+		duckdb_scan_state->duckdb_connection = nullptr;
+		duckdb_scan_state->prepared_statement = nullptr;
+		duckdb_scan_state->column_count = (duckdb::idx_t)list_length(duckdb_scan_state->custom_scan->custom_scan_tlist);
+	} else {
+		duckdb_scan_state->duckdb_connection = pgddb::GetConnection();
+		duckdb_scan_state->prepared_statement = prepared_query.release();
+	}
 	duckdb_scan_state->params = estate->es_param_list_info;
 	duckdb_scan_state->is_executed = false;
 	duckdb_scan_state->fetch_next = true;
@@ -250,15 +270,25 @@ Duckdb_ExecCustomScan_Cpp(CustomScanState *node) {
 			return slot;
 		}
 
+		auto fetch_chunk = [duckdb_scan_state]() {
+			return duckdb_scan_state->worker_stream ? duckdb_scan_state->worker_stream->Fetch()
+			                                        : duckdb_scan_state->query_results->Fetch();
+		};
+
 		bool already_executed = duckdb_scan_state->is_executed;
 		if (!already_executed) {
-			ExecuteQuery(duckdb_scan_state);
+			if (duckdb_scan_state->worker_stream) {
+				// Execution runs in the shared worker; results arrive via the stream.
+				duckdb_scan_state->is_executed = true;
+			} else {
+				ExecuteQuery(duckdb_scan_state);
+			}
 
 			// PG only sets es_processed via ModifyTable, which our CustomScan replaced.
 			// DuckDB's DML result is (Count BIGINT): read it into es_processed and end the
 			// scan, so the empty tuple means "no RETURNING rows".
 			if (duckdb_scan_state->query->commandType != CMD_SELECT) {
-				auto chunk = duckdb_scan_state->query_results->Fetch();
+				auto chunk = fetch_chunk();
 				uint64_t processed = 0;
 				if (chunk && chunk->size() > 0 && chunk->ColumnCount() > 0) {
 					try {
@@ -266,6 +296,9 @@ Duckdb_ExecCustomScan_Cpp(CustomScanState *node) {
 					} catch (...) {
 						// Result wasn't a single Count column; leave 0.
 					}
+				}
+				while (duckdb_scan_state->worker_stream && fetch_chunk()) {
+					// worker stream: drain to the Complete frame
 				}
 				duckdb_scan_state->css.ss.ps.state->es_processed = processed;
 				MemoryContextReset(duckdb_scan_state->css.ss.ps.ps_ExprContext->ecxt_per_tuple_memory);
@@ -275,7 +308,7 @@ Duckdb_ExecCustomScan_Cpp(CustomScanState *node) {
 		}
 
 		if (duckdb_scan_state->fetch_next) {
-			duckdb_scan_state->current_data_chunk = duckdb_scan_state->query_results->Fetch();
+			duckdb_scan_state->current_data_chunk = fetch_chunk();
 			duckdb_scan_state->current_row = 0;
 			duckdb_scan_state->fetch_next = false;
 			if (!duckdb_scan_state->current_data_chunk || duckdb_scan_state->current_data_chunk->size() == 0) {

--- a/libpgduckdb/pgddb_planner.cpp
+++ b/libpgduckdb/pgddb_planner.cpp
@@ -98,6 +98,12 @@ Prepare(const Query *query, const char *explain_prefix) {
 	return con->context->Prepare(query_string);
 }
 
+std::string
+DeparseQuery(const Query *query) {
+	Query *copied_query = (Query *)copyObjectImpl(query);
+	return std::string(pgddb_get_querydef(copied_query));
+}
+
 static Plan *
 CreatePlan(Query *query, bool throw_error) {
 	int elevel = throw_error ? ERROR : WARNING;

--- a/libpgduckdb/pgddb_types.cpp
+++ b/libpgduckdb/pgddb_types.cpp
@@ -1617,6 +1617,34 @@ AppendDecimal(duckdb::Vector &result, Datum value, idx_t offset) {
 	}
 }
 
+void
+NumericToDecimalBytes(Datum value, int width_bytes, void *out) {
+	alignas(int32) uint8_t buf[kShortRealignBufSize];
+	bool should_free = false;
+	Datum v = DetoastPostgresDatumInline(value, buf, &should_free);
+	auto numeric_var = FromNumeric(DatumGetNumeric(v));
+	switch (width_bytes) {
+	case 4:
+		*reinterpret_cast<int32_t *>(out) = ConvertDecimal<int32_t>(numeric_var);
+		break;
+	case 8:
+		*reinterpret_cast<int64_t *>(out) = ConvertDecimal<int64_t>(numeric_var);
+		break;
+	case 16: {
+		hugeint_t h = ConvertDecimal<hugeint_t, DecimalConversionHugeint>(numeric_var);
+		// Arrow decimal128 is little-endian two's-complement: low 8 bytes then high.
+		reinterpret_cast<uint64_t *>(out)[0] = h.lower;
+		reinterpret_cast<int64_t *>(out)[1] = h.upper;
+		break;
+	}
+	default:
+		break;
+	}
+	if (should_free) {
+		duckdb_free(reinterpret_cast<void *>(v));
+	}
+}
+
 static void
 AppendList(duckdb::Vector &result, Datum value, idx_t offset) {
 	alignas(int32) uint8_t buf[kShortRealignBufSize];

--- a/libpgduckdb/scan/order_pushdown_optimizer.cpp
+++ b/libpgduckdb/scan/order_pushdown_optimizer.cpp
@@ -1,7 +1,10 @@
 #include "pgddb/scan/order_pushdown_optimizer.hpp"
 
 #include "pgddb/logger.hpp"
+#include "pgddb/pg/relations.hpp"
+#include "pgddb/pgddb_process_lock.hpp"
 #include "pgddb/scan/postgres_scan.hpp"
+#include "pgddb/worker/duckdb_worker.hpp"
 
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
@@ -42,13 +45,16 @@ using duckdb::optional_idx;
 using duckdb::unique_ptr;
 
 static bool
-IndexSupportsOrder(Relation rel, const duckdb::vector<AttrNumber> &order_attrs,
+IndexSupportsOrder(Oid rel_oid, const duckdb::vector<AttrNumber> &order_attrs,
                    const duckdb::vector<PostgresOrderBySpec> &orders) {
 	if (order_attrs.empty()) {
 		return false;
 	}
+	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+	Relation rel = pgddb::OpenRelation(rel_oid);
 	List *index_list = RelationGetIndexList(rel);
 	if (index_list == NIL) {
+		pgddb::CloseRelation(rel);
 		return false;
 	}
 	bool supported = false;
@@ -115,6 +121,7 @@ IndexSupportsOrder(Relation rel, const duckdb::vector<AttrNumber> &order_attrs,
 		}
 	}
 	list_free(index_list);
+	pgddb::CloseRelation(rel);
 	return supported;
 }
 
@@ -294,7 +301,7 @@ TryPushdownOrder(unique_ptr<LogicalOperator> &op) {
 		new_orders.push_back(spec);
 		order_attrs.push_back(static_cast<AttrNumber>(column_id.GetPrimaryIndex() + 1));
 	}
-	if (!IndexSupportsOrder(bind_data->rel, order_attrs, new_orders)) {
+	if (!IndexSupportsOrder(bind_data->desc.oid, order_attrs, new_orders)) {
 		pd_log(DEBUG2, "(PGDuckDB/OrderPushdown) Skipping pushdown: no matching index found for ORDER BY");
 		return false;
 	}
@@ -321,7 +328,13 @@ PushdownRecursive(unique_ptr<LogicalOperator> &op) {
 }
 
 static void
-OptimizePlan(OptimizerExtensionInput &, unique_ptr<LogicalOperator> &plan) {
+OptimizePlan(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
+	// The PG-free worker cannot open relations to inspect indexes; skip the pushdown
+	// there (DuckDB still sorts correctly, just without the index shortcut). Resolved
+	// through the context too: a nested query optimizes on a DuckDB scheduler thread.
+	if (pgddb::worker::EffectiveWorkerSession(&input.context)) {
+		return;
+	}
 	PushdownRecursive(plan);
 }
 

--- a/libpgduckdb/scan/postgres_scan.cpp
+++ b/libpgduckdb/scan/postgres_scan.cpp
@@ -330,17 +330,15 @@ void
 PostgresScanGlobalState::ConstructTableScanQuery(const duckdb::TableFunctionInitInput &input) {
 	const auto &bind_data = input.bind_data->Cast<PostgresScanFunctionData>();
 	if (input.column_ids.size() == 1 && input.column_ids[0] == UINT64_MAX) {
-		scan_query << "SELECT COUNT(*) FROM " << pgddb::GenerateQualifiedRelationName(rel);
+		scan_query << "SELECT COUNT(*) FROM " << desc.qualified_name;
 		count_tuples_only = true;
 		return;
 	}
 	duckdb::vector<AttrNumber> col_idx_to_attno;
-	auto natts = GetTupleDescNatts(table_tuple_desc);
-	for (int i = 0; i < natts; i++) {
-		if (AttIsDropped(GetAttr(table_tuple_desc, i))) {
-			continue;
-		}
-		col_idx_to_attno.emplace_back(static_cast<AttrNumber>(i + 1));
+	duckdb::map<AttrNumber, duckdb::string> attno_to_name;
+	for (const auto &column : desc.columns) {
+		col_idx_to_attno.emplace_back(column.attno);
+		attno_to_name[column.attno] = pgddb::QuoteIdentifier(column.name.c_str());
 	}
 	// Read tuples in PG column order but output in DuckDB order; the map keys on attno to give us PG order.
 	duckdb::map<AttrNumber, duckdb::idx_t> pg_column_order;
@@ -359,8 +357,7 @@ PostgresScanGlobalState::ConstructTableScanQuery(const duckdb::TableFunctionInit
 	for (auto const &[att_num, duckdb_scanned_index] : pg_column_order) {
 		columns_to_scan.emplace_back(att_num, duckdb_scanned_index);
 
-		auto name_attr = pgddb::GetAttr(table_tuple_desc, att_num - 1);
-		scan_column_names[duckdb_scanned_index] = pgddb::QuoteIdentifier(pgddb::GetAttName(name_attr));
+		scan_column_names[duckdb_scanned_index] = attno_to_name[att_num];
 
 		if (!table_filters) {
 			continue;
@@ -391,11 +388,11 @@ PostgresScanGlobalState::ConstructTableScanQuery(const duckdb::TableFunctionInit
 			scan_query << ", ";
 		}
 		first = false;
-		auto attr = pgddb::GetAttr(table_tuple_desc, attr_num - 1);
-		scan_query << pgddb::QuoteIdentifier(pgddb::GetAttName(attr));
+		scan_query << attno_to_name[attr_num];
 	}
 
-	scan_query << " FROM " << pgddb::GenerateQualifiedRelationName(rel);
+	scan_query << " FROM " << desc.qualified_name;
+	remote_where_off = (uint32_t)scan_query.tellp(); // splice point for a CTID range predicate
 
 	duckdb::vector<duckdb::string> query_filters;
 	for (auto const &[attr_num, duckdb_scanned_index] : columns_to_scan) {
@@ -441,12 +438,34 @@ PostgresScanGlobalState::ConstructTableScanQuery(const duckdb::TableFunctionInit
 	}
 }
 
-PostgresScanGlobalState::PostgresScanGlobalState(Snapshot _snapshot, Relation _rel,
-                                                 const duckdb::TableFunctionInitInput &input)
-    : snapshot(_snapshot), rel(_rel), table_tuple_desc(pgddb::RelationGetDescr(rel)), count_tuples_only(false),
-      output_columns(), total_row_count(0), registered_local_states(0), scan_query(),
-      table_reader_global_state(nullptr), duckdb_scan_memory_ctx(nullptr), max_threads(1) {
+PostgresScanGlobalState::PostgresScanGlobalState(duckdb::ClientContext &context, Snapshot _snapshot,
+                                                 const RelationDesc &_desc, const duckdb::TableFunctionInitInput &input)
+    : snapshot(_snapshot), desc(_desc), count_tuples_only(false), output_columns(), total_row_count(0),
+      registered_local_states(0), scan_query(), table_reader_global_state(nullptr), duckdb_scan_memory_ctx(nullptr),
+      max_threads(1), remote_scan(nullptr) {
 	ConstructTableScanQuery(input);
+
+	// In the shared worker the scan runs on the requesting backend (scan inversion):
+	// open a remote stream for the inner SQL and skip all PG-touching reader setup.
+	if (pgddb_open_remote_scan_hook != nullptr) {
+		const auto &bind_data = input.bind_data->Cast<PostgresScanFunctionData>();
+		pgddb::RemoteScanInfo info;
+		info.rangeable = !count_tuples_only && bind_data.order_bys.empty();
+		info.where_off = remote_where_off;
+		info.nblocks = info.rangeable ? desc.nblocks : 0;
+		info.local_relation = desc.is_temporary;
+		remote_scan = pgddb_open_remote_scan_hook(context, scan_query.str(), count_tuples_only, info);
+		if (remote_scan) {
+			// The remote scan touches no PG, so let several DuckDB threads consume it
+			// (its channel round-trips are serialized on the consumer side). COUNT(*)
+			// returns a single value, so keep it single-threaded.
+			if (!count_tuples_only && duckdb_threads_for_postgres_scan > 1) {
+				max_threads = duckdb_threads_for_postgres_scan;
+			}
+			return;
+		}
+	}
+
 	table_reader_global_state = duckdb::make_shared_ptr<PostgresTableReader>();
 	table_reader_global_state->Init(scan_query.str().c_str(), count_tuples_only);
 	// Dedicated PG memory context for temporary type-conversion allocations during scans.
@@ -477,7 +496,9 @@ PostgresScanGlobalState::UnregisterLocalState() {
 	// Once the last local state is gone, clean up the reader and mark negative so none can register again.
 	if (registered_local_states == 0) {
 		registered_local_states = -1;
-		table_reader_global_state->Cleanup();
+		if (table_reader_global_state) {
+			table_reader_global_state->Cleanup();
+		}
 	}
 }
 
@@ -491,6 +512,10 @@ PostgresScanLocalState::PostgresScanLocalState(PostgresScanGlobalState *_global_
 	if (!registered) {
 		return;
 	}
+	// Remote (worker) scans pull DataChunks from the backend; no PG tuple slots needed.
+	if (global_state->remote_scan) {
+		return;
+	}
 	// Both single-thread and parallel scans stage tuples through these slots before the batched converter.
 	for (int i = 0; i < LOCAL_STATE_SLOT_BATCH_SIZE; i++) {
 		slots[i] = global_state->table_reader_global_state->InitTupleSlot();
@@ -500,8 +525,8 @@ PostgresScanLocalState::PostgresScanLocalState(PostgresScanGlobalState *_global_
 PostgresScanLocalState::~PostgresScanLocalState() {
 }
 
-PostgresScanFunctionData::PostgresScanFunctionData(Relation _rel, uint64_t _cardinality, Snapshot _snapshot)
-    : complex_filters(), order_bys(), limit(), offset(0), rel(_rel), cardinality(_cardinality), snapshot(_snapshot) {
+PostgresScanFunctionData::PostgresScanFunctionData(RelationDesc _desc, Snapshot _snapshot)
+    : complex_filters(), order_bys(), limit(), offset(0), desc(std::move(_desc)), snapshot(_snapshot) {
 }
 
 PostgresScanFunctionData::~PostgresScanFunctionData() {
@@ -530,7 +555,7 @@ duckdb::InsertionOrderPreservingMap<duckdb::string>
 PostgresScanTableFunction::ToString(duckdb::TableFunctionToStringInput &input) {
 	auto &bind_data = input.bind_data->Cast<PostgresScanFunctionData>();
 	duckdb::InsertionOrderPreservingMap<duckdb::string> result;
-	result["Table"] = pgddb::GetRelationName(bind_data.rel);
+	result["Table"] = bind_data.desc.name;
 	if (!bind_data.order_bys.empty()) {
 		duckdb::vector<duckdb::string> order_descriptions;
 		order_descriptions.reserve(bind_data.order_bys.size());
@@ -554,9 +579,10 @@ PostgresScanTableFunction::ToString(duckdb::TableFunctionToStringInput &input) {
 }
 
 duckdb::unique_ptr<duckdb::GlobalTableFunctionState>
-PostgresScanTableFunction::PostgresScanInitGlobal(duckdb::ClientContext &, duckdb::TableFunctionInitInput &input) {
+PostgresScanTableFunction::PostgresScanInitGlobal(duckdb::ClientContext &context,
+                                                  duckdb::TableFunctionInitInput &input) {
 	auto &bind_data = input.bind_data->CastNoConst<PostgresScanFunctionData>();
-	return duckdb::make_uniq<PostgresScanGlobalState>(bind_data.snapshot, bind_data.rel, input);
+	return duckdb::make_uniq<PostgresScanGlobalState>(context, bind_data.snapshot, bind_data.desc, input);
 }
 
 duckdb::unique_ptr<duckdb::LocalTableFunctionState>
@@ -574,13 +600,44 @@ SetOutputCardinality(duckdb::DataChunk &output, PostgresScanLocalState &local_st
 }
 
 void
-PostgresScanTableFunction::PostgresScanFunction(duckdb::ClientContext &, duckdb::TableFunctionInput &data,
+PostgresScanTableFunction::PostgresScanFunction(duckdb::ClientContext &context, duckdb::TableFunctionInput &data,
                                                 duckdb::DataChunk &output) {
 	auto &local_state = data.local_state->Cast<PostgresScanLocalState>();
 	auto &global_state = *local_state.global_state;
 
 	if (local_state.exhausted_scan) {
 		SetOutputCardinality(output, local_state);
+		return;
+	}
+
+	// Remote (worker) scan: the backend produces DataChunks for the inner SQL. No PG
+	// access here, so this runs safely on DuckDB worker threads.
+	if (global_state.remote_scan) {
+		local_state.output_vector_size = 0;
+		auto chunk = global_state.remote_scan->Next(context, output.GetTypes());
+		if (global_state.count_tuples_only) {
+			// COUNT(*): the backend returns one BIGINT; emit that many empty rows.
+			uint64_t count = 0;
+			if (chunk && chunk->size() > 0) {
+				count = static_cast<uint64_t>(chunk->GetValue(0, 0).GetValue<int64_t>());
+			}
+			global_state.total_row_count += count;
+			local_state.output_vector_size += count;
+			local_state.exhausted_scan = true;
+		} else if (!chunk || chunk->size() == 0) {
+			local_state.exhausted_scan = true;
+		} else {
+			// Reference (not Copy) the produced chunk: output shares its ref-counted
+			// vector buffers, so no per-chunk data copy here. The buffers outlive
+			// `chunk` via the shared_ptr the reference holds.
+			output.Reference(*chunk);
+		}
+		if (local_state.exhausted_scan) {
+			global_state.UnregisterLocalState();
+		}
+		if (global_state.count_tuples_only) {
+			SetOutputCardinality(output, local_state);
+		}
 		return;
 	}
 
@@ -648,7 +705,8 @@ PostgresScanTableFunction::PostgresScanFunction(duckdb::ClientContext &, duckdb:
 duckdb::unique_ptr<duckdb::NodeStatistics>
 PostgresScanTableFunction::PostgresScanCardinality(duckdb::ClientContext &, const duckdb::FunctionData *data) {
 	auto &bind_data = data->Cast<PostgresScanFunctionData>();
-	return duckdb::make_uniq<duckdb::NodeStatistics>(bind_data.cardinality, bind_data.cardinality);
+	auto cardinality = static_cast<uint64_t>(bind_data.desc.cardinality);
+	return duckdb::make_uniq<duckdb::NodeStatistics>(cardinality, cardinality);
 }
 
 } // namespace pgddb

--- a/libpgduckdb/worker/DESIGN.md
+++ b/libpgduckdb/worker/DESIGN.md
@@ -1,0 +1,283 @@
+# Design: the shared per-database duckdb worker
+
+Status: implemented. Vocabulary: see GLOSSARY.md. Formal models of the
+concurrency cores: `specs/tla/`.
+
+## Motivation
+
+Without the worker, every backend that offloads a query owns a private DuckDB
+instance, so N concurrent clients cost N duckdb memory budgets -- the per-backend
+OOM. The shared worker runs **one DuckDB instance per database** in a background
+worker process and lets backends dispatch queries to it, bounding memory to one
+engine per database regardless of client count.
+
+The worker serves N sessions concurrently. That is possible because worker-side
+query execution is **PG-free**: the worker holds no PG transaction and no snapshot,
+so no "one process, one snapshot" limit applies. Everything PostgreSQL -- catalog
+lookups, DuckLake metadata SQL, heap reads -- runs on the requesting backend (or on
+scan workers) under that backend's own MVCC view, reached over shared memory.
+
+## Roles
+
+- **backend** -- the PostgreSQL backend running the client query. Dispatches the
+  deparsed query to the worker, then sits in a service loop
+  (`BackendSession::Fetch`, duckdb_worker.cpp): it answers the worker's
+  catalog / metadata / scan requests and drains result chunks until the query ends.
+- **duckdb worker** -- one background worker per database (spawned on demand by the
+  first dispatching backend). Hosts the shared DuckDB instance and runs a thread
+  per session, each on its own DuckDB connection. No transaction, no snapshot,
+  pure compute; anything PG is an RPC back to the backend.
+- **scan worker** -- a bounded per-database pool of background workers (own DB
+  connection) that execute heap-scan block ranges in parallel and produce Arrow
+  scan pages. Spawned by the duckdb worker at startup; never runs DuckDB.
+
+Free functions that run in exactly one of these processes are namespaced by role:
+`pgddb::backend`, `pgddb::worker`, and `pgddb::producer` (scan workers). Code
+callable from several processes (the `DuckdbWorker` class, transport primitives,
+protocol codecs, the shared scan producer) stays directly in `pgddb`.
+
+## DuckdbWorker base class vs. extension subclass
+
+The generic machinery is the kernel **DuckdbWorker base class** (`worker/duckdb_worker.cpp`,
+`include/pgddb/worker/duckdb_worker.hpp`): worker registry + spawn, session pool,
+backend service loop, session threads, scan inversion + producer pool, cleanup and
+failure handling. An extension supplies a `DuckdbWorker::Settings` (shmem key prefix,
+bgworker entrypoint names, GUC value pointers, an optional `serve_frame` handler
+for extension-specific frames) and `the DuckdbWorker virtuals` (`configure`, `prime`,
+`database`). The adapters are thin:
+
+- `pg_duckdb/src/shared_engine_worker.cpp` -- dispatch gate: read-only heap SELECTs
+  when `duckdb.use_shared_worker` is on; no extra frames.
+- `pg_ducklake/src/shared_engine_worker.cpp` -- dispatch gate: SELECT plus
+  single-statement autocommit DML; serves the DuckLake metadata RPC
+  (MetaQuery/MetaExec) on the backend.
+
+Each extension gets its own registry, pool, and DuckDB instance (distinct shmem
+keys), so two extensions coexist in one cluster without sharing anything.
+
+## Session pool
+
+A fixed array of `max_worker_sessions` **session slots** in main shared memory
+(`worker/transport/session_pool.cpp`), sized at postmaster start. No dsm. Each
+slot owns a fixed **session channel** region: a header (the cooperative cancel
+flag) plus two `shm_mq` rings -- the **control queue** (backend -> worker, 64 KB)
+and the **result queue** (worker -> backend, 256 KB).
+
+Slot lifecycle is a refcount: `Acquire` takes a FREE slot (first-fit, under the
+pool spinlock) and bumps the slot's **generation**; each side calls `AttachEnd`
+when it maps the channel and `DetachEnd` when done; the detach that drops the
+count to zero returns the slot to FREE. The backend acquires and attaches in one
+go in `DuckdbWorker::OpenSession` (nothing that can fail sits between them),
+recreates the rings in place (`SessionChannel::OpenSlot`), and enqueues
+`PendingSession {slot index, slot generation}` on the worker's **pending-session
+ring** (in the worker registry slot, capacity 1024). The worker's session thread
+attaches via `TryAttachEnd(idx, generation)`, which succeeds only if the slot is
+still IN_USE at the enqueued generation -- a stale entry, whose backend released
+the slot (or whose slot was re-acquired) after enqueueing, is skipped instead of
+attaching someone else's session. A full pool or a full pending ring makes the
+backend wait, cancellably, for a slot -- dispatch never falls back to in-process
+execution for capacity reasons, since a per-backend engine per overflow query is
+exactly the memory growth the worker exists to bound.
+
+## Worker registry, spawn, respawn
+
+`DuckdbWorkerShmem` holds `MAX_DUCKDB_WORKERS` (16) per-database slots: db oid,
+worker pid + latch, a dispatched counter (diagnostics), and the pending ring.
+`EnsureWorkerForMyDatabase` finds or spawns the worker for `MyDatabaseId`; a slot
+whose pid no longer answers `kill(pid, 0)` (crash, SIGKILL) is reclaimed and the
+worker respawned. The worker publishes its pid + latch into the slot early in its
+main; backends poll the slot rather than `WaitForBackgroundWorkerStartup`.
+
+## Frame protocol and channel demux
+
+Frames are tagged (`FrameTag`, session_channel.hpp). Directions:
+
+- control queue (backend -> worker): `Snapshot`, `Sql`, then RPC **replies**:
+  `ScanChunk`/`ScanChunkArrow`/`ScanDone`/`ScanError`, `MetaResult`/`MetaError`,
+  `DescribeRelResult`/`DescribeRelError`.
+- result queue (worker -> backend): `Chunk*` then `Complete`, or `Error`; plus the
+  worker's RPC **requests**: `ScanFetch`, `MetaQuery`, `MetaExec`, `DescribeRel`.
+
+Several scans and metadata round-trips share one channel concurrently, so the
+worker side demultiplexes the control queue (`SessionChannel::RoutedRecv`,
+session_channel.cpp): every scan reply carries a `uint32 scan_id` prefix
+(`SendScanReply`, duckdb_worker.cpp) and is routed into a per-scan **demux lane**;
+metadata/catalog replies go to the single **meta lane**. `RoutedRecv` holds the
+demux lock across receive + route, so each lane preserves wire order; the raw
+`shm_mq` poke nests inside the global process lock. Metadata round-trips are
+serialized per channel by `MetaRequestMutex` (replies carry no request id, so at
+most one is in flight). `CloseScanLane` frees the Arrow pages of frames routed to
+a lane but never consumed.
+
+This demux lifts the old constraint that two scans on one channel were only safe
+because DuckDB drove them sequentially: concurrent scans (a join's two inputs on
+different DuckDB threads) and mid-execution metadata RPCs (DuckLake
+`GetFilesForTable` on a scheduler thread) are now safe. Modeled and checked in
+`specs/tla/ScanInversion.tla`.
+
+## Catalog RPC
+
+The worker never opens PG catalogs. Binding a PG relation asks the backend via
+`DescribeRel` (`WorkerDescribeRelation`, session_protocol.cpp): the backend
+answers with a serialized `RelationDesc` (oid, names, temp-ness, cardinality,
+block count, columns with DuckDB types) resolved under its own snapshot.
+
+## pg_ducklake metadata RPC
+
+DuckLake metadata SQL runs on the backend, inside the backend's transaction:
+
+- `MetaQuery` -- metadata reads (`ExecuteMetadataQueryLocally`), under the
+  backend's snapshot.
+- `MetaExec` -- the commit write path (`ExecuteMetadataExecLocally`). Because it
+  executes in the backend's transaction, a dispatched DML's DuckLake metadata
+  commit is atomic with the backend statement: the dispatch gate only accepts a
+  single autocommit statement, so statement commit and metadata commit coincide.
+
+Replies are serialized `QueryResult`s; `MetaError` carries the DuckDB exception
+type byte so e.g. a `TransactionException` survives the wire and triggers the
+DuckLake conflict-retry on the worker.
+
+## Scan execution: inversion and the producer pool
+
+Heap reads never run in the worker. The kernel remote-scan hook (`OpenRemoteScan`,
+duckdb_worker.cpp -- installed only inside the worker) picks one of two paths:
+
+- **scan inversion** (`InversionScanStream`, scan_producer.cpp): the worker sends
+  `ScanFetch` requests (first one carries `count_only` + the inner SQL) and keeps a
+  read-ahead window of 8 outstanding; the backend (`ServiceScanFetch`,
+  duckdb_worker.cpp) runs the scan via `PostgresTableReader` and replies one chunk
+  per fetch -- an Arrow batch in a global pool page (`ScanChunkArrow`, zero-copy)
+  or, for COUNT(*), one inline serialized chunk. A finished/errored scan is kept
+  (not re-opened) so windowed extra fetches get the same terminal reply. Used for
+  temp tables (backend-local) and as the fallback when the pool is unavailable.
+- **scan producer pool** (`PoolScanStream` + `ProcessScanRange`,
+  scan_producer.cpp): the scan is registered in the shared `ScanRing` with its
+  inner SQL + the shipped snapshot, split into CTID block ranges (>= 64 blocks
+  each, up to `scan_producers` ranges), and the ranges are enqueued on the global
+  `ScanQueue`. Scan workers claim ranges, splice a `ctid >= .. AND ctid < ..`
+  predicate into the SQL, read under the restored snapshot, and push Arrow pages
+  into the scan's ready-ring; the worker's DuckDB threads drain it with no
+  per-chunk round-trip. Generation guards make teardown (LIMIT, cancel, error)
+  drop in-flight ranges; `ScanRing::Close` reclaims queued pages. Modeled in
+  `specs/tla/ScanPool.tla`.
+
+The data transport is Arrow-only (`arrow_codec.cpp`); an unsupported column type
+fails the scan loudly rather than silently falling back.
+
+## Snapshot model
+
+The worker holds no PG transaction. It primes the engine exactly once at startup
+inside a transaction (extensions, secrets, catalog attach); after that every
+session runs transaction-free. The backend ships its active snapshot with the
+query (`Snapshot` frame); the worker never restores it -- it only re-ships it to
+scan-worker tasks (via the ScanRing), which restore it so all producers read the
+dispatching backend's MVCC view. The backend itself answers inversion fetches and
+metadata RPCs under its own live transaction. The dispatch gate refuses to
+dispatch when the current transaction has already written (the shipped snapshot
+could not see those changes).
+
+## Worker threading
+
+A PostgreSQL background worker is single-threaded by contract, so the worker runs
+a **thread per session** with every PG-non-thread-safe touch (shm_mq, palloc)
+serialized behind the **global process lock**, taken as a non-blocking poke with
+the lock dropped between attempts (`SerializedSendResult` /
+`SerializedRecvControl` / the recv inside `RoutedRecv`). `MyLatch` stays owned
+solely by the worker's main loop. Each session's channel + shipped snapshot are
+registered keyed by the executing DuckDB `ClientContext` (`g_session_ctx`),
+because a scan's `init_global` runs on a DuckDB scheduler thread where
+thread-locals are invisible; binding-phase code still uses the thread-local
+`CurrentWorkerSession`, which is correct because binding runs on the session
+thread during `con.SendQuery`.
+
+One registry subtlety: DuckLake's per-transaction metadata connection
+(`DuckLakeTransaction::GetConnection`) is a separate `ClientContext`.
+pg_ducklake's metadata manager **aliases** that nested context onto the owning
+session's registry entry (`AliasWorkerSessionContext`) before inlined-data reads
+(`ReadInlinedData` / `ReadAllInlinedDataForFlush` run `ExecuteRaw` on the nested
+connection, which opens remote heap scans that must invert to the same backend),
+and unaliases it in the metadata manager's destructor. The alias must not
+outlive the transaction: a freed `ClientContext` address can be reused by a
+later session, and a stale alias would route that session's scans to the wrong
+backend.
+
+## Lifecycle and failure handling
+
+- **dispatch**: backend ensures the worker, acquires + attaches a slot, enqueues it
+  on the pending ring, pokes the worker latch, ships `Snapshot` + `Sql`, and enters
+  the service loop. The worker main loop drains the pending ring and spawns a
+  session thread per entry (attach, run, detach); finished threads are reaped.
+- **backend abort/exit**: open streams are tracked in a backend-local registry;
+  the xact-abort callback and `before_shmem_exit` release all of them (cancel the
+  worker, detach, `DetachEnd`). Cleanup is **subtransaction-scoped**: each stream
+  records `GetCurrentSubTransactionId()` at creation, and a
+  `SUBXACT_EVENT_ABORT_SUB` releases only streams created in the aborting
+  subtransaction -- a subtransaction abort can be an internal, handled event
+  (the backend services a worker's `MetaExec` in a subtransaction that aborts on
+  a DuckLake commit conflict and is retried), and killing the servicing stream
+  there would free the channel out from under it. A slot claimed but not yet
+  owned by a stream is covered by `g_pending_conn_slot`; a pending-ring entry
+  whose backend already released the slot is rejected by the worker's
+  generation check.
+- **cancellation**: the backend sets the channel's cancel flag and pokes the worker
+  latch; the worker main loop `Interrupt()`s the `ClientContext` of any session
+  whose flag is set, so the query aborts promptly. Worker-side sends/recvs also
+  poll the flag and bail.
+- **worker death**: the backend's fetch loop probes the worker pid when idle and
+  errors out instead of spinning; `EnsureWorkerForMyDatabase` reclaims the dead
+  registry slot so the next dispatch respawns the worker.
+- **worker shutdown**: on SIGTERM a custom handler only flags + wakes, and the
+  main loop sets the draining flag (unblocking session-thread polls) and joins
+  all session threads before exiting. The same drain also runs from a
+  `before_shmem_exit` callback, so ERROR/FATAL exits -- which `proc_exit`
+  without returning through the main loop -- still join every session thread
+  and `DetachEnd` cleanly. Hard kills (SIGKILL, segfault) skip the callback,
+  but they trigger a postmaster crash-restart that reinitializes shared memory,
+  so no refcounts survive them either.
+- **capacity waits**: pool full, pending ring full, or worker mid-respawn at enqueue
+  time make `DuckdbWorker::OpenSession` wait (interrupt checks between retries, so
+  cancel and statement_timeout apply) and, for a dead worker, respawn it. In-process
+  execution happens only for statements the dispatch gate excludes by semantics.
+
+The slot/refcount lifecycle is modeled in `specs/tla/ControlProtocol.tla`.
+
+## Known limits
+
+- Data transport is Arrow-only. Covered types (`arrow_codec.cpp`): int2/int4/
+  int8, float4/float8, date, bool (bit-packed), timestamp, timestamptz,
+  text/varchar, bytea/BLOB (bytea matters because DuckLake inlined-data tables
+  store text columns as bytea), and numeric/decimal (32/64/128-bit). Any other
+  column type (or > 64 columns) fails the scan loudly. The Arrow page pool must
+  be configured (`arrow_pool_pages > 0`) for data scans.
+- The engine (secrets, extensions, DuckLake attach) is primed once at worker
+  start; secrets created later are not seen until the worker restarts.
+- A DuckDB `InternalException` in any session invalidates the shared engine
+  (DuckDB marks the database instance invalid), so every session fails until
+  the worker is restarted and re-primes.
+- At most `MAX_DUCKDB_WORKERS` = 16 databases can have a live duckdb worker.
+- pg_ducklake DML dispatch is gated to a single autocommit statement without
+  RETURNING (so the statement and its metadata commit coincide); pg_duckdb
+  dispatches SELECT only. Neither dispatches after the transaction has written.
+- Metadata round-trips are serialized per channel (one in flight); scans are the
+  concurrent fast path.
+- Provisioning is opt-in: `max_worker_sessions` defaults to 0, which disables the
+  worker and reserves no shared memory (registry, session pool, Arrow page pool,
+  scan queue, scan ring). Enabling it requires a postmaster restart, since the
+  shmem request runs at postmaster start.
+- Dispatch bounds **execution** memory only. Every dispatching backend still creates
+  its own DuckDB instance to plan and bind (and for the gate fallback), and each
+  dispatched query is planned in-process before dispatch, so the plan/bind memory is
+  not shared. Moving plan/bind into the worker is future work.
+- Scan producers take their own AccessShare locks (they are not in the dispatching
+  backend's lock group, unlike PG parallel workers), so a pending exclusive lock can
+  queue a producer behind DDL that is itself queued behind the dispatching backend --
+  a cycle whose backend edge is a latch wait, invisible to the deadlock detector. It
+  is cancellable; set `lock_timeout`/`statement_timeout` where concurrent DDL is
+  expected. Producer-side bounded lock waits are future work.
+- MetaExec durability window: the worker's in-memory DuckLake state advances when
+  MetaExec returns, but durability is the backend's later commit. If the backend dies
+  before committing, the metadata rolls back while the shared engine's caches may have
+  advanced; later sessions re-read metadata under their own snapshots, which
+  re-converges. No cross-session state is trusted without a metadata read.
+- A slow result consumer holds its session slot for the whole statement, pinning
+  1/`max_worker_sessions` of the database's dispatch capacity.

--- a/libpgduckdb/worker/GLOSSARY.md
+++ b/libpgduckdb/worker/GLOSSARY.md
@@ -1,0 +1,116 @@
+# Shared DuckDB worker - glossary
+
+Vocabulary for the shared duckdb worker and its shared-memory transport.
+
+Naming principles: (1) follow PostgreSQL and DuckDB names (backend, worker,
+connection); (2) avoid generic words (job, stage, task-on-its-own) - prefer
+specific names like "scan task" / "scan range" that carry meaning.
+
+## Roles (processes and threads)
+
+- **backend** - a PostgreSQL backend process serving a client. Decides whether to
+  offload a query; while one is offloaded it runs the service loop that answers the
+  worker's RPCs and can itself produce scan pages.
+- **duckdb worker** - the background worker (one per database) that
+  hosts the shared DuckDB instance and executes offloaded queries. PG-free during
+  execution: no transaction, no snapshot, no catalog access.
+- **DuckdbWorker base class** - the kernel machinery an extension embeds to get an engine
+  worker: registry + spawn, session pool, service loop, session threads, scan
+  producer pool (`duckdb_worker.cpp`). The extension subclass supplies the dispatch
+  gate, entrypoints, GUCs, and any extra frames.
+- **session thread** - one thread in the duckdb worker per in-flight session; owns
+  that session's DuckDB connection. PG touches are serialized behind the global
+  process lock.
+- **scan worker** - a background worker, in a bounded per-database pool, that only
+  executes scan ranges and produces scan pages.
+
+## Units of work
+
+- **session** (duckdb query) - one query a backend dispatches over a connection
+  slot: Snapshot + Sql in, Chunk*/Complete or Error out, plus the RPC traffic in
+  between. One session per slot at a time.
+- **scan task** - a PostgreSQL heap scan (the inner SQL over a real relation) that
+  the worker sends back out to be run against PostgreSQL - to the backend
+  (inversion) or to scan workers (pool). Identified by a scan_id.
+- **scan range** - a contiguous CTID block range `[lo, hi)` of a scan task: the
+  unit a scan worker claims from the scan queue. All of a task's ranges feed that
+  task's single scan ring.
+- **scan page** - one filled Arrow record batch, held in a page from the page pool.
+- **shipped snapshot** - the backend's serialized MVCC snapshot, sent with a
+  session. The worker never restores it; it re-ships it to scan workers so all
+  producers read the dispatching backend's view.
+
+## Shared-memory structures (worker/transport)
+
+All fixed-size regions in main shared memory, created at postmaster start. There
+is no dsm segment anywhere in the transport.
+
+- **session pool** - the fixed array of session slots
+  (`session_pool.cpp`). `Acquire` takes a FREE slot and bumps its generation;
+  each side `AttachEnd`s / `DetachEnd`s, and the detach that drops the attach
+  refcount to zero frees the slot.
+- **session slot** - one pool entry: the slot state, a **generation**
+  (bumped on every `Acquire`, so a stale reference to a released or re-acquired
+  slot is detectable), the attach refcount, plus a fixed session-channel region,
+  reused across sessions.
+- **session channel** - the per-slot transport: a header (cooperative cancel flag)
+  plus the control queue and the result queue (`session_channel.cpp`).
+- **control queue** - shm_mq ring, backend -> worker: Snapshot, Sql, and the
+  backend's RPC replies (scan replies, MetaResult/MetaError, DescribeRel replies).
+- **result queue** - shm_mq ring, worker -> backend: result Chunk*/Complete/Error
+  and the worker's RPC requests (ScanFetch, MetaQuery, MetaExec, DescribeRel).
+- **pending-session ring** - per duckdb worker (in its registry slot): entries of
+  {session slot index, slot generation} enqueued by backends, drained by the
+  worker main loop, which spawns a session thread per entry. The thread attaches
+  via `TryAttachEnd(idx, generation)`, so a stale entry (its backend released the
+  slot after enqueueing) is skipped rather than served.
+- **page pool** - the global fixed pool of equal-size scan pages; the zero-copy
+  Arrow area. A producer *acquires* a page; the consumer *releases* it once DuckDB
+  drops the chunk.
+- **scan queue** - the global MPMC queue of scan ranges awaiting a scan worker;
+  entries are tagged with db oid + scan_id + generation.
+- **scan ring** - per scan task; an MPSC ring of ready scan pages. Producers push;
+  the worker's DuckDB threads drain. Generation-guarded for teardown.
+
+## Worker-side session registry
+
+- **session context registry** - the worker's map from the executing DuckDB
+  `ClientContext` to that session's channel + shipped snapshot. Needed because a
+  scan's `init_global` runs on a DuckDB scheduler thread, where the session
+  thread's thread-locals are invisible.
+- **nested-connection alias** - a second registry key for the same session:
+  DuckLake's per-transaction metadata connection is a separate `ClientContext`,
+  so pg_ducklake aliases it onto the owning session's entry
+  (`AliasWorkerSessionContext`) before inlined-data reads and unaliases it when
+  the metadata manager (and so the transaction) is destroyed. A stale alias
+  would misroute a later session that reuses the freed context address.
+
+## Channel demux (worker side)
+
+- **demux lane** - the worker-side per-scan reply queue: `RoutedRecv` pulls frames
+  off the control queue and routes each to its lane, so several scans and metadata
+  RPCs share one channel concurrently. Frames keep wire order within a lane.
+- **scan_id-prefixed reply** - every scan reply (ScanChunk/ScanChunkArrow/
+  ScanDone/ScanError) carries a uint32 scan_id prefix; the prefix selects the lane
+  and is stripped while routing.
+- **meta lane** - the single lane for metadata/catalog replies
+  (MetaResult/MetaError, DescribeRelResult/DescribeRelError). Metadata round-trips
+  are serialized per channel by the meta-request mutex, so replies need no id.
+
+## RPCs (worker -> backend)
+
+- **ScanFetch** - inversion path: "produce the next chunk of scan_id"; the first
+  fetch carries count_only + the inner SQL.
+- **DescribeRel** - catalog RPC: resolve schema.table into a serialized
+  RelationDesc (oid, temp-ness, cardinality, blocks, columns + types) under the
+  backend's snapshot.
+- **MetaQuery** - pg_ducklake: run DuckLake metadata read SQL on the backend,
+  under its snapshot; reply is a serialized QueryResult.
+- **MetaExec** - pg_ducklake: run a DuckLake metadata commit write on the backend,
+  inside the backend's transaction, so a dispatched DML's metadata commit is
+  atomic with the statement. MetaError replies carry the DuckDB exception type.
+
+## Not shared memory
+
+- **arrow codec** - the direct PG-datum -> Arrow producer and the Arrow -> DuckDB
+  DataChunk consumer that write and read scan pages (`arrow_codec.cpp`).

--- a/libpgduckdb/worker/duckdb_worker.cpp
+++ b/libpgduckdb/worker/duckdb_worker.cpp
@@ -1,0 +1,1160 @@
+#include "pgddb/worker/duckdb_worker.hpp"
+
+#include <atomic>
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "pgddb/catalog/relation_desc.hpp"
+#include "pgddb/pgddb_process_lock.hpp"
+#include "pgddb/worker/scan_producer.hpp"
+#include "pgddb/worker/transport/page_pool.hpp"
+#include "pgddb/worker/transport/scan_queue.hpp"
+#include "pgddb/worker/transport/scan_ring.hpp"
+#include "pgddb/worker/transport/session_pool.hpp"
+#include "pgddb/worker/transport/session_protocol.hpp"
+#include "pgddb/worker/worker_session.hpp"
+
+#include <duckdb/common/serializer/memory_stream.hpp>
+#include <duckdb/main/connection.hpp>
+
+extern "C" {
+#include "postgres.h"
+
+#include <signal.h>
+
+#include "access/xact.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+#include "postmaster/bgworker.h"
+#include "postmaster/interrupt.h"
+#include "storage/ipc.h"
+#include "storage/latch.h"
+#include "storage/lwlock.h"
+#include "storage/proc.h"
+#include "storage/shmem.h"
+#include "storage/spin.h"
+#include "tcop/tcopprot.h"
+#include "utils/guc.h"
+#include "utils/memutils.h"
+#include "utils/snapmgr.h"
+}
+
+namespace pgddb {
+
+/* Internal: session threads run as free functions but need the subclass's engine
+ * accessor; this keeps the virtual protected in the public API. */
+struct WorkerAccess {
+	static duckdb::DuckDB &
+	Database(DuckdbWorker *worker) {
+		return worker->Database();
+	}
+};
+
+namespace {
+
+#define MAX_DUCKDB_WORKERS 16
+
+/* Pending-session ring depth per worker. A backend acquires a session-pool slot before
+ * enqueuing, so the queue can hold at most max_sessions entries; if it ever fills
+ * (max_sessions set very high), the backend waits and retries the enqueue. */
+#define MAX_PENDING_SESSIONS 1024
+
+/* A queued session: the session-pool slot plus its generation at enqueue time, so
+ * the worker never serves a stale entry whose backend already released the slot. */
+struct PendingSession {
+	uint32 session_slot;
+	uint32 session_generation;
+};
+
+struct DuckdbWorkerSlot {
+	Oid db_oid;
+	pid_t worker_pid; /* 0 while a spawn is in progress */
+	Latch *worker_latch;
+	uint32 generation;
+	bool in_use;
+	uint64 dispatched; /* sessions accepted since this worker started (diagnostics) */
+	/* Pending sessions enqueued by backends and drained by the worker, which spawns a
+	 * session thread per entry. Guarded by the shmem lock; head/tail are monotonic,
+	 * indexed mod MAX_PENDING_SESSIONS. */
+	PendingSession pending[MAX_PENDING_SESSIONS];
+	uint32 pending_head;
+	uint32 pending_tail;
+};
+
+struct DuckdbWorkerShmem {
+	slock_t lock;
+	DuckdbWorkerSlot workers[MAX_DUCKDB_WORKERS];
+};
+
+DuckdbWorker::Settings g_settings = {};
+DuckdbWorker *g_worker = nullptr;
+
+DuckdbWorkerShmem *g_duckdb_workers = nullptr;
+
+/* True inside the duckdb worker process itself, so it never recurses into dispatch. */
+bool g_in_duckdb_worker = false;
+
+} // namespace
+
+/* Code that runs only inside the duckdb worker process. */
+namespace worker {
+namespace {
+
+/* Per-session worker context, keyed by the executing DuckDB ClientContext. A scan's
+ * init_global (where the remote scan is opened) runs on a DuckDB scheduler thread, not the
+ * session thread, so thread-local state is invisible there; the ClientContext is the one
+ * handle reachable from both. Holds the session's channel (heap scans route their inner SQL
+ * back to the requesting backend over it) and the backend's serialized snapshot (so scan
+ * worker tasks read the same MVCC view). */
+struct WorkerSessionContext {
+	SessionChannel *channel = nullptr;
+	std::string snapshot_bytes = {};
+	// Liveness guard for the raw map key: the main loop's interrupt propagation only
+	// touches the context through this (a dead/stale entry simply fails to lock).
+	duckdb::weak_ptr<duckdb::ClientContext> ctx_weak = {};
+};
+std::mutex g_session_ctx_lock;
+std::unordered_map<duckdb::ClientContext *, WorkerSessionContext> g_session_ctx;
+
+/* Number of scan workers this duckdb worker spawned at startup; 0 means the scan
+ * worker pool is unavailable and scans fall back to the in-backend inversion path. */
+int g_scan_workers_spawned = 0;
+
+/* Active session threads, each running one query on its own DuckDB connection.
+ * File-scope so the worker's shmem-exit callback can drain them on any exit path. */
+struct WorkerSession {
+	std::thread thread;
+	std::shared_ptr<std::atomic<bool>> done;
+};
+std::vector<WorkerSession> g_worker_sessions;
+
+/* SIGTERM flag for the duckdb worker. A custom handler (not die) so the main loop can
+ * stop its session threads before the process exits. */
+volatile sig_atomic_t g_duckdb_worker_got_sigterm = false;
+
+void
+WorkerSigterm(SIGNAL_ARGS) {
+	int save_errno = errno;
+	g_duckdb_worker_got_sigterm = true;
+	SetLatch(MyLatch);
+	errno = save_errno;
+}
+
+} // namespace
+} // namespace worker
+
+namespace {
+
+#if PG_VERSION_NUM >= 150000
+shmem_request_hook_type prev_shmem_request_hook = nullptr;
+#endif
+shmem_startup_hook_type prev_shmem_startup_hook = nullptr;
+
+Size
+ArrowPoolBytes() {
+	if (*g_settings.arrow_pool_pages <= 0)
+		return 0;
+	return PagePool::ShmemSize(*g_settings.arrow_pool_pages, *g_settings.arrow_page_size);
+}
+
+std::string
+ShmemKey(const char *suffix) {
+	return std::string(g_settings.shmem_name) + suffix;
+}
+
+void
+ShmemRequest() {
+#if PG_VERSION_NUM >= 150000
+	if (prev_shmem_request_hook)
+		prev_shmem_request_hook();
+#endif
+	if (*g_settings.max_sessions <= 0)
+		return; /* worker disabled: reserve no shared memory */
+	RequestAddinShmemSpace(sizeof(DuckdbWorkerShmem));
+	RequestAddinShmemSpace(SessionPool::ShmemSize(*g_settings.max_sessions));
+	if (ArrowPoolBytes() > 0) {
+		RequestAddinShmemSpace(ArrowPoolBytes());
+		/* scan worker transports via the page pool: task queue + per-scan ready rings */
+		RequestAddinShmemSpace(ScanQueue::ShmemSize());
+		RequestAddinShmemSpace(ScanRing::ShmemSize());
+	}
+}
+
+void
+ShmemStartup() {
+	if (prev_shmem_startup_hook)
+		prev_shmem_startup_hook();
+
+	if (*g_settings.max_sessions <= 0)
+		return; /* worker disabled: no shared memory to initialize */
+
+	bool found;
+	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
+	g_duckdb_workers =
+	    (DuckdbWorkerShmem *)ShmemInitStruct(ShmemKey("Workers").c_str(), sizeof(DuckdbWorkerShmem), &found);
+	if (!found) {
+		MemSet(g_duckdb_workers, 0, sizeof(DuckdbWorkerShmem));
+		SpinLockInit(&g_duckdb_workers->lock);
+	}
+
+	bool cp_found;
+	int nconn = *g_settings.max_sessions;
+	void *cp = ShmemInitStruct(ShmemKey("SessionPool").c_str(), SessionPool::ShmemSize(nconn), &cp_found);
+	if (!cp_found)
+		SessionPool::Init(cp, nconn);
+	SessionPool::Attach(cp);
+
+	if (ArrowPoolBytes() > 0) {
+		bool pool_found;
+		void *pool = ShmemInitStruct(ShmemKey("ArrowPagePool").c_str(), ArrowPoolBytes(), &pool_found);
+		if (!pool_found)
+			PagePool::Init(pool, *g_settings.arrow_pool_pages, *g_settings.arrow_page_size);
+		PagePool::Attach(pool); // every process attaches to the identically-mapped region
+
+		bool sq_found;
+		void *sq = ShmemInitStruct(ShmemKey("ScanQueue").c_str(), ScanQueue::ShmemSize(), &sq_found);
+		if (!sq_found)
+			ScanQueue::Init(sq);
+		ScanQueue::Attach(sq);
+
+		bool sr_found;
+		void *sr = ShmemInitStruct(ShmemKey("ScanRing").c_str(), ScanRing::ShmemSize(), &sr_found);
+		if (!sr_found)
+			ScanRing::Init(sr);
+		ScanRing::Attach(sr);
+	}
+	LWLockRelease(AddinShmemInitLock);
+}
+
+/* Find a live worker slot for db_oid, or -1. Caller holds the lock. */
+int
+FindWorkerSlot(Oid db_oid) {
+	for (int i = 0; i < MAX_DUCKDB_WORKERS; i++) {
+		if (g_duckdb_workers->workers[i].in_use && g_duckdb_workers->workers[i].db_oid == db_oid)
+			return i;
+	}
+	return -1;
+}
+
+} // namespace
+
+/* Code that runs only in the requesting PG backend process. */
+namespace backend {
+namespace {
+
+/* Enqueue a session onto a worker's pending ring. Caller holds the lock.
+ * Returns false if the ring is full (the backend waits and retries). */
+bool
+EnqueuePendingSession(int slot_idx, uint32 session_slot, uint32 session_generation) {
+	DuckdbWorkerSlot &w = g_duckdb_workers->workers[slot_idx];
+	if (w.pending_tail - w.pending_head >= MAX_PENDING_SESSIONS)
+		return false;
+	w.pending[w.pending_tail % MAX_PENDING_SESSIONS] = PendingSession {session_slot, session_generation};
+	w.pending_tail++;
+	w.dispatched++;
+	return true;
+}
+
+} // namespace
+} // namespace backend
+
+namespace worker {
+namespace {
+
+/* Duckdb-worker startup (main thread): spawn the scan worker pool for this database.
+ * Fire-and-forget: producers publish their latch and claim queued tasks once up, so no
+ * startup wait is needed. Sets g_scan_workers_spawned; 0 disables the pool path. */
+void
+SpawnScanWorkers(Oid db_oid) {
+	int n = *g_settings.scan_pool_size;
+	if (n <= 0 || g_settings.bgw_scan_entrypoint == nullptr || !ScanQueue::Available() || !ScanRing::Available() ||
+	    !PagePool().Available())
+		return;
+
+	int spawned = 0;
+	for (int i = 0; i < n; i++) {
+		BackgroundWorker worker;
+		MemSet(&worker, 0, sizeof(BackgroundWorker));
+		worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
+		worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
+		snprintf(worker.bgw_library_name, BGW_MAXLEN, "%s", g_settings.bgw_library);
+		snprintf(worker.bgw_function_name, BGW_MAXLEN, "%s", g_settings.bgw_scan_entrypoint);
+		snprintf(worker.bgw_name, BGW_MAXLEN, "%s scan worker (db %u)", g_settings.display_name, db_oid);
+		snprintf(worker.bgw_type, BGW_MAXLEN, "%s scan worker", g_settings.display_name);
+		worker.bgw_restart_time = BGW_NEVER_RESTART;
+		worker.bgw_main_arg = ObjectIdGetDatum(db_oid);
+		worker.bgw_notify_pid = MyProcPid;
+
+		BackgroundWorkerHandle *handle = NULL;
+		if (RegisterDynamicBackgroundWorker(&worker, &handle))
+			spawned++;
+		else
+			elog(WARNING, "%s: could not register scan worker (out of background worker slots)",
+			     g_settings.display_name);
+	}
+	g_scan_workers_spawned = spawned;
+	elog(LOG, "%s scan worker pool: spawned %d/%d scan workers for database %u", g_settings.display_name, spawned, n,
+	     db_oid);
+}
+
+} // namespace
+} // namespace worker
+
+namespace backend {
+namespace {
+
+bool
+PidIsAlive(pid_t pid) {
+	return pid != 0 && kill(pid, 0) == 0;
+}
+
+/* Ensure a worker exists for MyDatabaseId, spawning one if needed; returns its latch
+ * and pid. A slot whose worker died (crash, SIGKILL) is reclaimed and respawned.
+ * Raises an error if the worker registry is full or the worker fails to start. */
+Latch *
+EnsureWorkerForMyDatabase(pid_t *out_pid) {
+	Oid db_oid = MyDatabaseId;
+
+	for (;;) {
+		SpinLockAcquire(&g_duckdb_workers->lock);
+		int idx = FindWorkerSlot(db_oid);
+		if (idx >= 0) {
+			pid_t pid = g_duckdb_workers->workers[idx].worker_pid;
+			Latch *latch = g_duckdb_workers->workers[idx].worker_latch;
+			SpinLockRelease(&g_duckdb_workers->lock);
+			/* PidIsAlive is a syscall; never run it under the spinlock. */
+			if (pid != 0 && latch != NULL && !PidIsAlive(pid)) {
+				/* The worker died without cleaning up; reclaim so it respawns.
+				 * Re-validate the slot still maps to that pid before clearing. */
+				SpinLockAcquire(&g_duckdb_workers->lock);
+				int idx2 = FindWorkerSlot(db_oid);
+				if (idx2 >= 0 && g_duckdb_workers->workers[idx2].worker_pid == pid)
+					g_duckdb_workers->workers[idx2].in_use = false;
+				SpinLockRelease(&g_duckdb_workers->lock);
+				continue;
+			}
+			if (pid != 0 && latch != NULL) {
+				*out_pid = pid;
+				return latch;
+			}
+			CHECK_FOR_INTERRUPTS();
+			pg_usleep(10000); /* spawn in progress; wait for the worker to publish */
+			continue;
+		}
+		int free_idx = -1;
+		for (int i = 0; i < MAX_DUCKDB_WORKERS; i++) {
+			if (!g_duckdb_workers->workers[i].in_use) {
+				free_idx = i;
+				break;
+			}
+		}
+		if (free_idx < 0) {
+			SpinLockRelease(&g_duckdb_workers->lock);
+			ereport(ERROR, (errcode(ERRCODE_CONFIGURATION_LIMIT_EXCEEDED),
+			                errmsg("no free duckdb worker slot (max %d)", MAX_DUCKDB_WORKERS)));
+		}
+		g_duckdb_workers->workers[free_idx].in_use = true;
+		g_duckdb_workers->workers[free_idx].db_oid = db_oid;
+		g_duckdb_workers->workers[free_idx].worker_pid = 0;
+		g_duckdb_workers->workers[free_idx].worker_latch = NULL;
+		g_duckdb_workers->workers[free_idx].dispatched = 0;
+		g_duckdb_workers->workers[free_idx].pending_head = 0;
+		g_duckdb_workers->workers[free_idx].pending_tail = 0;
+		g_duckdb_workers->workers[free_idx].generation++;
+		SpinLockRelease(&g_duckdb_workers->lock);
+
+		BackgroundWorker worker;
+		MemSet(&worker, 0, sizeof(BackgroundWorker));
+		worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
+		worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
+		snprintf(worker.bgw_library_name, BGW_MAXLEN, "%s", g_settings.bgw_library);
+		snprintf(worker.bgw_function_name, BGW_MAXLEN, "%s", g_settings.bgw_worker_entrypoint);
+		snprintf(worker.bgw_name, BGW_MAXLEN, "%s duckdb worker (db %u)", g_settings.display_name, db_oid);
+		snprintf(worker.bgw_type, BGW_MAXLEN, "%s duckdb worker", g_settings.display_name);
+		worker.bgw_restart_time = BGW_NEVER_RESTART; /* re-spawned on demand by backends */
+		worker.bgw_main_arg = ObjectIdGetDatum(db_oid);
+		worker.bgw_notify_pid = MyProcPid;
+
+		BackgroundWorkerHandle *handle = NULL;
+		if (!RegisterDynamicBackgroundWorker(&worker, &handle)) {
+			SpinLockAcquire(&g_duckdb_workers->lock);
+			g_duckdb_workers->workers[free_idx].in_use = false;
+			SpinLockRelease(&g_duckdb_workers->lock);
+			ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_RESOURCES),
+			                errmsg("could not register duckdb worker (out of background worker slots)")));
+		}
+		/* Poll the slot for the worker's published latch (set early in its main).
+		 * WaitForBackgroundWorkerStartup is avoided: it does not report startup when
+		 * called from inside the executor here. GetBackgroundWorkerPid still detects
+		 * a worker that dies during startup. */
+		for (int i = 0; i < 6000; i++) {
+			CHECK_FOR_INTERRUPTS();
+			SpinLockAcquire(&g_duckdb_workers->lock);
+			pid_t wpid = g_duckdb_workers->workers[free_idx].worker_pid;
+			Latch *wlatch = g_duckdb_workers->workers[free_idx].worker_latch;
+			SpinLockRelease(&g_duckdb_workers->lock);
+			if (wpid != 0 && wlatch != NULL) {
+				*out_pid = wpid;
+				return wlatch;
+			}
+			pid_t bpid;
+			if (GetBackgroundWorkerPid(handle, &bpid) == BGWH_STOPPED) {
+				SpinLockAcquire(&g_duckdb_workers->lock);
+				g_duckdb_workers->workers[free_idx].in_use = false;
+				SpinLockRelease(&g_duckdb_workers->lock);
+				ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("duckdb worker stopped during startup")));
+			}
+			pg_usleep(10000); /* 10ms */
+		}
+		SpinLockAcquire(&g_duckdb_workers->lock);
+		g_duckdb_workers->workers[free_idx].in_use = false;
+		SpinLockRelease(&g_duckdb_workers->lock);
+		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("timed out waiting for duckdb worker to start")));
+	}
+}
+
+class BackendSession;
+
+/* Backend-side cleanup state: sessions the kernel CustomScan holds are palloc'd, so a
+ * transaction abort frees the containing memory without running C++ destructors. The
+ * registry lets the abort callback (and process exit) release the channel and the
+ * connection slot explicitly. Backend-local, single-threaded. */
+std::unordered_set<BackendSession *> g_open_streams;
+int g_pending_session_slot = -1; /* claimed but not yet owned by a stream */
+bool g_backend_cleanup_registered = false;
+
+void ReleaseOpenSessions(SubTransactionId subid);
+
+void
+WorkerXactCallback(XactEvent event, void *) {
+	if (event == XACT_EVENT_ABORT || event == XACT_EVENT_PARALLEL_ABORT)
+		ReleaseOpenSessions(InvalidSubTransactionId);
+}
+
+/* Release only streams opened inside the aborting subtransaction: a subtransaction
+ * abort can be an internal, handled event (the backend services a worker's MetaExec
+ * in a subtransaction that aborts on a DuckLake commit conflict and is retried) --
+ * killing the servicing stream there would free the channel out from under it. */
+void
+WorkerSubXactCallback(SubXactEvent event, SubTransactionId my_subid, SubTransactionId, void *) {
+	if (event == SUBXACT_EVENT_ABORT_SUB)
+		ReleaseOpenSessions(my_subid);
+}
+
+void
+WorkerShmemExitCallback(int, Datum) {
+	ReleaseOpenSessions(InvalidSubTransactionId);
+}
+
+void
+EnsureBackendCleanupRegistered() {
+	if (g_backend_cleanup_registered)
+		return;
+	RegisterXactCallback(WorkerXactCallback, nullptr);
+	RegisterSubXactCallback(WorkerSubXactCallback, nullptr);
+	before_shmem_exit(WorkerShmemExitCallback, (Datum)0);
+	g_backend_cleanup_registered = true;
+}
+
+/* Pull-based result stream over a worker session, consumed by the kernel CustomScan.
+ * Releases its slot and detaches on destruction; on early teardown it cancels so the
+ * worker is not left blocked on a full result queue. */
+class BackendSession : public WorkerResultStream {
+public:
+	BackendSession(const BackendSession &) = delete;
+	BackendSession &operator=(const BackendSession &) = delete;
+	BackendSession(std::unique_ptr<SessionChannel> ch, int session_slot, Latch *worker_latch, pid_t worker_pid)
+	    : ch_(std::move(ch)), session_slot_(session_slot), worker_latch_(worker_latch), worker_pid_(worker_pid),
+	      created_in_subxact_(GetCurrentSubTransactionId()) {
+		g_open_streams.insert(this);
+	}
+
+	SubTransactionId
+	CreatedInSubxact() const {
+		return created_in_subxact_;
+	}
+
+	~BackendSession() override {
+		g_open_streams.erase(this);
+		if (!done_ && worker_latch_) {
+			ch_->RequestCancel();
+			SetLatch(worker_latch_);
+		}
+		/* A cancel longjmp out of SendScanReply skips the C++ catch; the abort callback
+		 * deletes this object, so the destructor frees the page held mid-reply. */
+		if (inflight_page_ >= 0 && PagePool().Available())
+			PagePool().Release(PagePool().Slot(inflight_page_));
+		ch_.reset();                            /* detach the backend end (unblocks the worker's result-queue send) */
+		SessionPool().DetachEnd(session_slot_); /* return the slot once the worker also detaches */
+	}
+
+	duckdb::unique_ptr<duckdb::DataChunk>
+	Fetch() override {
+		int idle_ticks = 0;
+		for (;;) {
+			FrameTag tag = FrameTag::Error;
+			const char *data = nullptr;
+			std::size_t len = 0;
+			FrameResult fr = ch_->RecvResult(&tag, &data, &len, /*nowait=*/true);
+
+			if (fr == FrameResult::WouldBlock) {
+				if (ProcDiePending) {
+					/* Terminate: FATAL out; the shmem-exit callback releases the session. */
+					ch_->RequestCancel();
+					if (worker_latch_)
+						SetLatch(worker_latch_);
+					done_ = true;
+					CHECK_FOR_INTERRUPTS();
+				}
+				if (QueryCancelPending) {
+					ch_->RequestCancel();
+					if (worker_latch_)
+						SetLatch(worker_latch_);
+					done_ = true;
+					throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, "Query cancelled");
+				}
+				/* A crashed worker never detaches its rings, so an empty queue would
+				 * spin forever; probe its pid once a second and bail if it is gone. */
+				if (++idle_ticks >= 1 && !PidIsAlive(worker_pid_)) {
+					done_ = true;
+					throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, "duckdb worker terminated unexpectedly");
+				}
+				WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH, 1000L, PG_WAIT_EXTENSION);
+				ResetLatch(MyLatch);
+				continue;
+			}
+			idle_ticks = 0;
+			if (fr == FrameResult::Detached) {
+				done_ = true;
+				throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, "duckdb worker detached");
+			}
+			if (tag == FrameTag::ScanFetch) {
+				ServiceScanFetch(data, len);
+				continue;
+			}
+			if (tag == FrameTag::DescribeRel) {
+				ServeDescribeRelation(*ch_, data, len);
+				continue;
+			}
+			if (g_worker != nullptr && g_worker->ServeFrame(*ch_, tag, data, len)) {
+				continue;
+			}
+			if (tag == FrameTag::Chunk) {
+				auto chunk = duckdb::make_uniq<duckdb::DataChunk>();
+				DeserializeDataChunk(data, len, *chunk);
+				return chunk;
+			}
+			if (tag == FrameTag::Complete) {
+				done_ = true;
+				return nullptr;
+			}
+			if (tag == FrameTag::Error) {
+				std::string msg(data, len);
+				done_ = true;
+				throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, msg);
+			}
+			/* ignore unexpected frames */
+		}
+	}
+
+private:
+	// Reply to a scan fetch; every reply is prefixed with the scan_id so the worker's
+	// channel demux routes it to the right scan lane (scans + metadata RPCs interleave
+	// on one channel).
+	void
+	SendScanReply(uint32_t scan_id, FrameTag tag, const char *data, std::size_t len) {
+		std::string payload(reinterpret_cast<const char *>(&scan_id), sizeof(scan_id));
+		if (len > 0)
+			payload.append(data, len);
+		ch_->SendControl(tag, payload.data(), payload.size());
+	}
+
+	// Service a worker's heap-scan fetch: payload is [uint32 scan_id][optional inner
+	// SQL on the first fetch]. Opens a streaming producer on first fetch, then streams
+	// one chunk per fetch until exhausted (ScanDone).
+	void
+	ServiceScanFetch(const char *data, std::size_t len) {
+		uint32_t scan_id = 0;
+		std::memcpy(&scan_id, data, sizeof(scan_id));
+
+		auto it = open_scans_.find(scan_id);
+		if (it == open_scans_.end()) {
+			// A bare fetch (no open payload) for an unknown scan: its open failed and
+			// was never registered; don't read past the 4-byte payload.
+			if (len <= sizeof(scan_id)) {
+				const char kMsg[] = "scan open previously failed";
+				SendScanReply(scan_id, FrameTag::ScanError, kMsg, sizeof(kMsg) - 1);
+				return;
+			}
+			// First fetch: payload is [scan_id][uint8 count_only][inner SQL]. Open
+			// errors are reported but the scan is not registered.
+			try {
+				bool count_only = data[sizeof(scan_id)] != 0;
+				std::string sql(data + sizeof(scan_id) + 1, len - sizeof(scan_id) - 1);
+				auto st = std::make_unique<BackendScanState>();
+				InitBackendScan(*st, sql, count_only);
+				it = open_scans_.emplace(scan_id, std::move(st)).first;
+			} catch (const std::exception &e) {
+				std::string msg = e.what();
+				SendScanReply(scan_id, FrameTag::ScanError, msg.c_str(), msg.size());
+				return;
+			}
+		}
+		BackendScanState &st = *it->second;
+
+		// A scan is kept (not erased) after it finishes/errors so the extra requests
+		// from the worker's read-ahead window get a terminal reply, not a re-open.
+		if (st.errored) {
+			SendScanReply(scan_id, FrameTag::ScanError, st.err_msg.c_str(), st.err_msg.size());
+			return;
+		}
+		if (st.done) {
+			st.ReleaseReader();
+			SendScanReply(scan_id, FrameTag::ScanDone, nullptr, 0);
+			return;
+		}
+
+		// inflight_page_ (not a local): a cancel longjmp out of the blocking send skips
+		// the catch below; the destructor then releases the held page.
+		// The reader is released the moment a scan turns terminal (done/errored): an
+		// open reader keeps this backend in parallel mode, which would fail the GUC
+		// write in metadata servicing interleaved on this channel.
+		try {
+			if (st.is_count) {
+				// COUNT(*): one BIGINT, serialized inline so the response is self-contained
+				// (the read-ahead window keeps several fetches in flight).
+				if (!ProduceCountChunk(st)) {
+					st.ReleaseReader();
+					SendScanReply(scan_id, FrameTag::ScanDone, nullptr, 0);
+					return;
+				}
+				st.ReleaseReader(); // ProduceCountChunk drained the reader (done)
+				duckdb::MemoryStream stream;
+				SerializeDataChunk(st.chunk, stream);
+				SendScanReply(scan_id, FrameTag::ScanChunk, reinterpret_cast<const char *>(stream.GetData()),
+				              stream.GetPosition());
+				return;
+			}
+
+			// Data scans use the Arrow transport only (no serialize fallback). A page is
+			// essentially always available -- bounded by the read-ahead window -- but
+			// briefly retry rather than fail if the pool is momentarily empty.
+			PagePool pool;
+			PageSlot *slot = nullptr;
+			for (int tries = 0; (slot = pool.Acquire()) == nullptr; tries++) {
+				if (tries >= 2000)
+					throw std::runtime_error("duckdb worker: Arrow page pool exhausted");
+				CHECK_FOR_INTERRUPTS();
+				pg_usleep(500);
+			}
+			inflight_page_ = slot->index;
+			char desc[sizeof(ArrowBatchHeader) + 64 * sizeof(ArrowColDesc)];
+			ssize_t desc_len =
+			    ProduceArrowChunk(st, slot->data, (std::size_t)pool.PageSize(), inflight_page_, desc, sizeof(desc));
+			if (desc_len == 0) { // end of scan
+				pool.Release(slot);
+				inflight_page_ = -1;
+				st.ReleaseReader();
+				SendScanReply(scan_id, FrameTag::ScanDone, nullptr, 0);
+				return;
+			}
+			SendScanReply(scan_id, FrameTag::ScanChunkArrow, desc, (std::size_t)desc_len);
+			inflight_page_ = -1; // the worker owns the page now (frees it on chunk drop)
+			if (st.done)
+				st.ReleaseReader(); // last page: don't hold parallel mode until the terminal fetch
+		} catch (const std::exception &e) {
+			if (inflight_page_ >= 0) {
+				PagePool().Release(PagePool().Slot(inflight_page_));
+				inflight_page_ = -1;
+			}
+			st.errored = true;
+			st.err_msg = e.what();
+			st.ReleaseReader();
+			SendScanReply(scan_id, FrameTag::ScanError, st.err_msg.c_str(), st.err_msg.size());
+		}
+	}
+
+	std::unique_ptr<SessionChannel> ch_;
+	int session_slot_;
+	Latch *worker_latch_;
+	pid_t worker_pid_;
+	bool done_ = false;
+	int inflight_page_ = -1; // page held across a scan-reply send; freed by the destructor
+	SubTransactionId created_in_subxact_;
+	std::unordered_map<uint32_t, std::unique_ptr<BackendScanState>> open_scans_ = {};
+};
+
+/* Release open sessions: all of them (InvalidSubTransactionId) on transaction abort
+ * or process exit, or only those created inside `subid` on a subtransaction abort. */
+void
+ReleaseOpenSessions(SubTransactionId subid) {
+	for (;;) {
+		BackendSession *victim = nullptr;
+		for (auto *stream : g_open_streams) {
+			if (subid == InvalidSubTransactionId || stream->CreatedInSubxact() == subid) {
+				victim = stream;
+				break;
+			}
+		}
+		if (victim == nullptr)
+			break;
+		delete victim; /* destructor cancels, detaches, unregisters */
+	}
+	if (g_pending_session_slot >= 0) {
+		/* A cancel longjmp out of OpenSession skipped the channel destructor; set the
+		 * cancel flag so the worker-side handshake (which polls it) bails too. */
+		SessionChannel::RequestCancelAt(SessionPool().ChannelBase(g_pending_session_slot));
+		SessionPool().DetachEnd(g_pending_session_slot);
+		g_pending_session_slot = -1;
+	}
+}
+
+} // namespace
+} // namespace backend
+
+namespace worker {
+namespace {
+
+/* Kernel remote-scan hook (worker only): open a heap scan. Prefer the shared
+ * scan worker pool (parallel producers) when it is up and the backend's snapshot is
+ * available; otherwise fall back to the in-backend scan-inversion stream. */
+duckdb::unique_ptr<RemoteScanStream>
+OpenRemoteScan(duckdb::ClientContext &context, const std::string &scan_sql, bool count_only,
+               const RemoteScanInfo &info) {
+	SessionChannel *channel = nullptr;
+	std::string snapshot_bytes;
+	{
+		std::lock_guard<std::mutex> lock(g_session_ctx_lock);
+		auto it = g_session_ctx.find(&context);
+		if (it == g_session_ctx.end())
+			return nullptr; /* not a worker session -> run in-process */
+		channel = it->second.channel;
+		snapshot_bytes = it->second.snapshot_bytes;
+	}
+
+	// Temp tables are backend-local: only the requesting backend can see them, so they
+	// must use the inversion path, never the separate scan-worker processes.
+	if (!info.local_relation && g_scan_workers_spawned > 0 && ScanQueue::Available() && ScanRing::Available() &&
+	    PagePool().Available() && !snapshot_bytes.empty()) {
+		auto stream = OpenPoolScanStream(channel, MyDatabaseId, scan_sql, count_only, info, snapshot_bytes,
+		                                 *g_settings.scan_producers);
+		if (stream)
+			return stream;
+		/* open/enqueue failed -> fall back to inversion */
+	}
+
+	return OpenInversionScanStream(channel, scan_sql, count_only);
+}
+
+/* Unregisters the session's context entries when the connection's scope ends (before
+ * the ClientContext is destroyed), on both normal and exception exit -- including any
+ * nested-connection aliases pointing at the same channel. */
+struct SessionCtxGuard {
+	duckdb::ClientContext *key;
+	~SessionCtxGuard() {
+		std::lock_guard<std::mutex> lock(g_session_ctx_lock);
+		auto it = g_session_ctx.find(key);
+		if (it == g_session_ctx.end())
+			return;
+		SessionChannel *channel = it->second.channel;
+		for (auto e = g_session_ctx.begin(); e != g_session_ctx.end();) {
+			e = (e->second.channel == channel) ? g_session_ctx.erase(e) : std::next(e);
+		}
+	}
+};
+
+/* Run one shipped query on its own DuckDB connection and stream the result. Runs on a
+ * session thread: the worker is PG-free here (catalog is fetched from the backend via
+ * DescribeRel RPC, heap scans run on the backend via scan inversion), and all channel
+ * transport goes through the Serialized* helpers that take the global process lock.
+ * Errors are C++ exceptions (no PG longjmp), so no PG_TRY -- which would be unsafe off
+ * the main thread anyway. */
+void
+RunOneSession(SessionChannel &ch) {
+	FrameTag tag = FrameTag::Error;
+	const char *data = nullptr;
+	std::size_t len = 0;
+	std::string snapshot_bytes;
+	if (ch.SerializedRecvControl(&tag, &data, &len) == FrameResult::Ok && tag == FrameTag::Snapshot) {
+		snapshot_bytes.assign(data, len);            /* re-shipped to scan worker tasks */
+		ch.SerializedRecvControl(&tag, &data, &len); /* next frame: the SQL */
+	}
+	std::string sql = (tag == FrameTag::Sql) ? std::string(data, len) : std::string();
+
+	/* Thread-local: read by binding/optimization code (catalog RPC, transaction manager,
+	 * order pushdown), which runs on this session thread during con.SendQuery. */
+	SetCurrentWorkerSession(&ch);
+	try {
+		/* Own connection on the shared instance: each session gets its own DuckDB
+		 * connection so N sessions run concurrently. The engine + its secrets/extensions
+		 * were primed once at worker startup, so a fresh connection needs no per-query
+		 * refresh (which would touch PG). */
+		duckdb::Connection con(WorkerAccess::Database(g_worker));
+		duckdb::ClientContext *ctx_key = con.context.get();
+		{
+			std::lock_guard<std::mutex> lock(g_session_ctx_lock);
+			g_session_ctx[ctx_key] = WorkerSessionContext {&ch, std::move(snapshot_bytes), con.context};
+		}
+		SessionCtxGuard guard {ctx_key};
+		RunWorkerSession(con, ch, sql);
+	} catch (const std::exception &e) {
+		ch.SerializedSendResult(FrameTag::Error, e.what(), std::strlen(e.what()));
+	}
+	SetCurrentWorkerSession(nullptr);
+}
+
+/* Session thread entry: validate + attach the connection slot (palloc in shm_mq_attach
+ * -> under the global process lock), run the query, detach. A stale entry -- its
+ * backend released the slot (or another backend re-acquired it) after enqueueing -- is
+ * skipped via the generation check. The done flag lets the main loop reap the thread. */
+void
+SessionThreadMain(PendingSession session, std::shared_ptr<std::atomic<bool>> done) {
+	int session_slot = (int)session.session_slot;
+	std::unique_ptr<SessionChannel> ch;
+	if (SessionPool().TryAttachEnd(session_slot, session.session_generation)) {
+		std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+		ch = SessionChannel::AttachSlot(SessionPool().ChannelBase(session_slot));
+	}
+	if (ch) {
+		RunOneSession(*ch);
+		std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+		ch.reset(); /* shm_mq_detach -> under the lock */
+		SessionPool().DetachEnd(session_slot);
+	}
+	done->store(true, std::memory_order_release);
+}
+
+} // namespace
+} // namespace worker
+
+DuckdbWorker::DuckdbWorker(const Settings &settings) : settings_(settings) {
+}
+
+void
+DuckdbWorker::Init() {
+	g_settings = settings_;
+	g_worker = this;
+
+#if PG_VERSION_NUM >= 150000
+	prev_shmem_request_hook = shmem_request_hook;
+	shmem_request_hook = ShmemRequest;
+#else
+	ShmemRequest();
+#endif
+	prev_shmem_startup_hook = shmem_startup_hook;
+	shmem_startup_hook = ShmemStartup;
+}
+
+bool
+DuckdbWorker::InWorker() {
+	return g_in_duckdb_worker;
+}
+
+bool
+DuckdbWorker::Enabled() {
+	return *g_settings.max_sessions > 0;
+}
+
+duckdb::unique_ptr<WorkerResultStream>
+DuckdbWorker::OpenSession(const std::string &sql) {
+	pid_t worker_pid = 0;
+	Latch *worker_latch = backend::EnsureWorkerForMyDatabase(&worker_pid);
+	backend::EnsureBackendCleanupRegistered();
+
+	/* Serialize the snapshot before claiming a slot: palloc may error, and the slot is
+	 * only tracked for cleanup (g_pending_session_slot) from the moment it is claimed. */
+	Snapshot snap = GetActiveSnapshot();
+	Size snap_sz = EstimateSnapshotSpace(snap);
+	char *snap_buf = (char *)palloc(snap_sz);
+	SerializeSnapshot(snap, snap_buf);
+
+	/* Wait (cancellably) for a free session slot rather than falling back to
+	 * in-process execution: spinning up a per-backend engine per overflow query is
+	 * exactly the memory blow-up the shared worker exists to prevent. The wait ends
+	 * on cancel/statement_timeout like any other statement. */
+	int session_slot;
+	for (;;) {
+		session_slot = SessionPool().Acquire();
+		if (session_slot >= 0)
+			break;
+		CHECK_FOR_INTERRUPTS();
+		(void)WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH, 10L, PG_WAIT_EXTENSION);
+		ResetLatch(MyLatch);
+	}
+	SessionPool().AttachEnd(session_slot);          /* the backend's hold on the slot */
+	backend::g_pending_session_slot = session_slot; /* released by the abort callback until a stream owns it */
+	auto ch = SessionChannel::OpenSlot(SessionPool().ChannelBase(session_slot));
+	if (!ch) {
+		SessionPool().DetachEnd(session_slot);
+		backend::g_pending_session_slot = -1;
+		pfree(snap_buf);
+		ereport(ERROR, (errcode(ERRCODE_OUT_OF_MEMORY), errmsg("could not open session channel")));
+	}
+
+	/* Publish the session to the worker's pending ring, waiting out transient states
+	 * (worker died -> respawn it; ring not yet drained -> retry) instead of falling
+	 * back. The interrupt check makes the wait cancellable; the abort callback then
+	 * releases the claimed slot. */
+	uint32 session_generation = SessionPool().Generation(session_slot);
+	for (;;) {
+		bool queued = false;
+		bool have_worker = false;
+		SpinLockAcquire(&g_duckdb_workers->lock);
+		int slot = FindWorkerSlot(MyDatabaseId);
+		if (slot >= 0) {
+			have_worker = true;
+			queued = backend::EnqueuePendingSession(slot, (uint32)session_slot, session_generation);
+			if (queued) {
+				worker_latch = g_duckdb_workers->workers[slot].worker_latch;
+				worker_pid = g_duckdb_workers->workers[slot].worker_pid;
+			}
+		}
+		SpinLockRelease(&g_duckdb_workers->lock);
+		if (queued)
+			break;
+		if (!have_worker) {
+			worker_latch = backend::EnsureWorkerForMyDatabase(&worker_pid); /* respawns a dead worker */
+			continue;
+		}
+		CHECK_FOR_INTERRUPTS();
+		(void)WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH, 10L, PG_WAIT_EXTENSION);
+		ResetLatch(MyLatch);
+	}
+
+	SetLatch(worker_latch);
+	/* Ship the backend's active snapshot, then the SQL, so heap reads produced for the
+	 * worker use this backend's MVCC view. */
+	ch->SendControl(FrameTag::Snapshot, snap_buf, snap_sz);
+	pfree(snap_buf);
+	ch->SendControl(FrameTag::Sql, sql.c_str(), sql.size());
+
+	auto stream = duckdb::make_uniq<backend::BackendSession>(std::move(ch), session_slot, worker_latch, worker_pid);
+	backend::g_pending_session_slot = -1; /* the stream owns the slot now */
+	return stream;
+}
+
+namespace worker {
+
+SessionChannel *
+WorkerSessionForContext(duckdb::ClientContext *ctx) {
+	std::lock_guard<std::mutex> lock(g_session_ctx_lock);
+	auto it = g_session_ctx.find(ctx);
+	return it == g_session_ctx.end() ? nullptr : it->second.channel;
+}
+
+SessionChannel *
+EffectiveWorkerSession(duckdb::ClientContext *ctx) {
+	if (auto *session = CurrentWorkerSession())
+		return session;
+	if (ctx == nullptr)
+		return nullptr;
+	return WorkerSessionForContext(ctx);
+}
+
+void
+AliasWorkerSessionContext(const duckdb::shared_ptr<duckdb::ClientContext> &ctx, duckdb::ClientContext *primary) {
+	std::lock_guard<std::mutex> lock(g_session_ctx_lock);
+	auto it = g_session_ctx.find(primary);
+	if (it == g_session_ctx.end() || ctx.get() == primary)
+		return;
+	WorkerSessionContext entry = it->second;
+	entry.ctx_weak = ctx; /* the alias's own liveness, not the primary's */
+	g_session_ctx[ctx.get()] = std::move(entry);
+}
+
+void
+UnaliasWorkerSessionContext(duckdb::ClientContext *ctx, SessionChannel *channel) {
+	std::lock_guard<std::mutex> lock(g_session_ctx_lock);
+	auto it = g_session_ctx.find(ctx);
+	/* Channel guard: another session may have re-registered the freed address. */
+	if (it != g_session_ctx.end() && it->second.channel == channel)
+		g_session_ctx.erase(it);
+}
+
+} // namespace worker
+
+uint64_t
+DuckdbWorker::DispatchCount() const {
+	if (g_duckdb_workers == nullptr)
+		return 0;
+	uint64 n = 0;
+	SpinLockAcquire(&g_duckdb_workers->lock);
+	int idx = FindWorkerSlot(MyDatabaseId);
+	if (idx >= 0)
+		n = g_duckdb_workers->workers[idx].dispatched;
+	SpinLockRelease(&g_duckdb_workers->lock);
+	return n;
+}
+
+void
+DuckdbWorker::Main(uint32_t db_oid_arg) {
+	Oid db_oid = (Oid)db_oid_arg;
+
+	g_in_duckdb_worker = true;
+	/* Heap scans run on the requesting backend (scan inversion), so the worker's
+	 * execution threads are PG-free; install the remote-scan hook here (worker only,
+	 * never in regular backends). */
+	pgddb_open_remote_scan_hook = worker::OpenRemoteScan;
+
+	/* Custom SIGTERM: just flag + wake. The worker runs session threads, so it must stop
+	 * them before exiting -- die()'s CHECK_FOR_INTERRUPTS path would proc_exit while
+	 * threads still touch shmem. The main loop drains threads, then exits cleanly. */
+	pqsignal(SIGTERM, worker::WorkerSigterm);
+	BackgroundWorkerUnblockSignals();
+
+	BackgroundWorkerInitializeConnectionByOid(db_oid, InvalidOid, 0);
+
+	Configure();
+
+	SpinLockAcquire(&g_duckdb_workers->lock);
+	int idx = FindWorkerSlot(db_oid);
+	if (idx >= 0) {
+		g_duckdb_workers->workers[idx].worker_pid = MyProcPid;
+		g_duckdb_workers->workers[idx].worker_latch = MyLatch;
+	}
+	SpinLockRelease(&g_duckdb_workers->lock);
+
+	elog(LOG, "%s duckdb worker started for database %u, pid %d", g_settings.display_name, db_oid, MyProcPid);
+
+	/* Prime the engine once, inside a transaction: lazy engine init reads PG catalog.
+	 * After this the per-query path reuses the primed instance and never re-initializes,
+	 * so it can run transaction-free. */
+	StartTransactionCommand();
+	PushActiveSnapshot(GetTransactionSnapshot());
+	Prime();
+	PopActiveSnapshot();
+	CommitTransactionCommand();
+
+	worker::SpawnScanWorkers(db_oid);
+
+	/* Drain session threads before any process exit -- including elog(FATAL), which
+	 * proc_exits without returning through the main loop; a thread touching shmem or
+	 * DuckDB during teardown (or left attached to its connection slot) must not
+	 * survive it. */
+	before_shmem_exit(
+	    [](int, Datum) {
+		    SetWorkerDraining(true);
+		    for (auto &s : worker::g_worker_sessions) {
+			    if (s.thread.joinable())
+				    s.thread.join();
+		    }
+		    worker::g_worker_sessions.clear();
+	    },
+	    (Datum)0);
+
+	while (!worker::g_duckdb_worker_got_sigterm) {
+		WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH, 1000L, PG_WAIT_EXTENSION);
+		ResetLatch(MyLatch);
+
+		/* Propagate backend cancellations into running DuckDB queries: a session whose
+		 * channel has the cancel flag set gets its ClientContext interrupted, so the
+		 * query aborts promptly instead of computing to the next chunk boundary. The
+		 * backend sets the flag and pokes this latch (RequestCancel + SetLatch). */
+		{
+			std::lock_guard<std::mutex> lock(worker::g_session_ctx_lock);
+			for (auto &entry : worker::g_session_ctx) {
+				/* Only touch the context through the weak_ptr; the raw key may be stale. */
+				auto live = entry.second.ctx_weak.lock();
+				if (live && entry.second.channel->IsCancelRequested())
+					live->Interrupt();
+			}
+		}
+
+		/* Reap finished session threads. */
+		for (std::size_t i = 0; i < worker::g_worker_sessions.size();) {
+			if (worker::g_worker_sessions[i].done->load(std::memory_order_acquire)) {
+				worker::g_worker_sessions[i].thread.join();
+				worker::g_worker_sessions.erase(worker::g_worker_sessions.begin() + i);
+			} else {
+				i++;
+			}
+		}
+
+		/* Drain pending sessions; spawn a thread for each. */
+		for (;;) {
+			PendingSession session {};
+			bool have = false;
+			SpinLockAcquire(&g_duckdb_workers->lock);
+			idx = FindWorkerSlot(db_oid);
+			if (idx >= 0) {
+				DuckdbWorkerSlot &w = g_duckdb_workers->workers[idx];
+				if (w.pending_head != w.pending_tail) {
+					session = w.pending[w.pending_head % MAX_PENDING_SESSIONS];
+					w.pending_head++;
+					have = true;
+				}
+			}
+			SpinLockRelease(&g_duckdb_workers->lock);
+			if (!have)
+				break;
+
+			auto done = std::make_shared<std::atomic<bool>>(false);
+			worker::g_worker_sessions.push_back(
+			    worker::WorkerSession {std::thread(worker::SessionThreadMain, session, done), done});
+		}
+	}
+
+	/* Shutdown: signal session-thread polls to bail, then join them before exiting so no
+	 * thread touches shmem/DuckDB during process teardown. */
+	SetWorkerDraining(true);
+	for (auto &s : worker::g_worker_sessions) {
+		if (s.thread.joinable())
+			s.thread.join();
+	}
+	worker::g_worker_sessions.clear();
+
+	elog(LOG, "%s duckdb worker for database %u shutting down", g_settings.display_name, db_oid);
+}
+
+/* A scan worker: idles on its latch, claims block-range tasks for its database, and
+ * runs each one (PostgresTableReader under the shipped snapshot -> Arrow/serialized
+ * pages into the scan's ready-ring). PG-only; never runs DuckDB. */
+void
+DuckdbWorker::ScanWorkerMain(uint32_t db_oid_arg) {
+	Oid db_oid = (Oid)db_oid_arg;
+
+	pqsignal(SIGTERM, die);
+	BackgroundWorkerUnblockSignals();
+	BackgroundWorkerInitializeConnectionByOid(db_oid, InvalidOid, 0);
+
+	/* The producer's own reader stays single-threaded (no nested PG parallel workers). */
+	SetConfigOption("duckdb.max_workers_per_postgres_scan", "0", PGC_SUSET, PGC_S_SESSION);
+
+	/* FATAL runs shmem-exit callbacks but skips PG_CATCH: error out the active range so
+	 * its consumer sees a terminal state instead of waiting forever. */
+	before_shmem_exit(
+	    [](int, Datum) {
+		    if (producer::g_have_active_range)
+			    ScanRing().SetError(producer::g_active_range.scan_id, producer::g_active_range.generation,
+			                        "scan worker terminated");
+		    if (producer::g_held_page >= 0 && PagePool().Available())
+			    PagePool().Release(PagePool().Slot(producer::g_held_page));
+		    ScanQueue().UnpublishWorker();
+	    },
+	    (Datum)0);
+	ScanQueue().PublishWorker((uint32)db_oid);
+	elog(LOG, "%s scan worker started for database %u, pid %d", g_settings.display_name, db_oid, MyProcPid);
+
+	while (!ShutdownRequestPending) {
+		WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH, 1000L, PG_WAIT_EXTENSION);
+		ResetLatch(MyLatch);
+		CHECK_FOR_INTERRUPTS();
+
+		ScanRange range;
+		ScanQueue q;
+		while (q.Claim((uint32)db_oid, &range)) {
+			producer::ProcessScanRange(range);
+		}
+	}
+
+	elog(LOG, "%s scan worker for database %u shutting down", g_settings.display_name, db_oid);
+}
+
+} // namespace pgddb

--- a/libpgduckdb/worker/scan_producer.cpp
+++ b/libpgduckdb/worker/scan_producer.cpp
@@ -1,0 +1,564 @@
+#include "pgddb/worker/scan_producer.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <exception>
+#include <mutex>
+
+#include "pgddb/pgddb_process_lock.hpp"
+#include "pgddb/pgddb_types.hpp"
+#include "pgddb/scan/postgres_table_reader.hpp"
+#include "pgddb/worker/transport/page_pool.hpp"
+#include "pgddb/worker/transport/scan_ring.hpp"
+#include "pgddb/worker/transport/session_channel.hpp"
+#include "pgddb/worker/transport/session_protocol.hpp"
+
+#include <duckdb/common/allocator.hpp>
+#include <duckdb/common/serializer/memory_stream.hpp>
+#include <duckdb/common/types/value.hpp>
+
+extern "C" {
+#include "postgres.h"
+
+#include "access/htup_details.h"
+#include "access/xact.h"
+#include "executor/tuptable.h"
+#include "miscadmin.h"
+#include "utils/memutils.h"
+#include "utils/snapmgr.h"
+}
+
+namespace pgddb {
+
+namespace {
+constexpr int SCAN_SLOT_BATCH = 32;
+} // namespace
+
+BackendScanState::BackendScanState()
+    : reader(), slots(), chunk(), err_msg(), arrow_codes(), arrow_prec(), arrow_scale() {
+}
+
+BackendScanState::~BackendScanState() {
+	if (reader) {
+		// abort-path cleanup must not throw out of a destructor
+		try {
+			reader->Cleanup();
+		} catch (...) {
+		}
+	}
+}
+
+void
+BackendScanState::ReleaseReader() {
+	slots.clear();
+	carry = nullptr;
+	has_carry = false;
+	if (!reader)
+		return;
+	try {
+		reader->Cleanup(); // exits parallel mode, drops the scan's executor state
+	} catch (...) {
+	}
+	reader.reset();
+}
+
+void
+InitBackendScan(BackendScanState &st, const std::string &sql, bool count_only) {
+	st.is_count = count_only;
+	st.reader = duckdb::make_uniq<PostgresTableReader>();
+	// count_only makes the reader handle the COUNT(*) aggregate plan (GetNextCount).
+	st.reader->Init(sql.c_str(), count_only); // guarded: a PG error becomes a C++ exception
+
+	if (count_only) {
+		// The worker reads the count from cell (0,0) of a single BIGINT chunk.
+		duckdb::vector<duckdb::LogicalType> types {duckdb::LogicalType::BIGINT};
+		st.ncols = 1;
+		st.chunk.Initialize(duckdb::Allocator::DefaultAllocator(), types);
+		return;
+	}
+
+	// Data scans use the Arrow transport exclusively. Every column must be Arrow-encodable
+	// (and fit the descriptor buffer); an unsupported column fails the scan loudly rather
+	// than silently falling back, so the gap is visible and gets Arrow support next.
+	if (!PagePool().Available())
+		throw std::runtime_error("duckdb worker requires an Arrow page pool (arrow_pool_pages > 0)");
+
+	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+	for (int i = 0; i < SCAN_SLOT_BATCH; i++) {
+		st.slots.push_back(st.reader->InitTupleSlot());
+	}
+	TupleDesc tupdesc = st.slots[0]->tts_tupleDescriptor;
+	st.ncols = tupdesc->natts;
+	if (st.ncols > 64)
+		throw std::runtime_error("duckdb worker: too many columns for the Arrow scan transport (max 64)");
+	for (int i = 0; i < st.ncols; i++) {
+		Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
+		duckdb::LogicalType type = ConvertPostgresToDuckColumnType(attr);
+		ArrowColCode code;
+		uint8_t p, s;
+		if (!ArrowColumnSpec(attr->atttypid, type, code, p, s))
+			throw std::runtime_error("duckdb worker: column \"" + std::string(NameStr(attr->attname)) +
+			                         "\" (type oid " + std::to_string((unsigned)attr->atttypid) +
+			                         ") is not supported by the Arrow scan transport");
+		st.arrow_codes.push_back(code);
+		st.arrow_prec.push_back(p);
+		st.arrow_scale.push_back(s);
+	}
+	st.carry = st.reader->InitTupleSlot();
+}
+
+ssize_t
+ProduceArrowChunk(BackendScanState &st, char *page, std::size_t capacity, int page_index, char *desc_out,
+                  std::size_t desc_cap) {
+	ArrowBatchBuilder b(page, capacity, st.arrow_codes, st.arrow_prec, st.arrow_scale, STANDARD_VECTOR_SIZE);
+	if (!b.LayoutOk())
+		throw std::runtime_error("duckdb worker: scan column layout too large for an Arrow page; "
+		                         "raise the arrow page size");
+
+	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+	if (st.has_carry) {
+		slot_getallattrs(st.carry);
+		if (!b.AppendSlot(st.carry))
+			throw std::runtime_error("row too large for arrow page; raise the arrow page size");
+		st.has_carry = false;
+	}
+	while (b.Rows() < STANDARD_VECTOR_SIZE && !st.done) {
+		int valid = st.reader->GetNextInProcessTuples(st.slots.data(), 1);
+		if (valid == 0) {
+			st.done = true;
+			break;
+		}
+		slot_getallattrs(st.slots[0]);
+		if (!b.AppendSlot(st.slots[0])) {
+			if (b.Rows() == 0)
+				throw std::runtime_error("row too large for arrow page; raise the arrow page size");
+			ExecCopySlot(st.carry, st.slots[0]); // defer to the next page
+			st.has_carry = true;
+			break;
+		}
+	}
+	if (b.Rows() == 0)
+		return 0;
+	return (ssize_t)b.Finalize(page_index, desc_out, desc_cap);
+}
+
+bool
+ProduceCountChunk(BackendScanState &st) {
+	if (st.done) {
+		return false;
+	}
+	uint64_t total = 0, partial = 0;
+	{
+		std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+		while (st.reader->GetNextCount(&partial)) {
+			total += partial;
+		}
+	}
+	st.chunk.Reset();
+	st.chunk.SetValue(0, 0, duckdb::Value::BIGINT((int64_t)total));
+	st.chunk.SetCardinality(1);
+	st.done = true;
+	return true;
+}
+
+/* Code that runs only in the dedicated scan-producer bgworker processes. */
+namespace producer {
+
+namespace {
+
+/* Scan-worker side: produce all chunks for one task and push them into the scan's
+ * ready-ring. Data scans build an Arrow batch into a pool page (descriptor at the page
+ * front, data after the reserved area); COUNT(*) serializes its single BIGINT chunk into
+ * a page. Stops early (returns) if the scan was torn down by the consumer. */
+void
+PoolProduceScan(BackendScanState &st, const ScanRange &range, int *held_page) {
+	const std::size_t reserve = ScanRing::DescReserve();
+	while (!st.done) {
+		PagePool pool;
+		PageSlot *slot = pool.Acquire();
+		if (slot == nullptr) { // pool momentarily empty -> wait for the consumer to free pages
+			if (!ScanRing().Alive(range.scan_id, range.generation))
+				return;
+			CHECK_FOR_INTERRUPTS();
+			pg_usleep(500);
+			continue;
+		}
+		int page_idx = slot->index;
+		*held_page = page_idx; // we own this page until it is pushed or released
+		char *page = slot->data;
+		std::size_t cap = (std::size_t)pool.PageSize();
+
+		uint32_t desc_len = 0, byte_len = 0;
+		if (st.is_count) {
+			if (!ProduceCountChunk(st)) { // already produced
+				pool.Release(slot);
+				*held_page = -1;
+				break;
+			}
+			duckdb::MemoryStream stream(reinterpret_cast<duckdb::data_ptr_t>(page), cap);
+			SerializeDataChunk(st.chunk, stream);
+			byte_len = (uint32_t)stream.GetPosition();
+		} else {
+			char desc[sizeof(ArrowBatchHeader) + 64 * sizeof(ArrowColDesc)];
+			ssize_t n = ProduceArrowChunk(st, page + reserve, cap - reserve, page_idx, desc, sizeof(desc));
+			if (n == 0) { // end of scan
+				pool.Release(slot);
+				*held_page = -1;
+				break;
+			}
+			std::memcpy(page, desc, (std::size_t)n); // descriptor in the reserved page front
+			desc_len = (uint32_t)n;
+		}
+
+		if (!ScanRing().Push(range.scan_id, range.generation, (uint32_t)page_idx, desc_len, byte_len)) {
+			pool.Release(slot); // scan torn down
+			*held_page = -1;
+			return;
+		}
+		*held_page = -1; // ring owns it now
+	}
+}
+
+/* Splice a CTID block-range predicate into the base scan SQL at `where_off` (right
+ * after FROM <relation>), AND-ing with any existing WHERE. Range is blocks [lo, hi). */
+std::string
+BuildRangedScanSql(const std::string &base, uint32_t where_off, uint32_t lo, uint32_t hi) {
+	std::string pred = "ctid >= '(" + std::to_string(lo) + ",1)' AND ctid < '(" + std::to_string(hi) + ",1)'";
+	std::string head = base.substr(0, where_off);
+	std::string tail = base.substr(where_off);
+	const std::string kWhere = " WHERE ";
+	if (tail.compare(0, kWhere.size(), kWhere) == 0)
+		return head + " WHERE " + pred + " AND " + tail.substr(kWhere.size());
+	return head + " WHERE " + pred + tail;
+}
+
+} // namespace
+
+/* The scan worker's currently-claimed range (main-thread-only plain flag), so the
+ * shmem-exit callback can error it out on FATAL (which skips PG_CATCH). */
+ScanRange g_active_range;
+bool g_have_active_range = false;
+int g_held_page = -1;
+
+/* The body runs in a PG_TRY so a raw PG error (longjmp) is turned into a scan error
+ * for the consumer instead of killing the producer and hanging the consumer; an inner
+ * C++ try/catch handles the guarded PostgresTableReader exceptions. Either way the
+ * scan gets TaskDone or SetError. */
+void
+ProcessScanRange(const ScanRange &range) {
+	std::vector<char> sqlbuf(16384), snapbuf(8192);
+	std::size_t sqllen = 0, snaplen = 0;
+	bool count_only = false;
+	uint32_t where_off = 0;
+	if (!ScanRing().GetInputs(range.scan_id, range.generation, sqlbuf.data(), sqlbuf.size(), &sqllen, snapbuf.data(),
+	                          snapbuf.size(), &snaplen, &count_only, &where_off))
+		return; // scan torn down before we started
+	std::string sql(sqlbuf.data(), sqllen);
+	if (range.hi_blk > 0) // ranged task: scan only blocks [lo, hi)
+		sql = BuildRangedScanSql(sql, where_off, range.lo_blk, range.hi_blk);
+
+	g_active_range = range;
+	g_have_active_range = true;
+
+	StartTransactionCommand();
+	PushActiveSnapshot(GetTransactionSnapshot());
+	PushActiveSnapshot(RestoreSnapshot(snapbuf.data()));
+
+	volatile bool ok = true;
+	std::string errmsg;
+	g_held_page = -1; // page the producer owns; freed here (or by the shmem-exit hook on FATAL)
+	PG_TRY();
+	{
+		// BackendScanState is a C++ local: its destructor runs on a normal return or a
+		// C++ exception, and is skipped on a PG longjmp (where AbortCurrentTransaction
+		// reclaims its PG resources instead).
+		try {
+			BackendScanState st;
+			InitBackendScan(st, sql, count_only);
+			PoolProduceScan(st, range, &g_held_page);
+		} catch (const std::exception &e) {
+			if (g_held_page >= 0) {
+				PagePool().Release(PagePool().Slot(g_held_page));
+				g_held_page = -1;
+			}
+			ok = false;
+			errmsg = e.what();
+		}
+	}
+	PG_CATCH();
+	{
+		if (g_held_page >= 0) {
+			PagePool().Release(PagePool().Slot(g_held_page));
+			g_held_page = -1;
+		}
+		MemoryContext ctx = MemoryContextSwitchTo(TopMemoryContext);
+		ErrorData *edata = CopyErrorData();
+		FlushErrorState();
+		MemoryContextSwitchTo(ctx);
+		ok = false;
+		errmsg = edata->message ? edata->message : "scan worker error";
+		FreeErrorData(edata);
+	}
+	PG_END_TRY();
+
+	if (ok)
+		ScanRing().TaskDone(range.scan_id, range.generation);
+	else
+		ScanRing().SetError(range.scan_id, range.generation, errmsg.c_str());
+	g_have_active_range = false;
+
+	PopActiveSnapshot();
+	PopActiveSnapshot();
+	if (ok)
+		CommitTransactionCommand();
+	else
+		AbortCurrentTransaction();
+}
+
+} // namespace producer
+
+/* Code that runs only inside the duckdb worker process. */
+namespace worker {
+
+namespace {
+
+/* Worker side: a heap scan that pulls DataChunks from the requesting backend over
+ * the session channel, so the worker's execution threads never call PostgreSQL.
+ * Each fetch is a round-trip: send ScanFetch (scan_id, + inner SQL on the first
+ * call) on the result queue, read one ScanChunk/ScanDone/ScanError on the control
+ * queue. */
+class InversionScanStream : public RemoteScanStream {
+public:
+	InversionScanStream(const InversionScanStream &) = delete;
+	InversionScanStream &operator=(const InversionScanStream &) = delete;
+	InversionScanStream(SessionChannel *ch, std::string sql, uint32_t scan_id, bool count_only)
+	    : ch_(ch), sql_(std::move(sql)), scan_id_(scan_id), count_only_(count_only) {
+	}
+
+	~InversionScanStream() override {
+		// Early teardown (LIMIT satisfied, error, cancel) can leave fetches outstanding;
+		// drain them so their Arrow pages are freed, then drop the demux lane (freeing
+		// pages of any frame that was routed there but never consumed).
+		if (!done_) {
+			try {
+				DrainOutstanding();
+			} catch (...) {
+			}
+		}
+		ch_->CloseScanLane(scan_id_, [](FrameTag tag, const std::string &payload) {
+			if (tag == FrameTag::ScanChunkArrow && payload.size() >= sizeof(ArrowBatchHeader)) {
+				auto *hdr = reinterpret_cast<const ArrowBatchHeader *>(payload.data());
+				PagePool().Release(PagePool().Slot((int)hdr->page_index));
+			}
+		});
+	}
+
+	duckdb::unique_ptr<duckdb::DataChunk>
+	Next(duckdb::ClientContext &context, const duckdb::vector<duckdb::LogicalType> &output_types) override {
+		// Read-ahead window: keep up to WINDOW ScanFetch requests outstanding so the
+		// backend produces chunks ahead while the worker computes -- the scan leaves
+		// the per-chunk critical path. Replies arrive on this scan's demux lane (they
+		// carry a scan_id prefix), so several scans and metadata RPCs share the channel.
+		std::lock_guard<std::mutex> lock(mutex_);
+		if (done_)
+			return nullptr;
+
+		while (outstanding_ < WINDOW) {
+			std::string req(reinterpret_cast<const char *>(&scan_id_), sizeof(scan_id_));
+			if (!started_) {
+				req += static_cast<char>(count_only_ ? 1 : 0); // first fetch carries the flag + SQL
+				req += sql_;
+				started_ = true;
+			}
+			ch_->SerializedSendResult(FrameTag::ScanFetch, req.data(), req.size());
+			outstanding_++;
+		}
+
+		FrameTag tag = FrameTag::ScanError;
+		std::string payload;
+		if (ch_->RecvScanReply(scan_id_, &tag, &payload) != FrameResult::Ok) {
+			done_ = true;
+			throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, "duckdb worker: scan channel detached");
+		}
+		outstanding_--;
+		if (tag == FrameTag::ScanChunkArrow) {
+			// Zero-copy: import the Arrow batch in the global pool page; the page is
+			// returned to the pool when DuckDB drops the chunk (release callback). On an
+			// import failure the page must be freed here since no callback was registered.
+			auto *hdr = reinterpret_cast<const ArrowBatchHeader *>(payload.data());
+			int page_index = (int)hdr->page_index;
+			char *page = PagePool().Slot(page_index)->data;
+			auto chunk = duckdb::make_uniq<duckdb::DataChunk>();
+			try {
+				ImportArrowBatch(context, page, payload.data(), payload.size(), output_types, *chunk,
+				                 [page_index]() { PagePool().Release(PagePool().Slot(page_index)); });
+			} catch (...) {
+				PagePool().Release(PagePool().Slot(page_index));
+				throw;
+			}
+			return chunk;
+		}
+		if (tag == FrameTag::ScanChunk) {
+			auto chunk = duckdb::make_uniq<duckdb::DataChunk>();
+			DeserializeDataChunk(payload.data(), payload.size(), *chunk);
+			return chunk;
+		}
+		if (tag == FrameTag::ScanDone) {
+			// Data is FIFO-before the first ScanDone, so the remaining outstanding
+			// replies are all terminal; drain them to leave the lane clean.
+			done_ = true;
+			DrainOutstanding();
+			return nullptr;
+		}
+		done_ = true; /* ScanError */
+		DrainOutstanding();
+		throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, payload);
+	}
+
+private:
+	void
+	DrainOutstanding() {
+		while (outstanding_ > 0) {
+			FrameTag tag;
+			std::string payload;
+			if (ch_->RecvScanReply(scan_id_, &tag, &payload) != FrameResult::Ok)
+				break;
+			// A drained Arrow response owns a pool page that nobody will import; free it.
+			if (tag == FrameTag::ScanChunkArrow && payload.size() >= sizeof(ArrowBatchHeader)) {
+				auto *hdr = reinterpret_cast<const ArrowBatchHeader *>(payload.data());
+				PagePool().Release(PagePool().Slot((int)hdr->page_index));
+			}
+			outstanding_--;
+		}
+	}
+
+	static constexpr int WINDOW = 8;
+	SessionChannel *ch_;
+	std::string sql_;
+	uint32_t scan_id_;
+	bool count_only_;
+	bool started_ = false;
+	bool done_ = false;
+	int outstanding_ = 0;
+	std::mutex mutex_ = {};
+};
+
+/* Worker side: a heap scan fed by the shared scan worker pool. Scan workers scan
+ * block ranges under the backend's shipped snapshot and push Arrow/serialized pages
+ * into this scan's ready-ring; Next drains it. No per-chunk round-trip to the backend,
+ * and multiple DuckDB threads drain concurrently (the ring is MPSC-safe). */
+class PoolScanStream : public RemoteScanStream {
+public:
+	PoolScanStream(SessionChannel *ch, uint32_t scan_id) : ch_(ch), scan_id_(scan_id) {
+	}
+	PoolScanStream(const PoolScanStream &) = delete;
+	PoolScanStream &operator=(const PoolScanStream &) = delete;
+
+	~PoolScanStream() override {
+		CloseRing();
+	}
+
+	duckdb::unique_ptr<duckdb::DataChunk>
+	Next(duckdb::ClientContext &context, const duckdb::vector<duckdb::LogicalType> &output_types) override {
+		if (done_)
+			return nullptr;
+		for (;;) {
+			uint32_t page_index = 0, desc_len = 0, byte_len = 0;
+			char errbuf[1024];
+			int r = ScanRing().TryNext(scan_id_, &page_index, &desc_len, &byte_len, errbuf, sizeof(errbuf));
+			if (r == 1) {
+				char *page = PagePool().Slot((int)page_index)->data;
+				auto chunk = duckdb::make_uniq<duckdb::DataChunk>();
+				try {
+					if (desc_len > 0) { // Arrow: descriptor at page front, data after the reserve
+						ImportArrowBatch(context, page + ScanRing::DescReserve(), page, desc_len, output_types, *chunk,
+						                 [page_index]() { PagePool().Release(PagePool().Slot((int)page_index)); });
+					} else { // serialized: copied out, free the page immediately
+						DeserializeDataChunk(page, byte_len, *chunk);
+						PagePool().Release(PagePool().Slot((int)page_index));
+					}
+				} catch (...) {
+					// import/deserialize failed before taking ownership
+					PagePool().Release(PagePool().Slot((int)page_index));
+					throw;
+				}
+				return chunk;
+			}
+			if (r == 0) {
+				done_ = true;
+				return nullptr;
+			}
+			if (r == -1) {
+				done_ = true;
+				throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, std::string(errbuf));
+			}
+			/* Nothing ready: bail on backend cancel / worker shutdown instead of
+			 * polling a ring nobody will fill. */
+			if (ch_->IsCancelRequested() || IsWorkerDraining()) {
+				CloseRing();
+				done_ = true;
+				throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, "query cancelled");
+			}
+			pg_usleep(300); /* nothing ready yet; producers are filling the ring */
+		}
+	}
+
+private:
+	void
+	CloseRing() {
+		ScanRing().Close(scan_id_, [](int idx) { PagePool().Release(PagePool().Slot(idx)); });
+	}
+
+	SessionChannel *ch_;
+	uint32_t scan_id_;
+	bool done_ = false;
+};
+
+} // namespace
+
+duckdb::unique_ptr<RemoteScanStream>
+OpenInversionScanStream(SessionChannel *ch, const std::string &sql, bool count_only) {
+	static std::atomic<uint32_t> next_scan_id {1};
+	return duckdb::make_uniq<InversionScanStream>(ch, sql, next_scan_id.fetch_add(1), count_only);
+}
+
+duckdb::unique_ptr<RemoteScanStream>
+OpenPoolScanStream(SessionChannel *ch, uint32_t db_oid, const std::string &scan_sql, bool count_only,
+                   const RemoteScanInfo &info, const std::string &snapshot_bytes, int producers) {
+	/* Degree: split a rangeable scan into block ranges, capped by the producers GUC
+	 * and the relation size (at least MIN_BLOCKS_PER_TASK blocks per task). */
+	constexpr uint32_t MIN_BLOCKS_PER_TASK = 64;
+	uint32_t degree = 1;
+	if (info.rangeable && info.nblocks >= 2 * MIN_BLOCKS_PER_TASK) {
+		uint32_t want = (uint32_t)std::max(1, producers);
+		degree = std::min(want, info.nblocks / MIN_BLOCKS_PER_TASK);
+		if (degree < 1)
+			degree = 1;
+	}
+
+	ScanHandle h = ScanRing().Open(db_oid, scan_sql.c_str(), scan_sql.size(), snapshot_bytes.data(),
+	                               snapshot_bytes.size(), count_only, info.where_off, /*ntasks=*/degree);
+	if (h.scan_id == 0)
+		return nullptr;
+
+	bool ok = true;
+	if (degree == 1) {
+		ok = ScanQueue().Enqueue(db_oid, h.scan_id, h.generation, 0, 0); /* (0,0): no CTID injection */
+	} else {
+		for (uint32_t i = 0; i < degree && ok; i++) {
+			uint32_t lo = (uint32_t)((uint64_t)info.nblocks * i / degree);
+			uint32_t hi = (uint32_t)((uint64_t)info.nblocks * (i + 1) / degree);
+			if (i == degree - 1)
+				hi = info.nblocks; /* last range covers the tail exactly */
+			ok = ScanQueue().Enqueue(db_oid, h.scan_id, h.generation, lo, hi);
+		}
+	}
+	if (ok)
+		return duckdb::make_uniq<PoolScanStream>(ch, h.scan_id);
+	ScanRing().Close(h.scan_id, [](int idx) { PagePool().Release(PagePool().Slot(idx)); });
+	return nullptr;
+}
+
+} // namespace worker
+
+} // namespace pgddb

--- a/libpgduckdb/worker/transport/arrow_codec.cpp
+++ b/libpgduckdb/worker/transport/arrow_codec.cpp
@@ -1,0 +1,486 @@
+#include "pgddb/worker/transport/arrow_codec.hpp"
+
+#include <cstdio>
+#include <cstring>
+
+#include "duckdb.hpp" // duckdb_free, base types
+#include <duckdb/common/arrow/arrow.hpp>
+#include <duckdb/common/arrow/arrow_wrapper.hpp>
+#include <duckdb/common/types/data_chunk.hpp>
+#include <duckdb/function/table/arrow.hpp>
+#include <duckdb/function/table/arrow/arrow_duck_schema.hpp>
+
+#include "pgddb/pgddb_types.hpp" // PGDUCKDB_DUCK_DATE_OFFSET
+
+extern "C" {
+#include "postgres.h"
+
+#include "executor/tuptable.h"
+#include "utils/date.h"
+}
+
+#include "pgddb/pgddb_detoast.hpp" // postgres-dependent: after postgres.h
+
+namespace pgddb {
+
+namespace {
+
+inline std::size_t
+Align8(std::size_t n) {
+	return (n + 7) & ~((std::size_t)7);
+}
+
+inline bool
+IsVarlen(ArrowColCode code) {
+	return code == ArrowColCode::Utf8 || code == ArrowColCode::Binary;
+}
+
+// Fixed-width element size for a code, or 0 for variable/unsupported.
+uint32_t
+ElemWidth(ArrowColCode code) {
+	switch (code) {
+	case ArrowColCode::Int16:
+		return 2;
+	case ArrowColCode::Int32:
+	case ArrowColCode::Float:
+	case ArrowColCode::Date32:
+		return 4;
+	case ArrowColCode::Int64:
+	case ArrowColCode::Double:
+	case ArrowColCode::Decimal64:
+	case ArrowColCode::TimestampUs:
+	case ArrowColCode::TimestampTzUs:
+		return 8;
+	case ArrowColCode::Decimal32:
+		return 4;
+	case ArrowColCode::Decimal128:
+		return 16;
+	case ArrowColCode::Utf8:
+	case ArrowColCode::Binary:
+		return 4; // offsets element width
+	case ArrowColCode::Bool:
+		return 0; // bit-packed like validity
+	default:
+		return 0;
+	}
+}
+
+const char *
+ArrowFormat(ArrowColCode code) {
+	switch (code) {
+	case ArrowColCode::Int16:
+		return "s";
+	case ArrowColCode::Int32:
+		return "i";
+	case ArrowColCode::Int64:
+		return "l";
+	case ArrowColCode::Float:
+		return "f";
+	case ArrowColCode::Double:
+		return "g";
+	case ArrowColCode::Date32:
+		return "tdD";
+	case ArrowColCode::Bool:
+		return "b";
+	case ArrowColCode::Utf8:
+		return "u";
+	case ArrowColCode::Binary:
+		return "z";
+	case ArrowColCode::TimestampUs:
+		return "tsu:";
+	case ArrowColCode::TimestampTzUs:
+		return "tsu:UTC";
+	default:
+		return "";
+	}
+}
+
+// Per-type value writers; `values` is the column's value buffer base in the page.
+void
+AppendInt16Val(char *values, int row, Datum v) {
+	*(int16_t *)(values + (std::size_t)row * 2) = DatumGetInt16(v);
+}
+void
+AppendInt32Val(char *values, int row, Datum v) {
+	*(int32_t *)(values + (std::size_t)row * 4) = DatumGetInt32(v);
+}
+void
+AppendInt64Val(char *values, int row, Datum v) {
+	*(int64_t *)(values + (std::size_t)row * 8) = DatumGetInt64(v);
+}
+void
+AppendFloatVal(char *values, int row, Datum v) {
+	*(float *)(values + (std::size_t)row * 4) = DatumGetFloat4(v);
+}
+void
+AppendDoubleVal(char *values, int row, Datum v) {
+	*(double *)(values + (std::size_t)row * 8) = DatumGetFloat8(v);
+}
+void
+AppendDate32Val(char *values, int row, Datum v) {
+	*(int32_t *)(values + (std::size_t)row * 4) = (int32_t)(DatumGetDateADT(v) + PGDUCKDB_DUCK_DATE_OFFSET);
+}
+void
+AppendBoolVal(char *values, int row, Datum v) {
+	if (DatumGetBool(v))
+		values[row / 8] |= (uint8_t)(1u << (row % 8));
+}
+// PG timestamps count microseconds from 2000-01-01; Arrow from 1970-01-01.
+void
+AppendTimestampVal(char *values, int row, Datum v) {
+	*(int64_t *)(values + (std::size_t)row * 8) = DatumGetInt64(v) + PGDUCKDB_DUCK_TIMESTAMP_OFFSET;
+}
+void
+AppendDecimal32Val(char *values, int row, Datum v) {
+	pgddb::NumericToDecimalBytes(v, 4, values + (std::size_t)row * 4);
+}
+void
+AppendDecimal64Val(char *values, int row, Datum v) {
+	pgddb::NumericToDecimalBytes(v, 8, values + (std::size_t)row * 8);
+}
+void
+AppendDecimal128Val(char *values, int row, Datum v) {
+	pgddb::NumericToDecimalBytes(v, 16, values + (std::size_t)row * 16);
+}
+void
+AppendNoopVal(char *, int, Datum) {
+}
+
+// Resolved once per column at builder setup; the row loop calls through it with
+// no type switch. Varlen (Utf8/Binary) is staged separately, never dispatched here.
+ArrowAppendValueFn
+ResolveAppendValueFn(ArrowColCode code) {
+	switch (code) {
+	case ArrowColCode::Int16:
+		return AppendInt16Val;
+	case ArrowColCode::Int32:
+		return AppendInt32Val;
+	case ArrowColCode::Int64:
+		return AppendInt64Val;
+	case ArrowColCode::Float:
+		return AppendFloatVal;
+	case ArrowColCode::Double:
+		return AppendDoubleVal;
+	case ArrowColCode::Date32:
+		return AppendDate32Val;
+	case ArrowColCode::Bool:
+		return AppendBoolVal;
+	case ArrowColCode::TimestampUs:
+	case ArrowColCode::TimestampTzUs:
+		return AppendTimestampVal;
+	case ArrowColCode::Decimal32:
+		return AppendDecimal32Val;
+	case ArrowColCode::Decimal64:
+		return AppendDecimal64Val;
+	case ArrowColCode::Decimal128:
+		return AppendDecimal128Val;
+	default:
+		return AppendNoopVal; // Unsupported never reaches AppendSlot (ArrowColumnSpec rejects it)
+	}
+}
+
+void
+NoopReleaseSchema(ArrowSchema *s) {
+	s->release = nullptr;
+}
+void
+NoopReleaseArray(ArrowArray *a) {
+	a->release = nullptr;
+}
+
+// Top-level array release: hands the page back to the pool exactly once.
+struct PageReleaseHolder {
+	std::function<void()> on_release;
+};
+void
+PageReleaseArray(ArrowArray *a) {
+	auto *h = reinterpret_cast<PageReleaseHolder *>(a->private_data);
+	if (h) {
+		if (h->on_release)
+			h->on_release();
+		delete h;
+	}
+	a->private_data = nullptr;
+	a->release = nullptr;
+}
+
+} // namespace
+
+bool
+ArrowColumnSpec(Oid /*pg_type*/, const duckdb::LogicalType &duck_type, ArrowColCode &code, uint8_t &precision,
+                uint8_t &scale) {
+	precision = 0;
+	scale = 0;
+	switch (duck_type.id()) {
+	case duckdb::LogicalTypeId::SMALLINT:
+		code = ArrowColCode::Int16;
+		return true;
+	case duckdb::LogicalTypeId::INTEGER:
+		code = ArrowColCode::Int32;
+		return true;
+	case duckdb::LogicalTypeId::BIGINT:
+		code = ArrowColCode::Int64;
+		return true;
+	case duckdb::LogicalTypeId::FLOAT:
+		code = ArrowColCode::Float;
+		return true;
+	case duckdb::LogicalTypeId::DOUBLE:
+		code = ArrowColCode::Double;
+		return true;
+	case duckdb::LogicalTypeId::DATE:
+		code = ArrowColCode::Date32;
+		return true;
+	case duckdb::LogicalTypeId::BOOLEAN:
+		code = ArrowColCode::Bool;
+		return true;
+	case duckdb::LogicalTypeId::TIMESTAMP:
+		code = ArrowColCode::TimestampUs;
+		return true;
+	case duckdb::LogicalTypeId::TIMESTAMP_TZ:
+		code = ArrowColCode::TimestampTzUs;
+		return true;
+	case duckdb::LogicalTypeId::VARCHAR:
+		code = ArrowColCode::Utf8;
+		return true;
+	case duckdb::LogicalTypeId::BLOB:
+		code = ArrowColCode::Binary;
+		return true;
+	case duckdb::LogicalTypeId::DECIMAL: {
+		uint8_t w = duckdb::DecimalType::GetWidth(duck_type);
+		precision = w;
+		scale = duckdb::DecimalType::GetScale(duck_type);
+		code = w <= 9 ? ArrowColCode::Decimal32 : (w <= 18 ? ArrowColCode::Decimal64 : ArrowColCode::Decimal128);
+		return true;
+	}
+	default:
+		code = ArrowColCode::Unsupported;
+		return false;
+	}
+}
+
+ArrowBatchBuilder::ArrowBatchBuilder(char *page, std::size_t capacity, const std::vector<ArrowColCode> &codes,
+                                     const std::vector<uint8_t> &precisions, const std::vector<uint8_t> &scales,
+                                     int max_rows)
+    : page_(page), capacity_(capacity), codes_(codes), precisions_(precisions), scales_(scales), max_rows_(max_rows),
+      validity_off_(), values_off_(), elem_width_(), append_fn_(), is_varlen_(), null_count_(), utf8_data_() {
+	std::size_t ncols = codes_.size();
+	validity_off_.resize(ncols);
+	values_off_.resize(ncols);
+	elem_width_.resize(ncols);
+	append_fn_.resize(ncols);
+	is_varlen_.resize(ncols);
+	null_count_.assign(ncols, 0);
+	utf8_data_.resize(ncols);
+
+	std::size_t cursor = 0;
+	std::size_t validity_bytes = (std::size_t)((max_rows + 7) / 8);
+	for (std::size_t c = 0; c < ncols; c++) {
+		elem_width_[c] = ElemWidth(codes_[c]);
+		append_fn_[c] = ResolveAppendValueFn(codes_[c]);
+		is_varlen_[c] = IsVarlen(codes_[c]);
+		validity_off_[c] = (uint32_t)cursor;
+		cursor = Align8(cursor + validity_bytes);
+		values_off_[c] = (uint32_t)cursor;
+		if (is_varlen_[c]) {
+			cursor = Align8(cursor + (std::size_t)(max_rows + 1) * 4); // offsets[max_rows+1]
+		} else if (codes_[c] == ArrowColCode::Bool) {
+			cursor = Align8(cursor + validity_bytes); // bit-packed values
+		} else {
+			cursor = Align8(cursor + (std::size_t)max_rows * elem_width_[c]);
+		}
+	}
+	fixed_end_ = cursor;
+	if (fixed_end_ > capacity_) {
+		layout_ok_ = false;
+		return;
+	}
+	// Validity bitmaps default to all-valid (1); cleared per null below. Bool value
+	// bitmaps start all-false and are set per true value.
+	for (std::size_t c = 0; c < ncols; c++) {
+		std::memset(page_ + validity_off_[c], 0xFF, validity_bytes);
+		if (codes_[c] == ArrowColCode::Bool)
+			std::memset(page_ + values_off_[c], 0, validity_bytes);
+	}
+}
+
+bool
+ArrowBatchBuilder::AppendSlot(TupleTableSlot *slot) {
+	if (!layout_ok_ || nrows_ >= max_rows_)
+		return false;
+	int row = nrows_;
+	Datum *values = slot->tts_values;
+	bool *nulls = slot->tts_isnull;
+	std::size_t ncols = codes_.size();
+
+	// First pass: detoast utf8 values and check the page still fits, WITHOUT mutating
+	// builder state, so an overflowing row can be deferred to the next batch.
+	std::vector<const char *> sv_ptr(ncols, nullptr);
+	std::vector<std::size_t> sv_len(ncols, 0);
+	std::vector<Datum> sv_free(ncols, 0);
+	std::size_t utf8_total = 0;
+	for (std::size_t c = 0; c < ncols; c++) {
+		if (!is_varlen_[c])
+			continue;
+		utf8_total += Align8(utf8_data_[c].size());
+		if (nulls[c])
+			continue;
+		bool should_free = false;
+		Datum v = pgddb::DetoastIfExternal(values[c], &should_free);
+		void *vp = DatumGetPointer(v); // PG19: Datum no longer converts to a pointer implicitly
+		sv_ptr[c] = VARDATA_ANY(vp);
+		sv_len[c] = (std::size_t)VARSIZE_ANY_EXHDR(vp);
+		sv_free[c] = should_free ? v : 0;
+	}
+	std::size_t add = 0;
+	for (std::size_t c = 0; c < ncols; c++)
+		add += sv_len[c];
+	if (fixed_end_ + utf8_total + add > capacity_) {
+		for (std::size_t c = 0; c < ncols; c++)
+			if (sv_free[c])
+				duckdb_free(reinterpret_cast<void *>(sv_free[c]));
+		return false; // defer this row to a fresh page
+	}
+
+	// Second pass: commit, dispatching through the per-column writer resolved at setup.
+	for (std::size_t c = 0; c < ncols; c++) {
+		if (is_varlen_[c]) {
+			((uint32_t *)(page_ + values_off_[c]))[row] = (uint32_t)utf8_data_[c].size();
+		}
+		if (nulls[c]) {
+			(page_ + validity_off_[c])[row / 8] &= (uint8_t)~(1u << (row % 8));
+			null_count_[c]++;
+			continue;
+		}
+		if (is_varlen_[c])
+			utf8_data_[c].append(sv_ptr[c], sv_len[c]);
+		else
+			append_fn_[c](page_ + values_off_[c], row, values[c]);
+	}
+	for (std::size_t c = 0; c < ncols; c++)
+		if (sv_free[c])
+			duckdb_free(reinterpret_cast<void *>(sv_free[c]));
+	nrows_++;
+	return true;
+}
+
+std::size_t
+ArrowBatchBuilder::Finalize(int page_index, char *out, std::size_t out_cap) {
+	std::size_t ncols = codes_.size();
+	// Place utf8 data contiguously per column after the fixed region; finalize offsets.
+	std::vector<uint32_t> utf8_buf2_off(ncols, 0), utf8_buf2_len(ncols, 0);
+	std::size_t cursor = fixed_end_;
+	for (std::size_t c = 0; c < ncols; c++) {
+		if (!IsVarlen(codes_[c]))
+			continue;
+		uint32_t *offs = (uint32_t *)(page_ + values_off_[c]);
+		offs[nrows_] = (uint32_t)utf8_data_[c].size(); // final end offset
+		std::memcpy(page_ + cursor, utf8_data_[c].data(), utf8_data_[c].size());
+		utf8_buf2_off[c] = (uint32_t)cursor;
+		utf8_buf2_len[c] = (uint32_t)utf8_data_[c].size();
+		cursor = Align8(cursor + utf8_data_[c].size());
+	}
+
+	std::size_t need = sizeof(ArrowBatchHeader) + ncols * sizeof(ArrowColDesc);
+	if (need > out_cap)
+		return 0;
+	auto *hdr = (ArrowBatchHeader *)out;
+	hdr->page_index = (uint32_t)page_index;
+	hdr->nrows = (uint32_t)nrows_;
+	hdr->ncols = (uint32_t)ncols;
+	auto *cd = (ArrowColDesc *)(out + sizeof(ArrowBatchHeader));
+	uint32_t validity_len = (uint32_t)((nrows_ + 7) / 8);
+	for (std::size_t c = 0; c < ncols; c++) {
+		cd[c].code = (uint8_t)codes_[c];
+		cd[c].precision = precisions_[c];
+		cd[c].scale = scales_[c];
+		cd[c].pad = 0;
+		cd[c].null_count = null_count_[c];
+		cd[c].validity_off = validity_off_[c];
+		cd[c].validity_len = validity_len;
+		cd[c].buf1_off = values_off_[c];
+		if (IsVarlen(codes_[c])) {
+			cd[c].buf1_len = (uint32_t)((nrows_ + 1) * 4);
+			cd[c].buf2_off = utf8_buf2_off[c];
+			cd[c].buf2_len = utf8_buf2_len[c];
+		} else if (codes_[c] == ArrowColCode::Bool) {
+			cd[c].buf1_len = validity_len; // bit-packed values
+			cd[c].buf2_off = 0;
+			cd[c].buf2_len = 0;
+		} else {
+			cd[c].buf1_len = (uint32_t)((std::size_t)nrows_ * elem_width_[c]);
+			cd[c].buf2_off = 0;
+			cd[c].buf2_len = 0;
+		}
+	}
+	return need;
+}
+
+void
+ImportArrowBatch(duckdb::ClientContext &context, char *page, const char *descriptor, std::size_t /*desc_len*/,
+                 const duckdb::vector<duckdb::LogicalType> &output_types, duckdb::DataChunk &out,
+                 std::function<void()> on_release) {
+	auto *hdr = (const ArrowBatchHeader *)descriptor;
+	auto *cd = (const ArrowColDesc *)(descriptor + sizeof(ArrowBatchHeader));
+	duckdb::idx_t nrows = hdr->nrows;
+	duckdb::idx_t ncols = hdr->ncols;
+
+	out.Initialize(duckdb::Allocator::DefaultAllocator(), output_types);
+
+	// One wrapper owns the page lifetime: its release frees the page when the last
+	// importing vector drops it.
+	auto wrapper = duckdb::make_shared_ptr<duckdb::ArrowArrayWrapper>();
+	wrapper->arrow_array.release = PageReleaseArray;
+	wrapper->arrow_array.private_data = new PageReleaseHolder {std::move(on_release)};
+
+	for (idx_t c = 0; c < ncols; c++) {
+		auto code = (ArrowColCode)cd[c].code;
+		const void *buffers[3];
+		ArrowArray col {};
+		col.length = (int64_t)nrows;
+		col.null_count = cd[c].null_count;
+		col.offset = 0;
+		col.n_children = 0;
+		col.children = nullptr;
+		col.dictionary = nullptr;
+		col.release = NoopReleaseArray;
+		col.private_data = nullptr;
+		buffers[0] = cd[c].null_count > 0 ? (const void *)(page + cd[c].validity_off) : nullptr;
+		buffers[1] = (const void *)(page + cd[c].buf1_off);
+		if (code == ArrowColCode::Utf8 || code == ArrowColCode::Binary) {
+			buffers[2] = (const void *)(page + cd[c].buf2_off);
+			col.n_buffers = 3;
+		} else {
+			col.n_buffers = 2;
+		}
+		col.buffers = buffers;
+
+		char decfmt[32];
+		const char *fmt;
+		if (code == ArrowColCode::Decimal32 || code == ArrowColCode::Decimal64 || code == ArrowColCode::Decimal128) {
+			int bits = code == ArrowColCode::Decimal32 ? 32 : (code == ArrowColCode::Decimal64 ? 64 : 128);
+			snprintf(decfmt, sizeof(decfmt), "d:%u,%u,%d", cd[c].precision, cd[c].scale, bits);
+			fmt = decfmt;
+		} else {
+			fmt = ArrowFormat(code);
+		}
+		ArrowSchema schema {};
+		schema.format = fmt;
+		schema.name = "";
+		schema.metadata = nullptr;
+		schema.flags = 2; // ARROW_FLAG_NULLABLE
+		schema.n_children = 0;
+		schema.children = nullptr;
+		schema.dictionary = nullptr;
+		schema.release = NoopReleaseSchema;
+		schema.private_data = nullptr;
+
+		auto arrow_type = duckdb::ArrowType::GetArrowLogicalType(context, schema);
+		duckdb::ArrowArrayScanState array_state(context);
+		array_state.owned_data = wrapper;
+		duckdb::ArrowToDuckDBConversion::SetValidityMask(out.data[c], col, 0, nrows, 0, -1);
+		duckdb::ArrowToDuckDBConversion::ColumnArrowToDuckDB(out.data[c], col, 0, array_state, nrows, *arrow_type);
+	}
+	out.SetCardinality(nrows);
+}
+
+} // namespace pgddb

--- a/libpgduckdb/worker/transport/page_pool.cpp
+++ b/libpgduckdb/worker/transport/page_pool.cpp
@@ -1,0 +1,130 @@
+#include "pgddb/worker/transport/page_pool.hpp"
+
+#include <vector>
+
+extern "C" {
+#include "postgres.h"
+
+#include "storage/spin.h"
+}
+
+namespace pgddb {
+
+namespace {
+
+// Shared-memory header; the free stack (int[total_pages]) and the pages region
+// (total_pages * page_size bytes) follow it, both MAXALIGN'd.
+struct ArrowPagePool {
+	slock_t lock;
+	int total_pages;
+	int page_size;
+	int free_top; // number of free entries currently in free_stack[0..free_top)
+};
+
+inline std::size_t
+HeaderBytes() {
+	return MAXALIGN(sizeof(ArrowPagePool));
+}
+
+inline std::size_t
+FreeStackBytes(int total_pages) {
+	return MAXALIGN(sizeof(int) * (std::size_t)total_pages);
+}
+
+int *
+FreeStack(ArrowPagePool *pool) {
+	return (int *)((char *)pool + HeaderBytes());
+}
+
+char *
+PagesBase(ArrowPagePool *pool) {
+	return (char *)pool + HeaderBytes() + FreeStackBytes(pool->total_pages);
+}
+
+// Process-local: pointer into the (identically-mapped) shared region, plus a per-page
+// PageSlot table so Acquire can hand out stable slot pointers.
+ArrowPagePool *g_pool = nullptr;
+std::vector<PageSlot> g_slots;
+
+} // namespace
+
+std::size_t
+PagePool::ShmemSize(int total_pages, int page_size) {
+	return HeaderBytes() + FreeStackBytes(total_pages) + (std::size_t)total_pages * (std::size_t)page_size;
+}
+
+void
+PagePool::Init(void *shmem, int total_pages, int page_size) {
+	auto *pool = (ArrowPagePool *)shmem;
+	SpinLockInit(&pool->lock);
+	pool->total_pages = total_pages;
+	pool->page_size = page_size;
+	pool->free_top = total_pages;
+	int *stack = FreeStack(pool);
+	for (int i = 0; i < total_pages; i++) {
+		stack[i] = i; // every page starts free
+	}
+}
+
+void
+PagePool::Attach(void *shmem) {
+	g_pool = (ArrowPagePool *)shmem;
+	g_slots.clear();
+	g_slots.reserve(g_pool->total_pages);
+	for (int i = 0; i < g_pool->total_pages; i++) {
+		g_slots.push_back(PageSlot {i, PagesBase(g_pool) + (std::size_t)i * (std::size_t)g_pool->page_size});
+	}
+}
+
+bool
+PagePool::Available() const {
+	return g_pool != nullptr && g_pool->total_pages > 0;
+}
+
+int
+PagePool::PageSize() const {
+	return g_pool ? g_pool->page_size : 0;
+}
+
+int
+PagePool::TotalPages() const {
+	return g_pool ? g_pool->total_pages : 0;
+}
+
+PageSlot *
+PagePool::Acquire() {
+	if (!Available()) {
+		return nullptr;
+	}
+	int idx = -1;
+	SpinLockAcquire(&g_pool->lock);
+	if (g_pool->free_top > 0) {
+		idx = FreeStack(g_pool)[--g_pool->free_top];
+	}
+	SpinLockRelease(&g_pool->lock);
+	return idx < 0 ? nullptr : &g_slots[idx];
+}
+
+void
+PagePool::Release(PageSlot *slot) {
+	if (slot == nullptr || slot->index < 0 || !Available() || slot->index >= g_pool->total_pages) {
+		return;
+	}
+	SpinLockAcquire(&g_pool->lock);
+	// Guard against a double release overflowing the free stack and corrupting the pages
+	// region (a stray extra release is dropped rather than written past the end).
+	if (g_pool->free_top < g_pool->total_pages) {
+		FreeStack(g_pool)[g_pool->free_top++] = slot->index;
+	}
+	SpinLockRelease(&g_pool->lock);
+}
+
+PageSlot *
+PagePool::Slot(int index) {
+	if (index < 0 || !Available() || index >= g_pool->total_pages) {
+		return nullptr;
+	}
+	return &g_slots[index];
+}
+
+} // namespace pgddb

--- a/libpgduckdb/worker/transport/scan_queue.cpp
+++ b/libpgduckdb/worker/transport/scan_queue.cpp
@@ -1,0 +1,163 @@
+#include "pgddb/worker/transport/scan_queue.hpp"
+
+extern "C" {
+#include "postgres.h"
+
+#include "miscadmin.h"
+#include "storage/latch.h"
+#include "storage/spin.h"
+}
+
+namespace pgddb {
+
+namespace {
+
+constexpr int TASK_RING_CAP = 256;
+constexpr int POOL_WORKER_SLOTS = 32;
+
+struct TaskEntry {
+	bool valid;
+	uint32_t db_oid;
+	uint32_t scan_id;
+	uint32_t generation;
+	uint32_t lo_blk;
+	uint32_t hi_blk;
+};
+
+struct PoolWorkerSlot {
+	bool in_use;
+	uint32_t db_oid;
+	Latch *latch;
+	int pid;
+};
+
+struct ScanQueueShmem {
+	slock_t qlock; // guards task ring + worker table
+	uint32_t q_head;
+	uint32_t q_tail;
+	TaskEntry tasks[TASK_RING_CAP];
+	PoolWorkerSlot workers[POOL_WORKER_SLOTS];
+};
+
+ScanQueueShmem *g_queue = nullptr;
+
+} // namespace
+
+std::size_t
+ScanQueue::ShmemSize() {
+	return sizeof(ScanQueueShmem);
+}
+
+void
+ScanQueue::Init(void *shmem) {
+	auto *p = (ScanQueueShmem *)shmem;
+	MemSet(p, 0, sizeof(ScanQueueShmem));
+	SpinLockInit(&p->qlock);
+}
+
+void
+ScanQueue::Attach(void *shmem) {
+	g_queue = (ScanQueueShmem *)shmem;
+}
+
+bool
+ScanQueue::Available() {
+	return g_queue != nullptr;
+}
+
+bool
+ScanQueue::Enqueue(uint32_t db_oid, uint32_t scan_id, uint32_t generation, uint32_t lo_blk, uint32_t hi_blk) {
+	if (!g_queue)
+		return false;
+	bool ok = false;
+	Latch *wake[POOL_WORKER_SLOTS];
+	int nwake = 0;
+	SpinLockAcquire(&g_queue->qlock);
+	if ((g_queue->q_tail - g_queue->q_head) < TASK_RING_CAP) {
+		TaskEntry *e = &g_queue->tasks[g_queue->q_tail % TASK_RING_CAP];
+		e->valid = true;
+		e->db_oid = db_oid;
+		e->scan_id = scan_id;
+		e->generation = generation;
+		e->lo_blk = lo_blk;
+		e->hi_blk = hi_blk;
+		g_queue->q_tail++;
+		ok = true;
+	}
+	// Collect this database's idle-worker latches; SetLatch (a syscall) after release.
+	if (ok) {
+		for (int i = 0; i < POOL_WORKER_SLOTS; i++) {
+			if (g_queue->workers[i].in_use && g_queue->workers[i].db_oid == db_oid && g_queue->workers[i].latch)
+				wake[nwake++] = g_queue->workers[i].latch;
+		}
+	}
+	SpinLockRelease(&g_queue->qlock);
+	for (int i = 0; i < nwake; i++)
+		SetLatch(wake[i]);
+	return ok;
+}
+
+bool
+ScanQueue::Claim(uint32_t db_oid, ScanRange *out) {
+	if (!g_queue)
+		return false;
+	bool found = false;
+	SpinLockAcquire(&g_queue->qlock);
+	// Wrap-safe: head/tail are monotonic uint32 counters, so compare with != only.
+	for (uint32_t i = g_queue->q_head; i != g_queue->q_tail; i++) {
+		TaskEntry *e = &g_queue->tasks[i % TASK_RING_CAP];
+		if (e->valid && e->db_oid == db_oid) {
+			out->scan_id = e->scan_id;
+			out->generation = e->generation;
+			out->lo_blk = e->lo_blk;
+			out->hi_blk = e->hi_blk;
+			e->valid = false;
+			found = true;
+			break;
+		}
+	}
+	while (g_queue->q_head != g_queue->q_tail && !g_queue->tasks[g_queue->q_head % TASK_RING_CAP].valid)
+		g_queue->q_head++;
+	SpinLockRelease(&g_queue->qlock);
+	return found;
+}
+
+void
+ScanQueue::PublishWorker(uint32_t db_oid) {
+	if (!g_queue)
+		return;
+	SpinLockAcquire(&g_queue->qlock);
+	int free_idx = -1;
+	for (int i = 0; i < POOL_WORKER_SLOTS; i++) {
+		if (g_queue->workers[i].in_use && g_queue->workers[i].pid == MyProcPid) {
+			free_idx = i;
+			break;
+		}
+		if (free_idx < 0 && !g_queue->workers[i].in_use)
+			free_idx = i;
+	}
+	if (free_idx >= 0) {
+		g_queue->workers[free_idx].in_use = true;
+		g_queue->workers[free_idx].db_oid = db_oid;
+		g_queue->workers[free_idx].latch = MyLatch;
+		g_queue->workers[free_idx].pid = MyProcPid;
+	}
+	SpinLockRelease(&g_queue->qlock);
+}
+
+void
+ScanQueue::UnpublishWorker() {
+	if (!g_queue)
+		return;
+	SpinLockAcquire(&g_queue->qlock);
+	for (int i = 0; i < POOL_WORKER_SLOTS; i++) {
+		if (g_queue->workers[i].in_use && g_queue->workers[i].pid == MyProcPid) {
+			g_queue->workers[i].in_use = false;
+			g_queue->workers[i].latch = nullptr;
+			g_queue->workers[i].pid = 0;
+		}
+	}
+	SpinLockRelease(&g_queue->qlock);
+}
+
+} // namespace pgddb

--- a/libpgduckdb/worker/transport/scan_ring.cpp
+++ b/libpgduckdb/worker/transport/scan_ring.cpp
@@ -1,0 +1,274 @@
+#include "pgddb/worker/transport/scan_ring.hpp"
+
+#include <cstring>
+
+extern "C" {
+#include "postgres.h"
+
+#include "miscadmin.h"
+#include "storage/spin.h"
+}
+
+namespace pgddb {
+
+namespace {
+
+constexpr int SCAN_POOL_SLOTS = 32; // concurrent scans (slot index encoded in low 8 bits of scan_id)
+constexpr int SCAN_SQL_CAP = 16384;
+constexpr int SCAN_SNAP_CAP = 8192;
+constexpr int SCAN_ERR_CAP = 1024;
+constexpr int READY_RING_CAP = 32;
+constexpr std::size_t DESC_RESERVE = 4096; // page front reserved for the Arrow descriptor
+
+struct ReadyEntry {
+	uint32_t page_index;
+	uint32_t desc_len; // >0 => Arrow descriptor at page[0, desc_len), data at page[DESC_RESERVE, ..)
+	uint32_t byte_len; // >0 => serialized DataChunk bytes at page[0, byte_len)
+};
+
+struct ScanSlot {
+	slock_t lock;
+	bool in_use;
+	uint32_t generation;
+	uint32_t scan_id;
+	uint32_t db_oid;
+	bool count_only;
+	bool errored;
+	uint32_t where_off; // CTID-predicate splice offset into sql
+	uint32_t tasks_total;
+	uint32_t tasks_done;
+	uint32_t sql_len;
+	uint32_t snap_len;
+	uint32_t r_head; // next to pop
+	uint32_t r_tail; // next to push
+	ReadyEntry ring[READY_RING_CAP];
+	char sql[SCAN_SQL_CAP];
+	char snap[SCAN_SNAP_CAP];
+	char err[SCAN_ERR_CAP];
+};
+
+struct ScanRingShmem {
+	slock_t alloc_lock; // guards next_seq + slot allocation
+	uint32_t next_seq;
+	ScanSlot slots[SCAN_POOL_SLOTS];
+};
+
+ScanRingShmem *g_ring = nullptr;
+
+inline ScanSlot *
+SlotOf(uint32_t scan_id) {
+	return &g_ring->slots[scan_id & 0xFF];
+}
+
+inline bool
+SlotMatches(ScanSlot *s, uint32_t scan_id, uint32_t generation) {
+	return s->in_use && s->scan_id == scan_id && s->generation == generation;
+}
+
+} // namespace
+
+std::size_t
+ScanRing::ShmemSize() {
+	return sizeof(ScanRingShmem);
+}
+
+void
+ScanRing::Init(void *shmem) {
+	auto *p = (ScanRingShmem *)shmem;
+	MemSet(p, 0, sizeof(ScanRingShmem));
+	SpinLockInit(&p->alloc_lock);
+	p->next_seq = 1;
+	for (int i = 0; i < SCAN_POOL_SLOTS; i++) {
+		SpinLockInit(&p->slots[i].lock);
+	}
+}
+
+void
+ScanRing::Attach(void *shmem) {
+	g_ring = (ScanRingShmem *)shmem;
+}
+
+bool
+ScanRing::Available() {
+	return g_ring != nullptr;
+}
+
+std::size_t
+ScanRing::DescReserve() {
+	return DESC_RESERVE;
+}
+
+ScanHandle
+ScanRing::Open(uint32_t db_oid, const char *sql, std::size_t sql_len, const char *snap, std::size_t snap_len,
+               bool count_only, uint32_t where_off, uint32_t ntasks) {
+	if (!g_ring || sql_len > SCAN_SQL_CAP || snap_len > SCAN_SNAP_CAP)
+		return {0, 0};
+
+	SpinLockAcquire(&g_ring->alloc_lock);
+	int slot = -1;
+	for (int i = 0; i < SCAN_POOL_SLOTS; i++) {
+		if (!g_ring->slots[i].in_use) {
+			slot = i;
+			break;
+		}
+	}
+	if (slot < 0) {
+		SpinLockRelease(&g_ring->alloc_lock);
+		return {0, 0};
+	}
+	uint32_t seq = g_ring->next_seq++;
+	uint32_t scan_id = (seq << 8) | (uint32_t)slot;
+	ScanSlot *s = &g_ring->slots[slot];
+	// Hold the per-slot lock across the fill: a stale producer from the slot's
+	// previous scan may still be reading the slot fields under s->lock.
+	SpinLockAcquire(&s->lock);
+	s->in_use = true;
+	s->generation++;
+	s->scan_id = scan_id;
+	s->db_oid = db_oid;
+	s->count_only = count_only;
+	s->errored = false;
+	s->where_off = where_off;
+	s->tasks_total = ntasks;
+	s->tasks_done = 0;
+	s->r_head = s->r_tail = 0;
+	s->sql_len = (uint32_t)sql_len;
+	s->snap_len = (uint32_t)snap_len;
+	memcpy(s->sql, sql, sql_len);
+	memcpy(s->snap, snap, snap_len);
+	uint32_t generation = s->generation;
+	SpinLockRelease(&s->lock);
+	SpinLockRelease(&g_ring->alloc_lock);
+	return {scan_id, generation};
+}
+
+int
+ScanRing::TryNext(uint32_t scan_id, uint32_t *page_index, uint32_t *desc_len, uint32_t *byte_len, char *errbuf,
+                  std::size_t errcap) {
+	ScanSlot *s = SlotOf(scan_id);
+	SpinLockAcquire(&s->lock);
+	int rc;
+	if (!s->in_use || s->scan_id != scan_id) {
+		rc = 0; // scan gone -> treat as finished
+	} else if (s->errored) {
+		std::size_t n = s->err[0] ? strlen(s->err) : 0;
+		if (n >= errcap)
+			n = errcap ? errcap - 1 : 0;
+		if (errcap) {
+			memcpy(errbuf, s->err, n);
+			errbuf[n] = '\0';
+		}
+		rc = -1;
+	} else if (s->r_head < s->r_tail) {
+		ReadyEntry *e = &s->ring[s->r_head % READY_RING_CAP];
+		*page_index = e->page_index;
+		*desc_len = e->desc_len;
+		*byte_len = e->byte_len;
+		s->r_head++;
+		rc = 1;
+	} else if (s->tasks_done >= s->tasks_total) {
+		rc = 0; // drained and all tasks done
+	} else {
+		rc = 2; // nothing ready yet
+	}
+	SpinLockRelease(&s->lock);
+	return rc;
+}
+
+void
+ScanRing::Close(uint32_t scan_id, void (*release_page)(int)) {
+	ScanSlot *s = SlotOf(scan_id);
+	SpinLockAcquire(&s->lock);
+	if (s->in_use && s->scan_id == scan_id) {
+		while (s->r_head < s->r_tail) {
+			ReadyEntry *e = &s->ring[s->r_head % READY_RING_CAP];
+			if (release_page)
+				release_page((int)e->page_index);
+			s->r_head++;
+		}
+		s->generation++; // in-flight producers stop on their next alive check
+		s->in_use = false;
+		s->scan_id = 0;
+		s->errored = false;
+		s->tasks_total = s->tasks_done = 0;
+		s->r_head = s->r_tail = 0;
+	}
+	SpinLockRelease(&s->lock);
+}
+
+bool
+ScanRing::GetInputs(uint32_t scan_id, uint32_t generation, char *sql, std::size_t sqlcap, std::size_t *sqllen,
+                    char *snap, std::size_t snapcap, std::size_t *snaplen, bool *count_only, uint32_t *where_off) {
+	ScanSlot *s = SlotOf(scan_id);
+	SpinLockAcquire(&s->lock);
+	bool ok = SlotMatches(s, scan_id, generation) && s->sql_len <= sqlcap && s->snap_len <= snapcap;
+	if (ok) {
+		*sqllen = s->sql_len;
+		*snaplen = s->snap_len;
+		memcpy(sql, s->sql, s->sql_len);
+		memcpy(snap, s->snap, s->snap_len);
+		*count_only = s->count_only;
+		*where_off = s->where_off;
+	}
+	SpinLockRelease(&s->lock);
+	return ok;
+}
+
+bool
+ScanRing::Alive(uint32_t scan_id, uint32_t generation) {
+	ScanSlot *s = SlotOf(scan_id);
+	SpinLockAcquire(&s->lock);
+	bool ok = SlotMatches(s, scan_id, generation);
+	SpinLockRelease(&s->lock);
+	return ok;
+}
+
+bool
+ScanRing::Push(uint32_t scan_id, uint32_t generation, uint32_t page_index, uint32_t desc_len, uint32_t byte_len) {
+	ScanSlot *s = SlotOf(scan_id);
+	for (;;) {
+		SpinLockAcquire(&s->lock);
+		if (!SlotMatches(s, scan_id, generation) || s->errored) {
+			SpinLockRelease(&s->lock);
+			return false;
+		}
+		if ((s->r_tail - s->r_head) < READY_RING_CAP) {
+			ReadyEntry *e = &s->ring[s->r_tail % READY_RING_CAP];
+			e->page_index = page_index;
+			e->desc_len = desc_len;
+			e->byte_len = byte_len;
+			s->r_tail++;
+			SpinLockRelease(&s->lock);
+			return true;
+		}
+		SpinLockRelease(&s->lock); // ring full -> wait for the consumer to drain
+		CHECK_FOR_INTERRUPTS();
+		pg_usleep(500);
+	}
+}
+
+void
+ScanRing::TaskDone(uint32_t scan_id, uint32_t generation) {
+	ScanSlot *s = SlotOf(scan_id);
+	SpinLockAcquire(&s->lock);
+	if (SlotMatches(s, scan_id, generation))
+		s->tasks_done++;
+	SpinLockRelease(&s->lock);
+}
+
+void
+ScanRing::SetError(uint32_t scan_id, uint32_t generation, const char *msg) {
+	ScanSlot *s = SlotOf(scan_id);
+	SpinLockAcquire(&s->lock);
+	if (SlotMatches(s, scan_id, generation) && !s->errored) {
+		std::size_t n = strlen(msg);
+		if (n >= SCAN_ERR_CAP)
+			n = SCAN_ERR_CAP - 1;
+		memcpy(s->err, msg, n);
+		s->err[n] = '\0';
+		s->errored = true;
+	}
+	SpinLockRelease(&s->lock);
+}
+
+} // namespace pgddb

--- a/libpgduckdb/worker/transport/session_channel.cpp
+++ b/libpgduckdb/worker/transport/session_channel.cpp
@@ -1,0 +1,364 @@
+#include "pgddb/worker/transport/session_channel.hpp"
+
+#include <atomic>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "pgddb/pgddb_process_lock.hpp"
+#include "pgddb/worker/transport/arrow_codec.hpp"
+#include "pgddb/worker/transport/page_pool.hpp"
+
+extern "C" {
+#include "postgres.h"
+
+#include "miscadmin.h"
+#include "port/atomics.h"
+#include "storage/proc.h"
+#include "storage/shm_mq.h"
+}
+
+namespace pgddb {
+
+namespace {
+
+std::atomic<bool> g_worker_draining {false};
+
+constexpr Size CONTROL_QUEUE_SIZE = 64 * 1024;
+constexpr Size RESULT_QUEUE_SIZE = 256 * 1024;
+
+struct SessionChannelHeader {
+	pg_atomic_uint32 cancel;
+};
+
+inline Size
+HeaderSize() {
+	return MAXALIGN(sizeof(SessionChannelHeader));
+}
+
+shm_mq_result
+SendFrame(shm_mq_handle *mqh, FrameTag tag, const char *data, std::size_t len, bool nowait) {
+	uint8 tagbyte = (uint8)tag;
+	shm_mq_iovec iov[2];
+	iov[0].data = (const char *)&tagbyte;
+	iov[0].len = 1;
+	iov[1].data = data;
+	iov[1].len = len;
+	int iovcnt = (len > 0) ? 2 : 1;
+	return shm_mq_sendv(mqh, iov, iovcnt, nowait, true);
+}
+
+FrameResult
+RecvFrame(shm_mq_handle *mqh, FrameTag *tag, const char **data, std::size_t *len, bool nowait) {
+	Size nbytes = 0;
+	void *d = nullptr;
+	shm_mq_result r = shm_mq_receive(mqh, &nbytes, &d, nowait);
+	if (r == SHM_MQ_SUCCESS) {
+		*tag = (FrameTag)(*(uint8 *)d);
+		*data = (const char *)d + 1;
+		*len = (std::size_t)(nbytes - 1);
+		return FrameResult::Ok;
+	}
+	if (r == SHM_MQ_WOULD_BLOCK)
+		return FrameResult::WouldBlock;
+	return FrameResult::Detached;
+}
+
+} // namespace
+
+struct RoutedFrame {
+	FrameTag tag;
+	std::string payload;
+};
+
+struct SessionChannel::State {
+	SessionChannelHeader *hdr = nullptr;
+	shm_mq_handle *control = nullptr;
+	shm_mq_handle *result = nullptr;
+	// Worker-side demux of the control queue: per-scan lanes (keyed by the scan_id
+	// prefix of scan replies) + one metadata lane. Guarded by demux_lock, which is held
+	// across recv+route so a lane's frame order matches the wire order.
+	std::mutex demux_lock = {};
+	std::unordered_map<uint32_t, std::deque<RoutedFrame>> scan_lanes = {};
+	// Scans whose lane was closed: late replies are dropped (their Arrow page freed)
+	// instead of resurrecting the lane and pinning pages forever.
+	std::unordered_set<uint32_t> closed_scans = {};
+	std::deque<RoutedFrame> meta_lane = {};
+	std::mutex meta_request_lock = {};
+};
+
+namespace {
+
+// Free the pool page a buffered-but-never-consumed ScanChunkArrow frame owns.
+void
+ReleaseArrowFramePage(FrameTag tag, const char *payload, std::size_t len) {
+	if (tag != FrameTag::ScanChunkArrow || len < sizeof(ArrowBatchHeader) || !PagePool().Available())
+		return;
+	ArrowBatchHeader hdr;
+	std::memcpy(&hdr, payload, sizeof(hdr));
+	PagePool().Release(PagePool().Slot((int)hdr.page_index));
+}
+
+} // namespace
+
+SessionChannel::SessionChannel() : state_(std::make_unique<State>()) {
+}
+
+SessionChannel::~SessionChannel() {
+	// Frames still buffered in scan lanes may own pool pages; free them.
+	for (auto &lane : state_->scan_lanes) {
+		for (auto &frame : lane.second)
+			ReleaseArrowFramePage(frame.tag, frame.payload.data(), frame.payload.size());
+	}
+	if (state_->control)
+		shm_mq_detach(state_->control);
+	if (state_->result)
+		shm_mq_detach(state_->result);
+}
+
+std::size_t
+SessionChannel::ChannelRegionBytes() {
+	return HeaderSize() + CONTROL_QUEUE_SIZE + RESULT_QUEUE_SIZE;
+}
+
+std::unique_ptr<SessionChannel>
+SessionChannel::OpenSlot(char *base) {
+	auto *hdr = (SessionChannelHeader *)base;
+	pg_atomic_init_u32(&hdr->cancel, 0);
+
+	char *control_addr = base + HeaderSize();
+	char *result_addr = control_addr + CONTROL_QUEUE_SIZE;
+	// Recreate the rings in place so the slot is reusable across queries (no dsm).
+	shm_mq *control_mq = shm_mq_create(control_addr, CONTROL_QUEUE_SIZE);
+	shm_mq *result_mq = shm_mq_create(result_addr, RESULT_QUEUE_SIZE);
+	shm_mq_set_sender(control_mq, MyProc);
+	shm_mq_set_receiver(result_mq, MyProc);
+
+	std::unique_ptr<SessionChannel> ch(new SessionChannel());
+	ch->state_->hdr = hdr;
+	ch->state_->control = shm_mq_attach(control_mq, NULL, NULL);
+	ch->state_->result = shm_mq_attach(result_mq, NULL, NULL);
+	return ch;
+}
+
+std::unique_ptr<SessionChannel>
+SessionChannel::AttachSlot(char *base) {
+	auto *hdr = (SessionChannelHeader *)base;
+	char *control_addr = base + HeaderSize();
+	char *result_addr = control_addr + CONTROL_QUEUE_SIZE;
+	shm_mq *control_mq = (shm_mq *)control_addr;
+	shm_mq *result_mq = (shm_mq *)result_addr;
+	shm_mq_set_receiver(control_mq, MyProc);
+	shm_mq_set_sender(result_mq, MyProc);
+
+	std::unique_ptr<SessionChannel> ch(new SessionChannel());
+	ch->state_->hdr = hdr;
+	ch->state_->control = shm_mq_attach(control_mq, NULL, NULL);
+	ch->state_->result = shm_mq_attach(result_mq, NULL, NULL);
+	return ch;
+}
+
+bool
+SessionChannel::SendControl(FrameTag tag, const char *data, std::size_t len) {
+	return SendFrame(state_->control, tag, data, len, false) == SHM_MQ_SUCCESS;
+}
+
+FrameResult
+SessionChannel::RecvControl(FrameTag *tag, const char **data, std::size_t *len, bool nowait) {
+	return RecvFrame(state_->control, tag, data, len, nowait);
+}
+
+FrameResult
+SessionChannel::RecvResult(FrameTag *tag, const char **data, std::size_t *len, bool nowait) {
+	return RecvFrame(state_->result, tag, data, len, nowait);
+}
+
+void
+SessionChannel::RequestCancel() {
+	pg_atomic_write_u32(&state_->hdr->cancel, 1);
+}
+
+bool
+SessionChannel::IsCancelRequested() const {
+	return pg_atomic_read_u32(&state_->hdr->cancel) != 0;
+}
+
+void
+SessionChannel::RequestCancelAt(char *base) {
+	auto *hdr = (SessionChannelHeader *)base;
+	pg_atomic_write_u32(&hdr->cancel, 1);
+}
+
+namespace {
+
+bool
+IsScanReply(FrameTag tag) {
+	return tag == FrameTag::ScanChunk || tag == FrameTag::ScanChunkArrow || tag == FrameTag::ScanDone ||
+	       tag == FrameTag::ScanError;
+}
+
+bool
+IsMetaReply(FrameTag tag) {
+	return tag == FrameTag::MetaResult || tag == FrameTag::MetaError || tag == FrameTag::DescribeRelResult ||
+	       tag == FrameTag::DescribeRelError;
+}
+
+} // namespace
+
+/* Pull the next frame of one lane. Holds demux_lock across the raw receive and the
+ * routing so a lane's frames keep wire order even with several concurrent pollers;
+ * the process lock nests inside (demux -> process, never the reverse). Scan replies
+ * carry a [uint32 scan_id] prefix that is stripped while routing. */
+FrameResult
+SessionChannel::RoutedRecv(bool meta, uint32_t scan_id, FrameTag *tag, std::string *payload) {
+	for (;;) {
+		{
+			std::lock_guard<std::mutex> demux(state_->demux_lock);
+			auto &lane = meta ? state_->meta_lane : state_->scan_lanes[scan_id];
+			if (!lane.empty()) {
+				*tag = lane.front().tag;
+				*payload = std::move(lane.front().payload);
+				lane.pop_front();
+				return FrameResult::Ok;
+			}
+			FrameTag rtag = FrameTag::Error;
+			const char *data = nullptr;
+			std::size_t len = 0;
+			FrameResult r;
+			{
+				std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+				r = RecvFrame(state_->control, &rtag, &data, &len, /*nowait=*/true);
+			}
+			if (r == FrameResult::Detached)
+				return FrameResult::Detached;
+			if (r == FrameResult::Ok) {
+				if (IsScanReply(rtag) && len >= sizeof(uint32_t)) {
+					uint32_t id = 0;
+					std::memcpy(&id, data, sizeof(id));
+					if (!meta && id == scan_id) {
+						*tag = rtag;
+						payload->assign(data + sizeof(id), len - sizeof(id));
+						return FrameResult::Ok;
+					}
+					if (state_->closed_scans.count(id)) {
+						// Late reply for a closed lane: drop it (freeing its page)
+						// instead of re-creating the lane.
+						ReleaseArrowFramePage(rtag, data + sizeof(id), len - sizeof(id));
+						continue;
+					}
+					state_->scan_lanes[id].push_back(
+					    RoutedFrame {rtag, std::string(data + sizeof(id), len - sizeof(id))});
+					continue;
+				}
+				if (IsMetaReply(rtag)) {
+					if (meta) {
+						*tag = rtag;
+						payload->assign(data, len);
+						return FrameResult::Ok;
+					}
+					state_->meta_lane.push_back(RoutedFrame {rtag, std::string(data, len)});
+					continue;
+				}
+				continue; /* unexpected frame kind: drop */
+			}
+		}
+		if (IsCancelRequested() || g_worker_draining.load(std::memory_order_relaxed))
+			return FrameResult::Detached;
+		pg_usleep(200);
+	}
+}
+
+FrameResult
+SessionChannel::RecvMetaReply(FrameTag *tag, std::string *payload) {
+	return RoutedRecv(true, 0, tag, payload);
+}
+
+FrameResult
+SessionChannel::RecvScanReply(uint32_t scan_id, FrameTag *tag, std::string *payload) {
+	return RoutedRecv(false, scan_id, tag, payload);
+}
+
+std::mutex &
+SessionChannel::MetaRequestMutex() {
+	return state_->meta_request_lock;
+}
+
+void
+SessionChannel::CloseScanLane(uint32_t scan_id, const std::function<void(FrameTag, const std::string &)> &on_frame) {
+	std::lock_guard<std::mutex> demux(state_->demux_lock);
+	state_->closed_scans.insert(scan_id);
+	auto it = state_->scan_lanes.find(scan_id);
+	if (it == state_->scan_lanes.end())
+		return;
+	for (auto &frame : it->second)
+		on_frame(frame.tag, frame.payload);
+	state_->scan_lanes.erase(it);
+}
+
+/* Thread-local: each duckdb-worker session runs on its own thread (Phase 4), so the
+ * "current session" is per-thread, not per-process. */
+static thread_local SessionChannel *g_current_worker_session = nullptr;
+
+void
+SetCurrentWorkerSession(SessionChannel *channel) {
+	g_current_worker_session = channel;
+}
+
+SessionChannel *
+CurrentWorkerSession() {
+	return g_current_worker_session;
+}
+
+/* Set when the worker is shutting down so session-thread polls bail promptly. */
+void
+SetWorkerDraining(bool draining) {
+	g_worker_draining.store(draining, std::memory_order_relaxed);
+}
+
+bool
+IsWorkerDraining() {
+	return g_worker_draining.load(std::memory_order_relaxed);
+}
+
+/* Worker-side transport for the multi-threaded duckdb worker. The shm_mq rings, MyLatch,
+ * and palloc are not thread-safe, so every poke is taken under the global process lock and
+ * the lock is dropped between attempts (a short sleep) so a thread never blocks holding it.
+ * This keeps MyLatch owned solely by the worker's main loop and serializes all PG access.
+ * Returns false on detach, cancel, or worker drain. */
+bool
+SessionChannel::SerializedSendResult(FrameTag tag, const char *data, std::size_t len) {
+	for (;;) {
+		shm_mq_result r;
+		{
+			std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+			r = SendFrame(state_->result, tag, data, len, /*nowait=*/true);
+		}
+		if (r == SHM_MQ_SUCCESS)
+			return true;
+		if (r == SHM_MQ_DETACHED)
+			return false;
+		if (IsCancelRequested() || g_worker_draining.load(std::memory_order_relaxed))
+			return false;
+		pg_usleep(200);
+	}
+}
+
+FrameResult
+SessionChannel::SerializedRecvControl(FrameTag *tag, const char **data, std::size_t *len) {
+	for (;;) {
+		FrameResult r;
+		{
+			std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+			r = RecvFrame(state_->control, tag, data, len, /*nowait=*/true);
+		}
+		if (r != FrameResult::WouldBlock)
+			return r;
+		if (IsCancelRequested() || g_worker_draining.load(std::memory_order_relaxed))
+			return FrameResult::Detached;
+		pg_usleep(200);
+	}
+}
+
+} // namespace pgddb

--- a/libpgduckdb/worker/transport/session_pool.cpp
+++ b/libpgduckdb/worker/transport/session_pool.cpp
@@ -1,0 +1,147 @@
+#include "pgddb/worker/transport/session_pool.hpp"
+
+#include "pgddb/worker/transport/session_channel.hpp"
+
+extern "C" {
+#include "postgres.h"
+
+#include "port/atomics.h"
+#include "storage/spin.h"
+}
+
+namespace pgddb {
+
+namespace {
+
+enum SlotState { SLOT_FREE = 0, SLOT_IN_USE = 1 };
+
+struct SessSlot {
+	int state;                 // SlotState, guarded by the pool lock
+	uint32 generation;         // bumped on Acquire; detects release/re-acquire
+	pg_atomic_uint32 attached; // number of attached ends (0..2); slot frees at 0
+};
+
+struct SessionPoolHeader {
+	slock_t lock;
+	int nslots;
+};
+
+inline std::size_t
+HeaderBytes() {
+	return MAXALIGN(sizeof(SessionPoolHeader));
+}
+
+inline std::size_t
+SlotArrayBytes(int nslots) {
+	return MAXALIGN(sizeof(SessSlot) * (std::size_t)nslots);
+}
+
+inline std::size_t
+RegionBytes() {
+	return MAXALIGN(SessionChannel::ChannelRegionBytes());
+}
+
+// Process-local pointers into the (identically-mapped) shared region.
+SessionPoolHeader *g_hdr = nullptr;
+SessSlot *g_slots = nullptr;
+char *g_regions = nullptr;
+
+} // namespace
+
+std::size_t
+SessionPool::ShmemSize(int nslots) {
+	return HeaderBytes() + SlotArrayBytes(nslots) + (std::size_t)nslots * RegionBytes();
+}
+
+void
+SessionPool::Init(void *shmem, int nslots) {
+	auto *hdr = (SessionPoolHeader *)shmem;
+	SpinLockInit(&hdr->lock);
+	hdr->nslots = nslots;
+	auto *slots = (SessSlot *)((char *)shmem + HeaderBytes());
+	for (int i = 0; i < nslots; i++) {
+		slots[i].state = SLOT_FREE;
+		slots[i].generation = 0;
+		pg_atomic_init_u32(&slots[i].attached, 0);
+	}
+}
+
+void
+SessionPool::Attach(void *shmem) {
+	g_hdr = (SessionPoolHeader *)shmem;
+	g_slots = (SessSlot *)((char *)shmem + HeaderBytes());
+	g_regions = (char *)shmem + HeaderBytes() + SlotArrayBytes(g_hdr->nslots);
+}
+
+bool
+SessionPool::Available() {
+	return g_hdr != nullptr && g_hdr->nslots > 0;
+}
+
+int
+SessionPool::NumSlots() {
+	return g_hdr ? g_hdr->nslots : 0;
+}
+
+int
+SessionPool::Acquire() {
+	if (!Available())
+		return -1;
+	int idx = -1;
+	SpinLockAcquire(&g_hdr->lock);
+	for (int i = 0; i < g_hdr->nslots; i++) {
+		if (g_slots[i].state == SLOT_FREE) {
+			g_slots[i].state = SLOT_IN_USE;
+			g_slots[i].generation++;
+			pg_atomic_write_u32(&g_slots[i].attached, 0);
+			idx = i;
+			break;
+		}
+	}
+	SpinLockRelease(&g_hdr->lock);
+	return idx;
+}
+
+uint32_t
+SessionPool::Generation(int idx) {
+	SpinLockAcquire(&g_hdr->lock);
+	uint32 g = g_slots[idx].generation;
+	SpinLockRelease(&g_hdr->lock);
+	return g;
+}
+
+char *
+SessionPool::ChannelBase(int idx) {
+	return g_regions + (std::size_t)idx * RegionBytes();
+}
+
+void
+SessionPool::AttachEnd(int idx) {
+	pg_atomic_fetch_add_u32(&g_slots[idx].attached, 1);
+}
+
+bool
+SessionPool::TryAttachEnd(int idx, uint32_t generation) {
+	SpinLockAcquire(&g_hdr->lock);
+	bool ok = g_slots[idx].state == SLOT_IN_USE && g_slots[idx].generation == generation;
+	if (ok)
+		pg_atomic_fetch_add_u32(&g_slots[idx].attached, 1);
+	SpinLockRelease(&g_hdr->lock);
+	return ok;
+}
+
+void
+SessionPool::DetachEnd(int idx) {
+	// The end that brings the attach count to zero returns the slot to the pool; until
+	// then the rings stay mapped and are never recreated under a live peer. The whole
+	// decrement + free decision happens under the pool lock so it is atomic against
+	// TryAttachEnd's check + increment (else a detach landing between them could free
+	// a slot the worker just attached).
+	SpinLockAcquire(&g_hdr->lock);
+	uint32 prev = pg_atomic_fetch_sub_u32(&g_slots[idx].attached, 1);
+	if (prev == 1)
+		g_slots[idx].state = SLOT_FREE;
+	SpinLockRelease(&g_hdr->lock);
+}
+
+} // namespace pgddb

--- a/libpgduckdb/worker/transport/session_protocol.cpp
+++ b/libpgduckdb/worker/transport/session_protocol.cpp
@@ -1,0 +1,288 @@
+#include "pgddb/worker/transport/session_protocol.hpp"
+#include "pgddb/worker/transport/session_channel.hpp"
+
+#include <cstdint>
+#include <string>
+
+#include <duckdb/common/allocator.hpp>
+#include <duckdb/common/enums/statement_type.hpp>
+#include <duckdb/common/exception.hpp>
+#include <duckdb/common/serializer/binary_deserializer.hpp>
+#include <duckdb/common/serializer/binary_serializer.hpp>
+#include <duckdb/common/serializer/memory_stream.hpp>
+#include <duckdb/common/types/column/column_data_collection.hpp>
+#include <duckdb/common/types/data_chunk.hpp>
+#include <duckdb/main/materialized_query_result.hpp>
+
+namespace pgddb {
+
+void
+SerializeDataChunk(duckdb::DataChunk &chunk, duckdb::MemoryStream &out) {
+	duckdb::BinarySerializer serializer(out);
+	serializer.Begin();
+	chunk.Serialize(serializer);
+	serializer.End();
+}
+
+void
+DeserializeDataChunk(const char *data, std::size_t len, duckdb::DataChunk &out) {
+	duckdb::MemoryStream stream(reinterpret_cast<duckdb::data_ptr_t>(const_cast<char *>(data)),
+	                            static_cast<duckdb::idx_t>(len));
+	duckdb::BinaryDeserializer deserializer(stream);
+	deserializer.Begin();
+	out.Deserialize(deserializer);
+	deserializer.End();
+}
+
+static void
+WriteU32(duckdb::MemoryStream &s, uint32_t v) {
+	s.WriteData(reinterpret_cast<duckdb::const_data_ptr_t>(&v), sizeof(v));
+}
+
+static uint32_t
+ReadU32(duckdb::MemoryStream &s) {
+	uint32_t v = 0;
+	s.ReadData(reinterpret_cast<duckdb::data_ptr_t>(&v), sizeof(v));
+	return v;
+}
+
+static void
+WriteString(duckdb::MemoryStream &s, const std::string &str) {
+	WriteU32(s, static_cast<uint32_t>(str.size()));
+	if (!str.empty())
+		s.WriteData(reinterpret_cast<duckdb::const_data_ptr_t>(str.data()), str.size());
+}
+
+static std::string
+ReadString(duckdb::MemoryStream &s) {
+	uint32_t len = ReadU32(s);
+	std::string str;
+	str.resize(len);
+	if (len)
+		s.ReadData(reinterpret_cast<duckdb::data_ptr_t>(&str[0]), len);
+	return str;
+}
+
+// Length-prefixed serialized DataChunk, so chunks can be read back sequentially.
+static void
+WriteChunk(duckdb::MemoryStream &out, duckdb::DataChunk &chunk) {
+	duckdb::MemoryStream tmp;
+	SerializeDataChunk(chunk, tmp);
+	WriteU32(out, static_cast<uint32_t>(tmp.GetPosition()));
+	out.WriteData(tmp.GetData(), tmp.GetPosition());
+}
+
+static void
+ReadChunk(duckdb::MemoryStream &in, duckdb::DataChunk &chunk) {
+	uint32_t len = ReadU32(in);
+	auto pos = in.GetPosition();
+	DeserializeDataChunk(reinterpret_cast<const char *>(in.GetData() + pos), len, chunk);
+	in.SetPosition(pos + len);
+}
+
+void
+SerializeQueryResult(duckdb::QueryResult &result, duckdb::MemoryStream &out) {
+	WriteU32(out, static_cast<uint32_t>(result.names.size()));
+	for (auto &name : result.names) {
+		WriteU32(out, static_cast<uint32_t>(name.size()));
+		if (!name.empty())
+			out.WriteData(reinterpret_cast<duckdb::const_data_ptr_t>(name.data()), name.size());
+	}
+
+	// Empty chunk carrying the column types, so 0-row results still convey their schema.
+	duckdb::DataChunk schema_chunk;
+	schema_chunk.Initialize(duckdb::Allocator::DefaultAllocator(), result.types);
+	schema_chunk.SetCardinality(0);
+	WriteChunk(out, schema_chunk);
+
+	duckdb::vector<duckdb::unique_ptr<duckdb::DataChunk>> chunks;
+	while (true) {
+		auto chunk = result.Fetch();
+		if (!chunk || chunk->size() == 0)
+			break;
+		chunks.push_back(std::move(chunk));
+	}
+	WriteU32(out, static_cast<uint32_t>(chunks.size()));
+	for (auto &chunk : chunks)
+		WriteChunk(out, *chunk);
+}
+
+duckdb::unique_ptr<duckdb::QueryResult>
+DeserializeQueryResult(const char *data, std::size_t len) {
+	duckdb::MemoryStream in(reinterpret_cast<duckdb::data_ptr_t>(const_cast<char *>(data)),
+	                        static_cast<duckdb::idx_t>(len));
+
+	uint32_t ncols = ReadU32(in);
+	duckdb::vector<duckdb::string> names;
+	names.reserve(ncols);
+	for (uint32_t i = 0; i < ncols; i++) {
+		uint32_t nlen = ReadU32(in);
+		duckdb::string name;
+		name.resize(nlen);
+		if (nlen)
+			in.ReadData(reinterpret_cast<duckdb::data_ptr_t>(&name[0]), nlen);
+		names.push_back(std::move(name));
+	}
+
+	duckdb::DataChunk schema_chunk;
+	ReadChunk(in, schema_chunk);
+	auto types = schema_chunk.GetTypes();
+
+	uint32_t nchunks = ReadU32(in);
+	auto &allocator = duckdb::Allocator::DefaultAllocator();
+	auto collection = duckdb::make_uniq<duckdb::ColumnDataCollection>(allocator, types);
+	duckdb::ColumnDataAppendState append_state;
+	collection->InitializeAppend(append_state);
+	for (uint32_t i = 0; i < nchunks; i++) {
+		duckdb::DataChunk chunk;
+		ReadChunk(in, chunk);
+		collection->Append(append_state, chunk);
+	}
+
+	duckdb::StatementProperties properties;
+	duckdb::ClientProperties client_properties;
+	return duckdb::make_uniq<duckdb::MaterializedQueryResult>(duckdb::StatementType::SELECT_STATEMENT, properties,
+	                                                          std::move(names), std::move(collection),
+	                                                          client_properties);
+}
+
+void
+SerializeRelationDesc(const RelationDesc &desc, duckdb::MemoryStream &out) {
+	WriteU32(out, static_cast<uint32_t>(desc.oid));
+	WriteString(out, desc.qualified_name);
+	WriteString(out, desc.name);
+	uint8_t is_temp = desc.is_temporary ? 1 : 0;
+	out.WriteData(reinterpret_cast<duckdb::const_data_ptr_t>(&is_temp), sizeof(is_temp));
+	out.WriteData(reinterpret_cast<duckdb::const_data_ptr_t>(&desc.cardinality), sizeof(desc.cardinality));
+	WriteU32(out, desc.nblocks);
+	WriteU32(out, static_cast<uint32_t>(desc.columns.size()));
+	for (const auto &col : desc.columns) {
+		int32_t attno = static_cast<int32_t>(col.attno);
+		out.WriteData(reinterpret_cast<duckdb::const_data_ptr_t>(&attno), sizeof(attno));
+		WriteString(out, col.name);
+		duckdb::BinarySerializer serializer(out);
+		serializer.Begin();
+		col.type.Serialize(serializer);
+		serializer.End();
+	}
+}
+
+RelationDesc
+DeserializeRelationDesc(const char *data, std::size_t len) {
+	duckdb::MemoryStream in(reinterpret_cast<duckdb::data_ptr_t>(const_cast<char *>(data)),
+	                        static_cast<duckdb::idx_t>(len));
+	RelationDesc desc;
+	desc.oid = static_cast<Oid>(ReadU32(in));
+	desc.qualified_name = ReadString(in);
+	desc.name = ReadString(in);
+	uint8_t is_temp = 0;
+	in.ReadData(reinterpret_cast<duckdb::data_ptr_t>(&is_temp), sizeof(is_temp));
+	desc.is_temporary = is_temp != 0;
+	in.ReadData(reinterpret_cast<duckdb::data_ptr_t>(&desc.cardinality), sizeof(desc.cardinality));
+	desc.nblocks = ReadU32(in);
+	uint32_t ncols = ReadU32(in);
+	desc.columns.reserve(ncols);
+	for (uint32_t i = 0; i < ncols; i++) {
+		RelationColumn col;
+		int32_t attno = 0;
+		in.ReadData(reinterpret_cast<duckdb::data_ptr_t>(&attno), sizeof(attno));
+		col.attno = static_cast<AttrNumber>(attno);
+		col.name = ReadString(in);
+		duckdb::BinaryDeserializer deserializer(in);
+		deserializer.Begin();
+		col.type = duckdb::LogicalType::Deserialize(deserializer);
+		deserializer.End();
+		desc.columns.push_back(std::move(col));
+	}
+	return desc;
+}
+
+RelationDesc
+WorkerDescribeRelation(SessionChannel &channel, const std::string &schema, const std::string &table) {
+	/* One metadata-lane round-trip at a time per channel: replies carry no request id. */
+	std::lock_guard<std::mutex> request(channel.MetaRequestMutex());
+	std::string payload = schema;
+	payload.push_back('\0');
+	payload += table;
+	if (!channel.SerializedSendResult(FrameTag::DescribeRel, payload.data(), payload.size()))
+		throw duckdb::IOException("duckdb worker: describe-relation channel detached");
+	FrameTag tag = FrameTag::Error;
+	std::string reply;
+	if (channel.RecvMetaReply(&tag, &reply) != FrameResult::Ok) {
+		throw duckdb::IOException("duckdb worker: describe-relation channel detached");
+	}
+	if (tag == FrameTag::DescribeRelResult) {
+		return DeserializeRelationDesc(reply.data(), reply.size());
+	}
+	throw duckdb::CatalogException(reply); /* DescribeRelError */
+}
+
+namespace {
+
+/* Send a metadata request on the result queue and wait for the reply on the channel's
+ * metadata lane. Safe from any worker thread: sends are serialized, the reply comes
+ * off the demuxed metadata lane, and the meta-request mutex keeps a single metadata
+ * round-trip in flight per channel (replies carry no request id). */
+duckdb::unique_ptr<duckdb::QueryResult>
+MetadataRoundTrip(SessionChannel &channel, FrameTag request, const std::string &sql) {
+	std::lock_guard<std::mutex> request_lock(channel.MetaRequestMutex());
+	if (!channel.SerializedSendResult(request, sql.c_str(), sql.size())) {
+		return duckdb::make_uniq<duckdb::MaterializedQueryResult>(
+		    duckdb::ErrorData(duckdb::ExceptionType::IO, "duckdb worker: metadata channel detached"));
+	}
+	FrameTag tag = FrameTag::Error;
+	std::string reply;
+	if (channel.RecvMetaReply(&tag, &reply) != FrameResult::Ok) {
+		return duckdb::make_uniq<duckdb::MaterializedQueryResult>(
+		    duckdb::ErrorData(duckdb::ExceptionType::IO, "duckdb worker: metadata channel detached"));
+	}
+	if (tag == FrameTag::MetaResult) {
+		return DeserializeQueryResult(reply.data(), reply.size());
+	}
+	if (tag == FrameTag::MetaError) {
+		/* payload: [uint8 duckdb exception type][message] */
+		auto etype = duckdb::ExceptionType::IO;
+		std::string msg;
+		if (!reply.empty()) {
+			etype = (duckdb::ExceptionType)(uint8_t)reply[0];
+			msg = reply.substr(1);
+		}
+		return duckdb::make_uniq<duckdb::MaterializedQueryResult>(duckdb::ErrorData(etype, msg));
+	}
+	return duckdb::make_uniq<duckdb::MaterializedQueryResult>(
+	    duckdb::ErrorData(duckdb::ExceptionType::IO, "duckdb worker: unexpected metadata reply"));
+}
+
+} // namespace
+
+duckdb::unique_ptr<duckdb::QueryResult>
+WorkerMetadataQuery(SessionChannel &channel, const std::string &sql) {
+	return MetadataRoundTrip(channel, FrameTag::MetaQuery, sql);
+}
+
+duckdb::unique_ptr<duckdb::QueryResult>
+WorkerMetadataExec(SessionChannel &channel, const std::string &sql) {
+	return MetadataRoundTrip(channel, FrameTag::MetaExec, sql);
+}
+
+void
+SendMetadataReply(SessionChannel &channel, duckdb::QueryResult &result) {
+	if (result.HasError()) {
+		auto &err = result.GetErrorObject();
+		SendMetadataError(channel, err.Type(), err.RawMessage());
+		return;
+	}
+	duckdb::MemoryStream stream;
+	SerializeQueryResult(result, stream);
+	channel.SendControl(FrameTag::MetaResult, reinterpret_cast<const char *>(stream.GetData()), stream.GetPosition());
+}
+
+void
+SendMetadataError(SessionChannel &channel, duckdb::ExceptionType type, const std::string &msg) {
+	std::string payload;
+	payload.push_back((char)(uint8_t)type);
+	payload += msg;
+	channel.SendControl(FrameTag::MetaError, payload.data(), payload.size());
+}
+
+} // namespace pgddb

--- a/libpgduckdb/worker/worker_session.cpp
+++ b/libpgduckdb/worker/worker_session.cpp
@@ -1,0 +1,56 @@
+#include "pgddb/worker/worker_session.hpp"
+
+#include <exception>
+#include <string>
+
+#include "pgddb/worker/transport/session_channel.hpp"
+#include "pgddb/worker/transport/session_protocol.hpp"
+
+#include <duckdb/common/error_data.hpp>
+#include <duckdb/common/serializer/memory_stream.hpp>
+#include <duckdb/common/types/data_chunk.hpp>
+#include <duckdb/main/connection.hpp>
+#include <duckdb/main/query_result.hpp>
+
+namespace pgddb {
+namespace worker {
+
+namespace {
+void
+SendError(SessionChannel &channel, const std::string &msg) {
+	channel.SerializedSendResult(FrameTag::Error, msg.c_str(), msg.size());
+}
+} // namespace
+
+void
+RunWorkerSession(duckdb::Connection &con, SessionChannel &channel, const std::string &sql) {
+	try {
+		auto result = con.SendQuery(sql);
+		if (result->HasError()) {
+			SendError(channel, result->GetError());
+			return;
+		}
+		while (true) {
+			if (channel.IsCancelRequested()) {
+				con.Interrupt();
+				SendError(channel, "query cancelled");
+				return;
+			}
+			auto chunk = result->Fetch();
+			if (!chunk || chunk->size() == 0)
+				break;
+			duckdb::MemoryStream stream;
+			SerializeDataChunk(*chunk, stream);
+			if (!channel.SerializedSendResult(FrameTag::Chunk, (const char *)stream.GetData(), stream.GetPosition()))
+				return; /* backend detached */
+		}
+		channel.SerializedSendResult(FrameTag::Complete, nullptr, 0);
+	} catch (const std::exception &e) {
+		/* Raw message only: the backend wraps it in EXECUTOR, so e.what()'s
+		 * "Executor Error:" prefix would be doubled. */
+		SendError(channel, duckdb::ErrorData(e).RawMessage());
+	}
+}
+
+} // namespace worker
+} // namespace pgddb

--- a/pg_duckdb/include/pgduckdb/pgduckdb_guc.hpp
+++ b/pg_duckdb/include/pgduckdb/pgduckdb_guc.hpp
@@ -5,6 +5,13 @@ void InitGUC();
 void InitGUCHooks();
 
 extern bool duckdb_force_execution;
+extern bool duckdb_use_shared_worker;
+extern int duckdb_arrow_pool_pages;
+extern int duckdb_arrow_page_size;
+extern int duckdb_scan_pool_size;
+extern int duckdb_scan_producers;
+extern int duckdb_max_worker_sessions;
+extern int duckdb_worker_threads;
 extern bool duckdb_unsafe_allow_execution_inside_functions;
 extern bool duckdb_unsafe_allow_mixed_transactions;
 extern int duckdb_threads;

--- a/pg_duckdb/src/pgduckdb.cpp
+++ b/pg_duckdb/src/pgduckdb.cpp
@@ -18,6 +18,10 @@ extern "C" {
 #include "pgduckdb/pgduckdb_types.hpp"
 #include "pgduckdb/pgduckdb_xact.hpp"
 
+namespace pgduckdb {
+void InitDuckdbWorker();
+}
+
 extern "C" {
 
 #ifdef PG_MODULE_MAGIC_EXT
@@ -50,6 +54,7 @@ _PG_init(void) {
 	DuckdbInitHooks();
 	pgddb::InitNode("DuckDBScan");
 	pgduckdb::InitBackgroundWorkersShmem();
+	pgduckdb::InitDuckdbWorker();
 	pgduckdb::RegisterDuckdbXactCallback();
 }
 } // extern "C"

--- a/pg_duckdb/src/pgduckdb_guc.cpp
+++ b/pg_duckdb/src/pgduckdb_guc.cpp
@@ -122,6 +122,13 @@ DefineCustomDuckDBVariable(const char *name, const char *short_desc, T *var, T m
 } // namespace
 
 bool duckdb_force_execution = false;
+bool duckdb_use_shared_worker = false;
+int duckdb_arrow_pool_pages = 256;
+int duckdb_arrow_page_size = 1024 * 1024;
+int duckdb_scan_pool_size = 0;
+int duckdb_scan_producers = 4;
+int duckdb_max_worker_sessions = 0;
+int duckdb_worker_threads = 4;
 bool duckdb_unsafe_allow_execution_inside_functions = false;
 bool duckdb_unsafe_allow_mixed_transactions = false;
 char *duckdb_motherduck_session_hint = strdup("");
@@ -154,6 +161,42 @@ InitGUC() {
 	/* pg_duckdb specific GUCs */
 	DefineCustomVariable("duckdb.force_execution", "Force queries to use DuckDB execution", &duckdb_force_execution,
 	                     PGC_USERSET, GUC_REPORT);
+
+	DefineCustomVariable("duckdb.use_shared_worker",
+	                     "Dispatch eligible read-only queries to the shared DuckDB worker process "
+	                     "instead of executing DuckDB in this backend.",
+	                     &duckdb_use_shared_worker, PGC_USERSET);
+
+	DefineCustomVariable("duckdb.arrow_pool_pages",
+	                     "Number of fixed shared-memory pages for zero-copy Arrow transport to the shared "
+	                     "DuckDB worker (allocated at startup; 0 disables the Arrow fast path).",
+	                     &duckdb_arrow_pool_pages, 0, 65536, PGC_POSTMASTER);
+
+	DefineCustomVariable("duckdb.arrow_page_size", "Size in bytes of each Arrow transport page.",
+	                     &duckdb_arrow_page_size, 64 * 1024, 64 * 1024 * 1024, PGC_POSTMASTER);
+
+	DefineCustomVariable("duckdb.scan_pool_size",
+	                     "Number of shared scan workers each DuckDB worker spawns to "
+	                     "produce Postgres heap-scan batches in parallel (0 disables the pool; scans then "
+	                     "run on the requesting backend).",
+	                     &duckdb_scan_pool_size, 0, 64, PGC_POSTMASTER);
+
+	DefineCustomVariable("duckdb.scan_producers",
+	                     "Maximum number of disjoint CTID block-range tasks a single Postgres heap scan is "
+	                     "split into for the scan worker pool (effective parallelism is bounded by the pool "
+	                     "size and the relation size).",
+	                     &duckdb_scan_producers, 1, 64, PGC_USERSET);
+
+	DefineCustomVariable("duckdb.max_worker_sessions",
+	                     "Number of fixed shared-memory session-pool slots for dispatching queries to the "
+	                     "shared DuckDB worker. Each slot carries one query's control and result rings. "
+	                     "0 (default) disables the shared worker and reserves no shared memory.",
+	                     &duckdb_max_worker_sessions, 0, 1024, PGC_POSTMASTER);
+
+	DefineCustomVariable("duckdb.shared_worker_threads",
+	                     "DuckDB compute threads in the shared duckdb worker; applies when the worker "
+	                     "(re)starts.",
+	                     &duckdb_worker_threads, 1, 1024, PGC_SIGHUP);
 
 	DefineCustomVariable("duckdb.unsafe_allow_execution_inside_functions", "Allow DuckDB execution inside functions",
 	                     &duckdb_unsafe_allow_execution_inside_functions, PGC_SUSET);

--- a/pg_duckdb/src/shared_engine_worker.cpp
+++ b/pg_duckdb/src/shared_engine_worker.cpp
@@ -1,0 +1,127 @@
+/*
+ * The pg_duckdb duckdb worker (heap-table queries).
+ *
+ * The generic machinery -- per-database worker registry, session-pool dispatch,
+ * scan inversion + the scan-producer pool, session threads -- is the kernel
+ * pgddb::DuckdbWorker base class. This subclass supplies pg_duckdb's policy: the
+ * dispatch gate (read-only heap SELECTs when duckdb.use_shared_worker is on), the
+ * engine accessors, and the background-worker entrypoints.
+ */
+
+#include "pgduckdb/pgduckdb_duckdb.hpp"
+#include "pgduckdb/pgduckdb_guc.hpp"
+
+#include <string>
+
+#include "pgddb/pgddb_planner.hpp"
+#include "pgddb/worker/duckdb_worker.hpp"
+
+extern "C" {
+#include "postgres.h"
+
+#include "access/xact.h"
+#include "fmgr.h"
+#include "miscadmin.h"
+#include "nodes/parsenodes.h"
+#include "postmaster/bgworker.h"
+#include "utils/guc.h"
+#include "utils/snapmgr.h"
+}
+
+namespace pgduckdb {
+
+class DuckdbWorker final : public pgddb::DuckdbWorker {
+public:
+	DuckdbWorker()
+	    : pgddb::DuckdbWorker(Settings {
+	          "PgDuckdbWorker",
+	          "pg_duckdb",
+	          "pgduckdb_duckdb_worker_main",
+	          "pgduckdb_scan_worker_main",
+	          "pg_duckdb",
+	          &duckdb_max_worker_sessions,
+	          &duckdb_arrow_pool_pages,
+	          &duckdb_arrow_page_size,
+	          &duckdb_scan_pool_size,
+	          &duckdb_scan_producers,
+	      }) {
+	}
+
+protected:
+	void
+	Configure() override {
+		/* Scan inversion makes worker execution PG-free, so the worker can run
+		 * multi-threaded (the macOS single-thread workaround only applies to in-backend
+		 * PG scans on DuckDB threads, which no longer happen here). Use a fixed small
+		 * pool and let that many threads consume each remote scan. Set before the first
+		 * DuckDBManager::Get() so it takes effect at instance init. */
+		std::string threads = std::to_string(pgduckdb::duckdb_worker_threads);
+		SetConfigOption("duckdb.threads", threads.c_str(), PGC_SUSET, PGC_S_SESSION);
+		SetConfigOption("duckdb.threads_for_postgres_scan", threads.c_str(), PGC_USERSET, PGC_S_SESSION);
+	}
+
+	void
+	Prime() override {
+		(void)DuckDBManager::Get();
+	}
+
+	duckdb::DuckDB &
+	Database() override {
+		return DuckDBManager::Get().GetDatabase();
+	}
+};
+
+static DuckdbWorker *
+TheWorker() {
+	static DuckdbWorker worker;
+	return &worker;
+}
+
+} // namespace pgduckdb
+
+namespace {
+
+/* Kernel CustomScan dispatch hook: route eligible read-only queries to the worker. */
+duckdb::unique_ptr<pgddb::WorkerResultStream>
+DispatchToWorker(const Query *query) {
+	if (pgddb::DuckdbWorker::InWorker() || !pgduckdb::duckdb_use_shared_worker)
+		return nullptr;
+	if (!pgddb::DuckdbWorker::Enabled())
+		return nullptr; /* not provisioned -> in-process execution */
+	if (query->commandType != CMD_SELECT)
+		return nullptr;
+	if (!ActiveSnapshotSet())
+		return nullptr;
+	/* The shipped snapshot cannot see this transaction's own uncommitted changes;
+	 * only dispatch when nothing has been written yet in this transaction. */
+	if (GetTopTransactionIdIfAny() != InvalidTransactionId)
+		return nullptr;
+
+	return pgduckdb::TheWorker()->OpenSession(pgddb::DeparseQuery(query));
+}
+
+} // namespace
+
+extern "C" {
+
+PGDLLEXPORT void
+pgduckdb_duckdb_worker_main(Datum main_arg) {
+	pgduckdb::TheWorker()->Main((uint32_t)DatumGetObjectId(main_arg));
+}
+
+PGDLLEXPORT void
+pgduckdb_scan_worker_main(Datum main_arg) {
+	pgduckdb::TheWorker()->ScanWorkerMain((uint32_t)DatumGetObjectId(main_arg));
+}
+
+} // extern "C"
+
+namespace pgduckdb {
+
+void
+InitDuckdbWorker() {
+	TheWorker()->Init();
+	pgddb::pgddb_dispatch_to_worker_hook = DispatchToWorker;
+}
+
+} // namespace pgduckdb

--- a/pg_duckdb/test/regression/expected/execution_error.out
+++ b/pg_duckdb/test/regression/expected/execution_error.out
@@ -16,7 +16,7 @@ Did you mean "main.pragma_user_agent"?
 
 LINE 1: SELECT raw_query FROM duckdb.raw_query('aaaaa'::text) raw_query(raw_query)
                               ^
-LOCATION:  CreatePlan, pgddb_planner.cpp:108
+LOCATION:  CreatePlan, pgddb_planner.cpp:114
 ERROR:  XX000: (PGDuckDB/pgduckdb_raw_query_cpp) Parser Error: syntax error at or near "aaaaa"
 
 LINE 1: aaaaa

--- a/pg_duckdb/test/regression/expected/shared_worker.out
+++ b/pg_duckdb/test/regression/expected/shared_worker.out
@@ -1,0 +1,196 @@
+-- Dispatch read-only heap-table queries to the shared DuckDB worker and
+-- confirm identical results to in-process DuckDB execution. force_execution is on
+-- globally (regression.conf), so each SELECT is offloaded to DuckDB; toggling
+-- duckdb.use_shared_worker decides whether DuckDB runs in this backend or the worker.
+CREATE TABLE sw_t(a int, b int, c text);
+INSERT INTO sw_t SELECT g, g % 10, 'row_' || g FROM generate_series(1, 1000) g;
+CREATE TABLE sw_u(b int, label text);
+INSERT INTO sw_u VALUES (0, 'zero'), (1, 'one'), (2, 'two');
+-- count
+SET duckdb.use_shared_worker = off;
+SELECT count(*) FROM sw_t;
+ count 
+-------
+  1000
+(1 row)
+
+SET duckdb.use_shared_worker = on;
+SELECT count(*) FROM sw_t;
+ count 
+-------
+  1000
+(1 row)
+
+-- filter + ordered scan
+SET duckdb.use_shared_worker = off;
+SELECT a, b, c FROM sw_t WHERE a <= 5 ORDER BY a;
+ a | b |   c   
+---+---+-------
+ 1 | 1 | row_1
+ 2 | 2 | row_2
+ 3 | 3 | row_3
+ 4 | 4 | row_4
+ 5 | 5 | row_5
+(5 rows)
+
+SET duckdb.use_shared_worker = on;
+SELECT a, b, c FROM sw_t WHERE a <= 5 ORDER BY a;
+ a | b |   c   
+---+---+-------
+ 1 | 1 | row_1
+ 2 | 2 | row_2
+ 3 | 3 | row_3
+ 4 | 4 | row_4
+ 5 | 5 | row_5
+(5 rows)
+
+-- grouped aggregation
+SET duckdb.use_shared_worker = off;
+SELECT b, count(*), sum(a) FROM sw_t GROUP BY b ORDER BY b;
+ b | count |  sum  
+---+-------+-------
+ 0 |   100 | 50500
+ 1 |   100 | 49600
+ 2 |   100 | 49700
+ 3 |   100 | 49800
+ 4 |   100 | 49900
+ 5 |   100 | 50000
+ 6 |   100 | 50100
+ 7 |   100 | 50200
+ 8 |   100 | 50300
+ 9 |   100 | 50400
+(10 rows)
+
+SET duckdb.use_shared_worker = on;
+SELECT b, count(*), sum(a) FROM sw_t GROUP BY b ORDER BY b;
+ b | count |  sum  
+---+-------+-------
+ 0 |   100 | 50500
+ 1 |   100 | 49600
+ 2 |   100 | 49700
+ 3 |   100 | 49800
+ 4 |   100 | 49900
+ 5 |   100 | 50000
+ 6 |   100 | 50100
+ 7 |   100 | 50200
+ 8 |   100 | 50300
+ 9 |   100 | 50400
+(10 rows)
+
+-- join
+SET duckdb.use_shared_worker = off;
+SELECT u.label, count(*) FROM sw_t t JOIN sw_u u USING (b) GROUP BY u.label ORDER BY u.label;
+ label | count 
+-------+-------
+ one   |   100
+ two   |   100
+ zero  |   100
+(3 rows)
+
+SET duckdb.use_shared_worker = on;
+SELECT u.label, count(*) FROM sw_t t JOIN sw_u u USING (b) GROUP BY u.label ORDER BY u.label;
+ label | count 
+-------+-------
+ one   |   100
+ two   |   100
+ zero  |   100
+(3 rows)
+
+-- bool / timestamp / timestamptz columns (Arrow scan transport coverage)
+CREATE TABLE sw_types(a int, ok bool, ts timestamp, tstz timestamptz);
+INSERT INTO sw_types VALUES
+    (1, true, '2024-01-02 03:04:05', '2024-01-02 03:04:05+00'),
+    (2, false, '1999-12-31 23:59:59', '1999-12-31 23:59:59+00'),
+    (3, NULL, NULL, NULL);
+SET timezone = 'UTC';
+SET duckdb.use_shared_worker = off;
+SELECT a, ok, ts, tstz FROM sw_types ORDER BY a;
+ a | ok |            ts            |             tstz             
+---+----+--------------------------+------------------------------
+ 1 | t  | Tue Jan 02 03:04:05 2024 | Tue Jan 02 03:04:05 2024 UTC
+ 2 | f  | Fri Dec 31 23:59:59 1999 | Fri Dec 31 23:59:59 1999 UTC
+ 3 |    |                          | 
+(3 rows)
+
+SET duckdb.use_shared_worker = on;
+SELECT a, ok, ts, tstz FROM sw_types ORDER BY a;
+ a | ok |            ts            |             tstz             
+---+----+--------------------------+------------------------------
+ 1 | t  | Tue Jan 02 03:04:05 2024 | Tue Jan 02 03:04:05 2024 UTC
+ 2 | f  | Fri Dec 31 23:59:59 1999 | Fri Dec 31 23:59:59 1999 UTC
+ 3 |    |                          | 
+(3 rows)
+
+RESET timezone;
+-- temp tables are backend-local: dispatched queries read them via the inversion
+-- path (never the scan-producer pool)
+CREATE TEMP TABLE sw_tmp(a int, d text);
+INSERT INTO sw_tmp VALUES (1, 't1'), (2, 't2');
+SET duckdb.use_shared_worker = off;
+SELECT t.a, m.d FROM sw_t t JOIN sw_tmp m USING (a) ORDER BY t.a;
+ a | d  
+---+----
+ 1 | t1
+ 2 | t2
+(2 rows)
+
+SET duckdb.use_shared_worker = on;
+SELECT t.a, m.d FROM sw_t t JOIN sw_tmp m USING (a) ORDER BY t.a;
+ a | d  
+---+----
+ 1 | t1
+ 2 | t2
+(2 rows)
+
+-- a worker-side execution error surfaces as a PG ERROR
+SET duckdb.use_shared_worker = off;
+SELECT CAST(c AS int) FROM sw_t WHERE a = 1;
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Conversion Error: Could not convert string 'row_1' to INT32 when casting from source column c
+
+LINE 1:  SELECT (c)::integer AS c FROM pgduckdb.public.sw_t WHERE (a = 1)
+                   ^
+SET duckdb.use_shared_worker = on;
+SELECT CAST(c AS int) FROM sw_t WHERE a = 1;
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: Conversion Error: Could not convert string 'row_1' to INT32 when casting from source column c
+
+LINE 1: SELECT (c)::integer AS c FROM pgduckdb.public.sw_t WHERE (a = 1)
+                  ^
+-- an Arrow-unsupported heap column fails loudly, naming the column
+CREATE TABLE sw_uuid(a int, u uuid);
+INSERT INTO sw_uuid VALUES (1, '00000000-0000-0000-0000-000000000001');
+SELECT a, u FROM sw_uuid;
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: Executor Error: duckdb worker: column "u" (type oid 2950) is not supported by the Arrow scan transport
+-- cancellation: a statement timeout cancels a dispatched long-running aggregate
+SET statement_timeout = '200ms';
+SELECT count(*) FROM sw_t x, sw_t y, sw_t z WHERE x.a + y.a + z.a > 0;
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: Query cancelled
+RESET statement_timeout;
+-- the worker survived the cancelled query and still serves new dispatches
+SELECT count(*) FROM sw_t;
+ count 
+-------
+  1000
+(1 row)
+
+-- kill the duckdb worker; the next dispatch respawns it on demand
+SELECT count(pg_terminate_backend(pid)) AS terminated
+FROM pg_stat_activity WHERE backend_type = 'pg_duckdb duckdb worker';
+ terminated 
+------------
+          1
+(1 row)
+
+SELECT pg_sleep(0.5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT count(*) FROM sw_t;
+ count 
+-------
+  1000
+(1 row)
+
+RESET duckdb.use_shared_worker;
+DROP TABLE sw_t, sw_u, sw_types, sw_uuid;

--- a/pg_duckdb/test/regression/regression.conf
+++ b/pg_duckdb/test/regression/regression.conf
@@ -6,3 +6,9 @@ duckdb.postgres_role = 'duckdb_group'
 log_temp_files = -1
 # Workaround for non-deterministic hangs in multi-threaded DuckDB on macOS.
 duckdb.threads = 1
+# Exercise the shared scan-producer pool in the shared_worker test. Pool workers are
+# our own background workers (not PG parallel workers), so the macOS parallel-worker
+# hang does not apply; arrow_pool_pages enables the page transport the pool needs.
+duckdb.arrow_pool_pages = 64
+duckdb.scan_pool_size = 2
+duckdb.max_worker_sessions = 8

--- a/pg_duckdb/test/regression/schedule
+++ b/pg_duckdb/test/regression/schedule
@@ -63,3 +63,4 @@ test: postgres_table_etl
 test: order_by
 test: order_by_pushdown
 test: allowed_directories
+test: shared_worker

--- a/pg_duckdb/test/regression/sql/shared_worker.sql
+++ b/pg_duckdb/test/regression/sql/shared_worker.sql
@@ -1,0 +1,83 @@
+-- Dispatch read-only heap-table queries to the shared DuckDB worker and
+-- confirm identical results to in-process DuckDB execution. force_execution is on
+-- globally (regression.conf), so each SELECT is offloaded to DuckDB; toggling
+-- duckdb.use_shared_worker decides whether DuckDB runs in this backend or the worker.
+CREATE TABLE sw_t(a int, b int, c text);
+INSERT INTO sw_t SELECT g, g % 10, 'row_' || g FROM generate_series(1, 1000) g;
+
+CREATE TABLE sw_u(b int, label text);
+INSERT INTO sw_u VALUES (0, 'zero'), (1, 'one'), (2, 'two');
+
+-- count
+SET duckdb.use_shared_worker = off;
+SELECT count(*) FROM sw_t;
+SET duckdb.use_shared_worker = on;
+SELECT count(*) FROM sw_t;
+
+-- filter + ordered scan
+SET duckdb.use_shared_worker = off;
+SELECT a, b, c FROM sw_t WHERE a <= 5 ORDER BY a;
+SET duckdb.use_shared_worker = on;
+SELECT a, b, c FROM sw_t WHERE a <= 5 ORDER BY a;
+
+-- grouped aggregation
+SET duckdb.use_shared_worker = off;
+SELECT b, count(*), sum(a) FROM sw_t GROUP BY b ORDER BY b;
+SET duckdb.use_shared_worker = on;
+SELECT b, count(*), sum(a) FROM sw_t GROUP BY b ORDER BY b;
+
+-- join
+SET duckdb.use_shared_worker = off;
+SELECT u.label, count(*) FROM sw_t t JOIN sw_u u USING (b) GROUP BY u.label ORDER BY u.label;
+SET duckdb.use_shared_worker = on;
+SELECT u.label, count(*) FROM sw_t t JOIN sw_u u USING (b) GROUP BY u.label ORDER BY u.label;
+
+-- bool / timestamp / timestamptz columns (Arrow scan transport coverage)
+CREATE TABLE sw_types(a int, ok bool, ts timestamp, tstz timestamptz);
+INSERT INTO sw_types VALUES
+    (1, true, '2024-01-02 03:04:05', '2024-01-02 03:04:05+00'),
+    (2, false, '1999-12-31 23:59:59', '1999-12-31 23:59:59+00'),
+    (3, NULL, NULL, NULL);
+SET timezone = 'UTC';
+SET duckdb.use_shared_worker = off;
+SELECT a, ok, ts, tstz FROM sw_types ORDER BY a;
+SET duckdb.use_shared_worker = on;
+SELECT a, ok, ts, tstz FROM sw_types ORDER BY a;
+RESET timezone;
+
+-- temp tables are backend-local: dispatched queries read them via the inversion
+-- path (never the scan-producer pool)
+CREATE TEMP TABLE sw_tmp(a int, d text);
+INSERT INTO sw_tmp VALUES (1, 't1'), (2, 't2');
+SET duckdb.use_shared_worker = off;
+SELECT t.a, m.d FROM sw_t t JOIN sw_tmp m USING (a) ORDER BY t.a;
+SET duckdb.use_shared_worker = on;
+SELECT t.a, m.d FROM sw_t t JOIN sw_tmp m USING (a) ORDER BY t.a;
+
+-- a worker-side execution error surfaces as a PG ERROR
+SET duckdb.use_shared_worker = off;
+SELECT CAST(c AS int) FROM sw_t WHERE a = 1;
+SET duckdb.use_shared_worker = on;
+SELECT CAST(c AS int) FROM sw_t WHERE a = 1;
+
+-- an Arrow-unsupported heap column fails loudly, naming the column
+CREATE TABLE sw_uuid(a int, u uuid);
+INSERT INTO sw_uuid VALUES (1, '00000000-0000-0000-0000-000000000001');
+SELECT a, u FROM sw_uuid;
+
+-- cancellation: a statement timeout cancels a dispatched long-running aggregate
+SET statement_timeout = '200ms';
+SELECT count(*) FROM sw_t x, sw_t y, sw_t z WHERE x.a + y.a + z.a > 0;
+RESET statement_timeout;
+
+-- the worker survived the cancelled query and still serves new dispatches
+SELECT count(*) FROM sw_t;
+
+-- kill the duckdb worker; the next dispatch respawns it on demand
+SELECT count(pg_terminate_backend(pid)) AS terminated
+FROM pg_stat_activity WHERE backend_type = 'pg_duckdb duckdb worker';
+SELECT pg_sleep(0.5);
+SELECT count(*) FROM sw_t;
+
+RESET duckdb.use_shared_worker;
+DROP TABLE sw_t, sw_u, sw_types, sw_uuid;

--- a/pg_ducklake/include/pgducklake/guc.hpp
+++ b/pg_ducklake/include/pgducklake/guc.hpp
@@ -10,6 +10,12 @@ extern bool ctas_skip_data;
 extern bool enable_metadata_sync;
 
 extern int threads;
+extern bool use_shared_worker;
+extern int worker_max_sessions;
+extern int worker_arrow_pool_pages;
+extern int worker_arrow_page_size;
+extern int worker_scan_pool_size;
+extern int worker_scan_producers;
 
 extern char *superuser_role;
 extern char *writer_role;

--- a/pg_ducklake/include/pgducklake/pgducklake_metadata_manager.hpp
+++ b/pg_ducklake/include/pgducklake/pgducklake_metadata_manager.hpp
@@ -11,11 +11,17 @@
 #include <storage/ducklake_metadata_manager.hpp>
 #include <storage/ducklake_transaction.hpp>
 
+namespace pgddb {
+class SessionChannel;
+}
+
 namespace pgducklake {
 
 class PgDuckLakeMetadataManager : public duckdb::PostgresMetadataManager {
 public:
 	explicit PgDuckLakeMetadataManager(duckdb::DuckLakeTransaction &transaction);
+	PgDuckLakeMetadataManager(const PgDuckLakeMetadataManager &) = delete;
+	PgDuckLakeMetadataManager &operator=(const PgDuckLakeMetadataManager &) = delete;
 	~PgDuckLakeMetadataManager() override;
 
 	static duckdb::unique_ptr<duckdb::DuckLakeMetadataManager>
@@ -50,6 +56,14 @@ public:
 
 private:
 	static void EnsureSnapshotTrigger();
+	void AliasNestedConnection();
+
+	// The nested metadata connection's context aliased into the worker session
+	// registry (see AliasNestedConnection); unaliased in the destructor. The channel
+	// it was registered under guards the unalias: the entry is only erased if it
+	// still belongs to this session (the context address may have been reused).
+	duckdb::ClientContext *aliased_nested_ctx_ = nullptr;
+	pgddb::SessionChannel *aliased_channel_ = nullptr;
 
 protected:
 	duckdb::string GetInlinedTableQueries(duckdb::DuckLakeSnapshot commit_snapshot,
@@ -81,5 +95,14 @@ bool GetTableInliningInfo(Oid table_oid, uint64_t *table_id_out, uint64_t *schem
 uint64_t GetNextRowIdForTable(uint64_t table_id, uint64_t schema_version);
 uint64_t GetNextSnapshotId();
 void CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int64_t rows_inserted);
+
+/* Run a metadata SQL locally via SPI and return the result. The duckdb
+ * worker's backend side calls this to service a worker's remoted metadata query. */
+duckdb::unique_ptr<duckdb::QueryResult> ExecuteMetadataQueryLocally(const duckdb::string &query);
+
+/* Run a worker-requested metadata write locally in a subtransaction. Throws
+ * duckdb::TransactionException on a PG error (e.g. a concurrent-commit conflict),
+ * matching the in-process ExecuteCommit semantics. */
+duckdb::unique_ptr<duckdb::QueryResult> ExecuteMetadataExecLocally(const duckdb::string &query);
 
 } // namespace pgducklake

--- a/pg_ducklake/sql/pg_ducklake--1.0.0--1.1.0.sql
+++ b/pg_ducklake/sql/pg_ducklake--1.0.0--1.1.0.sql
@@ -178,3 +178,12 @@ CREATE OPERATOR CLASS ducklake.unresolved_type_hash_ops
 DEFAULT FOR TYPE ducklake.unresolved_type USING hash AS
     OPERATOR 1 = (ducklake.unresolved_type, ducklake.unresolved_type),
     FUNCTION 1 ducklake.unresolved_type_hash(ducklake.unresolved_type);
+
+-- ducklake.worker_stats() -- sessions this database's duckdb worker has
+-- accepted since it started; lets tests assert a query really dispatched.
+-- Superuser-only.
+CREATE FUNCTION ducklake.worker_stats()
+    RETURNS bigint
+    SET search_path = pg_catalog, pg_temp
+    LANGUAGE C AS 'MODULE_PATHNAME', 'ducklake_worker_stats';
+REVOKE ALL ON FUNCTION ducklake.worker_stats() FROM PUBLIC;

--- a/pg_ducklake/src/guc.cpp
+++ b/pg_ducklake/src/guc.cpp
@@ -17,6 +17,12 @@ bool ctas_skip_data = false;
 bool enable_metadata_sync = true;
 
 int threads = -1;
+bool use_shared_worker = false;
+int worker_max_sessions = 0;
+int worker_arrow_pool_pages = 256;
+int worker_arrow_page_size = 1024 * 1024;
+int worker_scan_pool_size = 0;
+int worker_scan_producers = 4;
 
 char *superuser_role = strdup("ducklake_superuser");
 char *writer_role = strdup("ducklake_writer");
@@ -51,6 +57,36 @@ InitGUCs() {
 	    "Takes effect when the DuckDB instance initializes; SET before the first DuckLake query in a "
 	    "session, or call ducklake.recycle_ddb() to re-apply.",
 	    &threads, -1, -1, 1024, PGC_USERSET, 0, NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("ducklake.use_shared_worker",
+	                         "Dispatch eligible read-only DuckLake/file queries to the shared DuckDB worker "
+	                         "process instead of executing DuckDB in this backend.",
+	                         NULL, &use_shared_worker, false, PGC_USERSET, 0, NULL, NULL, NULL);
+
+	DefineCustomIntVariable("ducklake.max_worker_sessions",
+	                        "Concurrent sessions the shared DuckDB worker serves (session-pool slots in "
+	                        "shared memory); further dispatches wait for a free slot. "
+	                        "0 (default) disables the shared worker and reserves no shared memory.",
+	                        NULL, &worker_max_sessions, 0, 0, 1024, PGC_POSTMASTER, 0, NULL, NULL, NULL);
+
+	DefineCustomIntVariable("ducklake.arrow_pool_pages",
+	                        "Shared-memory Arrow pages for the worker scan transport (0 disables the pool "
+	                        "and with it shared-worker heap scans).",
+	                        NULL, &worker_arrow_pool_pages, 256, 0, 65536, PGC_POSTMASTER, 0, NULL, NULL, NULL);
+
+	DefineCustomIntVariable("ducklake.arrow_page_size", "Size of one Arrow scan-transport page, in bytes.", NULL,
+	                        &worker_arrow_page_size, 1024 * 1024, 64 * 1024, 64 * 1024 * 1024, PGC_POSTMASTER, 0, NULL,
+	                        NULL, NULL);
+
+	DefineCustomIntVariable("ducklake.scan_pool_size",
+	                        "Scan-producer background workers per database for shared-worker heap scans "
+	                        "(0 = produce on the requesting backend).",
+	                        NULL, &worker_scan_pool_size, 0, 0, 64, PGC_POSTMASTER, 0, NULL, NULL, NULL);
+
+	DefineCustomIntVariable("ducklake.scan_producers",
+	                        "Parallel scan-producer tasks per shared-worker heap scan (capped by "
+	                        "ducklake.scan_pool_size).",
+	                        NULL, &worker_scan_producers, 4, 1, 64, PGC_USERSET, 0, NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("ducklake.enable_metadata_sync",
 	                         "Enable reverse metadata sync from DuckDB to PostgreSQL. "

--- a/pg_ducklake/src/pgducklake.cpp
+++ b/pg_ducklake/src/pgducklake.cpp
@@ -23,6 +23,7 @@ namespace pgducklake {
 // Bootstrap entry points wired up by _PG_init; declared here since it is their only caller.
 void InitGUCs();
 void InitMaintenanceWorker();
+void InitDuckdbWorker();
 void InitDirectInsertStatsShmem();
 void InitDuckDBManager();
 void RegisterDirectInsertNode();
@@ -54,6 +55,7 @@ _PG_init(void) {
 	duckdb::DuckLakeMetadataManager::Register(PGDUCKLAKE_DUCKDB_CATALOG, pgducklake::PgDuckLakeMetadataManager::Create);
 	pgducklake::InitGUCs();
 	pgducklake::InitMaintenanceWorker();
+	pgducklake::InitDuckdbWorker();
 	pgducklake::InitDirectInsertStatsShmem();
 	pgducklake::InitDuckDBManager();
 	pgddb::InitNode("DuckLakeScan");

--- a/pg_ducklake/src/pgducklake_metadata_manager.cpp
+++ b/pg_ducklake/src/pgducklake_metadata_manager.cpp
@@ -10,6 +10,9 @@
 
 #include "pgddb/pgddb_types.hpp"
 #include "pgddb/pgddb_utils.hpp"
+#include "pgddb/worker/duckdb_worker.hpp"
+#include "pgddb/worker/transport/session_channel.hpp"
+#include "pgddb/worker/transport/session_protocol.hpp"
 
 #include <common/ducklake_util.hpp>
 #include <duckdb/common/allocator.hpp>
@@ -93,9 +96,11 @@ SPIExecuteInSubtransaction(const duckdb::string &query, bool &had_error, duckdb:
 	int ret = -1;
 	had_error = false;
 
-	/* Suppress NOTICEs: DuckLake re-runs CREATE TABLE IF NOT EXISTS, whose NOTICE would leak to the client. */
+	/* Suppress NOTICEs: DuckLake re-runs CREATE TABLE IF NOT EXISTS, whose NOTICE would leak to the client.
+	 * Skipped in parallel mode (an in-flight scan-inversion reader keeps it entered), where SET errors. */
 	int save_nestlevel = NewGUCNestLevel();
-	::SetConfigOption("client_min_messages", "warning", PGC_USERSET, PGC_S_SESSION);
+	if (!IsInParallelMode())
+		::SetConfigOption("client_min_messages", "warning", PGC_USERSET, PGC_S_SESSION);
 
 	SetAllowSubtransaction(true);
 	BeginInternalSubTransaction(NULL);
@@ -127,7 +132,7 @@ SPIExecuteInSubtransaction(const duckdb::string &query, bool &had_error, duckdb:
 }
 
 static duckdb::unique_ptr<duckdb::QueryResult>
-CreateSPIResult(const duckdb::string &query) {
+CreateSPIResultLocal(const duckdb::string &query) {
 	elog(DEBUG1, "Creating SPI result for query: %s", query.c_str());
 
 	std::lock_guard<std::recursive_mutex> lock(pgddb::GlobalProcessLock::GetLock());
@@ -223,6 +228,36 @@ CreateSPIResult(const duckdb::string &query) {
 	                                                          names, std::move(collection_p), client_properties);
 }
 
+/* The worker session serving this metadata manager's transaction: the session thread's
+ * thread-local, or -- on DuckDB scheduler threads, where thread-locals are invisible --
+ * the session keyed by the transaction's ClientContext (DuckLake reads metadata during
+ * execution, e.g. GetFilesForTable from a pipeline task). */
+static pgddb::SessionChannel *
+WorkerSessionFor(duckdb::DuckLakeTransaction &transaction) {
+	auto ctx = transaction.context.lock();
+	return pgddb::worker::EffectiveWorkerSession(ctx.get());
+}
+
+/* In the duckdb worker, route metadata reads back to the requesting backend (so the
+ * worker stays PG-free); in a normal backend, run them locally via SPI. A worker
+ * thread with no session must fail loudly: local SPI there would touch PG off the
+ * main thread with no transaction. */
+static duckdb::unique_ptr<duckdb::QueryResult>
+CreateSPIResult(const duckdb::string &query, duckdb::DuckLakeTransaction &transaction) {
+	if (auto *session = WorkerSessionFor(transaction)) {
+		return pgddb::WorkerMetadataQuery(*session, query);
+	}
+	if (pgddb::DuckdbWorker::InWorker() && !IsTransactionState()) {
+		throw duckdb::InternalException("ducklake metadata query outside a worker session: %s", query.c_str());
+	}
+	return CreateSPIResultLocal(query);
+}
+
+duckdb::unique_ptr<duckdb::QueryResult>
+ExecuteMetadataQueryLocally(const duckdb::string &query) {
+	return CreateSPIResultLocal(query);
+}
+
 /* Avoids transaction.GetCatalog(): during init the AttachedDatabase is not yet reachable via db_manager. */
 static void
 SubstitutePgCatalogPlaceholders(duckdb::string &query) {
@@ -270,11 +305,21 @@ CreateSPIExecuteInSubtransaction(const duckdb::string &query) {
 	return CreateEmptyResult(duckdb::StatementType::EXECUTE_STATEMENT);
 }
 
+duckdb::unique_ptr<duckdb::QueryResult>
+ExecuteMetadataExecLocally(const duckdb::string &query) {
+	/* Same trigger skip as the in-process ExecuteCommit path. */
+	SkipSnapshotSyncGuard sync_guard;
+	return CreateSPIExecuteInSubtransaction(query);
+}
+
 PgDuckLakeMetadataManager::PgDuckLakeMetadataManager(duckdb::DuckLakeTransaction &transaction_)
     : duckdb::PostgresMetadataManager(transaction_) {
 }
 
 PgDuckLakeMetadataManager::~PgDuckLakeMetadataManager() {
+	if (aliased_nested_ctx_ != nullptr) {
+		pgddb::worker::UnaliasWorkerSessionContext(aliased_nested_ctx_, aliased_channel_);
+	}
 }
 
 /* find()-guarded: GetCatalog() is unsafe during init, and these placeholders never appear in init queries. */
@@ -294,7 +339,7 @@ duckdb::unique_ptr<duckdb::QueryResult>
 PgDuckLakeMetadataManager::Query(duckdb::string query) {
 	SubstitutePathPlaceholders(query, transaction);
 	SubstitutePgCatalogPlaceholders(query);
-	return CreateSPIResult(query);
+	return CreateSPIResult(query, transaction);
 }
 
 /* Mirrors the static GetProjection() in ducklake_metadata_manager.cpp. */
@@ -311,10 +356,31 @@ BuildProjection(const duckdb::vector<duckdb::string> &columns_to_read) {
 	return result;
 }
 
+/* DuckLake runs ExecuteRaw on the transaction's own metadata connection -- a separate
+ * ClientContext. In a worker session that nested context must resolve to the same
+ * session (its heap reads invert to the backend; local PG access would crash the
+ * PG-free worker), so alias it in the session registry. The alias lives exactly as
+ * long as this metadata manager (== the transaction, == the nested connection): a
+ * stale alias would misroute a later session whose context reuses the freed address. */
+void
+PgDuckLakeMetadataManager::AliasNestedConnection() {
+	auto outer = transaction.context.lock();
+	if (!outer)
+		return;
+	auto *channel = pgddb::worker::EffectiveWorkerSession(outer.get());
+	if (!channel)
+		return;
+	auto &con = transaction.GetConnection();
+	aliased_nested_ctx_ = con.context.get();
+	aliased_channel_ = channel; // guards the unalias against a reused context address
+	pgddb::worker::AliasWorkerSessionContext(con.context, outer.get());
+}
+
 /* Route through DuckDB, not SPI: PostgresTableReader holds GlobalProcessLock per 32-tuple batch, not whole op. */
 duckdb::unique_ptr<duckdb::QueryResult>
 PgDuckLakeMetadataManager::ReadInlinedData(duckdb::DuckLakeSnapshot snapshot, const duckdb::string &inlined_table_name,
                                            const duckdb::vector<duckdb::string> &columns_to_read) {
+	AliasNestedConnection();
 	auto projection = BuildProjection(columns_to_read);
 	auto query =
 	    duckdb::StringUtil::Format(R"(
@@ -339,6 +405,7 @@ duckdb::unique_ptr<duckdb::QueryResult>
 PgDuckLakeMetadataManager::ReadAllInlinedDataForFlush(duckdb::DuckLakeSnapshot snapshot,
                                                       const duckdb::string &inlined_table_name,
                                                       const duckdb::vector<duckdb::string> &columns_to_read) {
+	AliasNestedConnection();
 	auto projection = BuildProjection(columns_to_read);
 	auto query = duckdb::StringUtil::Format(R"(
 SELECT %s
@@ -361,7 +428,7 @@ duckdb::unique_ptr<duckdb::QueryResult>
 PgDuckLakeMetadataManager::Execute(duckdb::string query) {
 	SubstitutePathPlaceholders(query, transaction);
 	SubstitutePgCatalogPlaceholders(query);
-	return CreateSPIResult(query);
+	return CreateSPIResult(query, transaction);
 }
 
 duckdb::unique_ptr<duckdb::QueryResult>
@@ -374,6 +441,19 @@ duckdb::unique_ptr<duckdb::QueryResult>
 PgDuckLakeMetadataManager::ExecuteCommit(duckdb::DuckLakeSnapshot snapshot, duckdb::string query) {
 	DuckLakeMetadataManager::FillSnapshotArgs(query, snapshot);
 	SubstitutePgCatalogPlaceholders(query);
+	/* In the duckdb worker: run the commit write on the requesting backend (MetaExec),
+	 * inside that backend's transaction, and rethrow its error with the original
+	 * exception type so DuckLake's conflict-retry sees a TransactionException. */
+	if (auto *session = WorkerSessionFor(transaction)) {
+		auto result = pgddb::WorkerMetadataExec(*session, query);
+		if (result->HasError()) {
+			result->GetErrorObject().Throw();
+		}
+		return result;
+	}
+	if (pgddb::DuckdbWorker::InWorker() && !IsTransactionState()) {
+		throw duckdb::InternalException("ducklake metadata write outside a worker session: %s", query.c_str());
+	}
 	/* Skip the snapshot sync trigger: nothing to reverse-sync, and it crashes on a DuckDB worker thread
 	 * (PG's InterruptHoldoffCount is not thread-safe). */
 	SkipSnapshotSyncGuard sync_guard;

--- a/pg_ducklake/src/shared_engine_worker.cpp
+++ b/pg_ducklake/src/shared_engine_worker.cpp
@@ -1,0 +1,172 @@
+/*
+ * The pg_ducklake duckdb worker.
+ *
+ * The generic machinery -- per-database worker registry, session-pool dispatch,
+ * scan inversion + the scan-producer pool, session threads -- is the kernel
+ * pgddb::DuckdbWorker base class. This subclass supplies pg_ducklake's policy: the
+ * dispatch gate (read-only SELECTs plus autocommit DML when
+ * ducklake.use_shared_worker is on), the engine accessors, the DuckLake metadata RPC
+ * servicing (MetaQuery reads / MetaExec commit writes run on the requesting backend,
+ * so the worker stays PG-free), and the background-worker entrypoints.
+ *
+ * ducklake.worker_stats() exposes the accepted-session count for tests.
+ *
+ * Session-local engine state (e.g. an ad-hoc CREATE SECRET via ducklake.raw_query)
+ * exists only in the issuing backend's engine; credentials that dispatched queries
+ * need must use the ducklake_secret FDW, which every engine loads at init.
+ */
+
+#include "pgducklake/duckdb_manager.hpp"
+#include "pgducklake/guc.hpp"
+#include "pgducklake/pgducklake_metadata_manager.hpp"
+
+#include <exception>
+#include <string>
+
+#include "pgddb/pgddb_planner.hpp"
+#include "pgddb/worker/duckdb_worker.hpp"
+#include "pgddb/worker/transport/session_channel.hpp"
+#include "pgddb/worker/transport/session_protocol.hpp"
+
+#include <duckdb/common/error_data.hpp>
+#include <duckdb/common/types/data_chunk.hpp>
+#include <duckdb/common/types/value.hpp>
+#include <duckdb/main/query_result.hpp>
+
+extern "C" {
+#include "postgres.h"
+
+#include "access/xact.h"
+#include "fmgr.h"
+#include "miscadmin.h"
+#include "nodes/parsenodes.h"
+#include "postmaster/bgworker.h"
+#include "utils/snapmgr.h"
+}
+
+namespace pgducklake {
+
+class DuckdbWorker final : public pgddb::DuckdbWorker {
+public:
+	DuckdbWorker()
+	    : pgddb::DuckdbWorker(Settings {
+	          "PgDuckLakeWorker",
+	          "pg_ducklake",
+	          "ducklake_duckdb_worker_main",
+	          "ducklake_scan_worker_main",
+	          "pg_ducklake",
+	          &worker_max_sessions,
+	          &worker_arrow_pool_pages,
+	          &worker_arrow_page_size,
+	          &worker_scan_pool_size,
+	          &worker_scan_producers,
+	      }) {
+	}
+
+protected:
+	/* No Configure step: the engine reads ducklake.threads etc. from the GUCs at init. */
+
+	void
+	Prime() override {
+		/* GetConnection (not Get) so secrets, extensions, and the DuckLake catalog attach
+		 * are all primed; per-session connections never refresh (they run PG-free). */
+		(void)DuckDBManager::Get().GetConnection();
+	}
+
+	duckdb::DuckDB &
+	Database() override {
+		return DuckDBManager::Get().GetDatabase();
+	}
+
+	/* Backend side: service the worker's DuckLake metadata RPCs under this backend's
+	 * snapshot (reads) / transaction (commit writes), keeping the worker PG-free. */
+	bool
+	ServeFrame(pgddb::SessionChannel &ch, pgddb::FrameTag tag, const char *data, std::size_t len) override {
+		if (tag != pgddb::FrameTag::MetaQuery && tag != pgddb::FrameTag::MetaExec)
+			return false;
+		std::string sql(data, len);
+		try {
+			duckdb::unique_ptr<duckdb::QueryResult> result;
+			if (tag == pgddb::FrameTag::MetaQuery)
+				result = ExecuteMetadataQueryLocally(sql);
+			else
+				result = ExecuteMetadataExecLocally(sql);
+			pgddb::SendMetadataReply(ch, *result);
+		} catch (const std::exception &e) {
+			duckdb::ErrorData err(e);
+			pgddb::SendMetadataError(ch, err.Type(), err.RawMessage());
+		}
+		return true;
+	}
+};
+
+static DuckdbWorker *
+TheWorker() {
+	static DuckdbWorker worker;
+	return &worker;
+}
+
+} // namespace pgducklake
+
+namespace {
+
+/* Kernel CustomScan dispatch hook: route eligible queries to the worker. */
+duckdb::unique_ptr<pgddb::WorkerResultStream>
+DispatchToWorker(const Query *query) {
+	if (pgddb::DuckdbWorker::InWorker() || !pgducklake::use_shared_worker)
+		return nullptr;
+	if (!pgddb::DuckdbWorker::Enabled())
+		return nullptr; /* not provisioned -> in-process execution */
+	bool is_write =
+	    query->commandType == CMD_INSERT || query->commandType == CMD_UPDATE || query->commandType == CMD_DELETE;
+	if (query->commandType != CMD_SELECT && !is_write)
+		return nullptr; /* utility / DDL never dispatch */
+	if (!ActiveSnapshotSet())
+		return nullptr;
+	/* The shipped snapshot cannot see this transaction's own uncommitted changes, so
+	 * only dispatch when nothing has been written yet in this transaction. */
+	if (GetTopTransactionIdIfAny() != InvalidTransactionId)
+		return nullptr;
+	if (is_write) {
+		/* A dispatched write's DuckLake metadata commit runs on this backend (MetaExec),
+		 * inside this backend's transaction; keep the gate at a single autocommit
+		 * statement without RETURNING so statement and metadata commit coincide. */
+		if (IsTransactionBlock() || query->returningList != NIL)
+			return nullptr;
+	}
+
+	return pgducklake::TheWorker()->OpenSession(pgddb::DeparseQuery(query));
+}
+
+} // namespace
+
+extern "C" {
+
+PGDLLEXPORT void
+ducklake_duckdb_worker_main(Datum main_arg) {
+	pgducklake::TheWorker()->Main((uint32_t)DatumGetObjectId(main_arg));
+}
+
+PGDLLEXPORT void
+ducklake_scan_worker_main(Datum main_arg) {
+	pgducklake::TheWorker()->ScanWorkerMain((uint32_t)DatumGetObjectId(main_arg));
+}
+
+/* Sessions this database's duckdb worker accepted since it started. */
+PG_FUNCTION_INFO_V1(ducklake_worker_stats);
+Datum
+ducklake_worker_stats(PG_FUNCTION_ARGS) {
+	PG_RETURN_INT64((int64)pgducklake::TheWorker()->DispatchCount());
+}
+
+} // extern "C"
+
+namespace pgducklake {
+
+void
+InitDuckdbWorker() {
+	TheWorker()->Init();
+	pgddb::pgddb_dispatch_to_worker_hook = DispatchToWorker;
+}
+
+} // namespace pgducklake

--- a/pg_ducklake/test/e2e/conftest.py
+++ b/pg_ducklake/test/e2e/conftest.py
@@ -133,6 +133,7 @@ class PgCluster:
             # No background flush/compaction: tests drive maintenance
             # explicitly so file layouts stay deterministic.
             conf.write("ducklake.maintenance_enabled = false\n")
+            conf.write("ducklake.max_worker_sessions = 16\n")
             # No max_parallel_workers=0 workaround needed (unlike regression.conf):
             # the kernel defaults DuckDB to one thread, so PG parallelism is safe.
             conf.write("fsync = off\n")
@@ -523,13 +524,14 @@ class Lake:
             await set_inlining(conn, inlining)
             await conn.execute("CALL ducklake.recycle_ddb()")
             if configure and self.s3:
-                await self.configure_s3(conn)  # recycle dropped the secret
+                await self.configure_s3(conn)  # re-probe httpfs on the fresh engine
         return conn
 
     async def configure_s3(self, conn):
-        """Configure this backend's DuckDB for the MinIO bucket. Secrets are
-        per-DuckDB-instance and non-persistent: rerun on every new PG
-        connection and again after ducklake.recycle_ddb()."""
+        """Configure this backend for the MinIO bucket. Credentials come from
+        the per-database ducklake_secret FDW (created in the `lake` fixture),
+        which every engine -- backend or shared duckdb worker -- loads at
+        init; only the table-path GUC is per-session."""
         # httpfs is not bundled into pg_ducklake; INSTALL downloads it on
         # first use (cached in the duckdb extension dir afterwards).
         try:
@@ -539,9 +541,6 @@ class Lake:
         except asyncpg.PostgresError as e:
             skip_or_fail(f"backend cannot INSTALL httpfs (offline?): {e}")
         await conn.execute("SELECT ducklake.raw_query('LOAD httpfs')")
-        await conn.execute(
-            f"SELECT ducklake.raw_query($e2e${self.s3.secret_sql()}$e2e$)"
-        )
         await conn.execute(
             f"SET ducklake.default_table_path = '{self.table_path}'"
         )
@@ -554,7 +553,6 @@ class Lake:
             statements = (
                 "SELECT ducklake.raw_query('INSTALL httpfs')",
                 "SELECT ducklake.raw_query('LOAD httpfs')",
-                f"SELECT ducklake.raw_query($e2e${self.s3.secret_sql()}$e2e$)",
                 f"SET ducklake.default_table_path = '{self.table_path}'",
             ) + statements
         return self.cluster.psql(self.dbname, *statements)
@@ -588,6 +586,20 @@ class Lake:
         return con
 
 
+def create_fdw_secret(cluster, db, s3ctx):
+    """FDW-backed credential: loaded by every DuckDB engine of this database
+    at init, including the shared duckdb worker's (a raw CREATE SECRET would
+    exist only in the issuing backend's engine)."""
+    srv = s3ctx.server
+    cluster.psql(
+        db,
+        "SELECT ducklake.create_s3_secret('s3', "
+        f"'{srv.access_key}', '{srv.secret_key}', "
+        f"region => 'us-east-1', url_style => 'path', "
+        f"endpoint => '{srv.endpoint}', use_ssl => 'false')",
+    )
+
+
 @pytest.fixture(params=["local", "s3"])
 def lake(request, cluster, db):
     """The same lake-backed database, parametrized over storage backends.
@@ -598,6 +610,7 @@ def lake(request, cluster, db):
         # catalog option, persisted in metadata: applies to all backends of
         # this database; set_option only writes PG tables, no secret needed
         cluster.psql(db, "CALL ducklake.set_option('data_inlining_row_limit', 0)")
+        create_fdw_secret(cluster, db, s3ctx)
     yield Lake(cluster, db, s3ctx)
     if s3ctx:
         # canary: an s3-parametrized test that never produced a single
@@ -624,4 +637,6 @@ def inlining_lake(request, cluster, db):
     PG catalog) and never touch S3. Enable inlining per connection with
     Lake.connect(inlining=...) and toggle per-statement with set_inlining()."""
     s3ctx = request.getfixturevalue("s3") if request.param == "s3" else None
+    if s3ctx:
+        create_fdw_secret(cluster, db, s3ctx)
     return Lake(cluster, db, s3ctx)

--- a/pg_ducklake/test/e2e/test_s3.py
+++ b/pg_ducklake/test/e2e/test_s3.py
@@ -1,5 +1,8 @@
 # S3-specific e2e tests: pg_ducklake writing table data to a MinIO bucket via
-# ducklake.default_table_path plus a DuckDB S3 secret. Skips without S3 infra
+# ducklake.default_table_path plus an S3 credential -- normally the catalog-backed
+# ducklake_secret FDW (created per database by the fixtures; loaded by every
+# engine at init, including the shared duckdb worker's), with raw session
+# CREATE SECRET behavior covered explicitly. Skips without S3 infra
 # (unless E2E_REQUIRE_S3=1); storage-agnostic behavior lives in test_crud.py.
 
 import os
@@ -7,11 +10,12 @@ import os
 import asyncpg
 import pytest
 
-from conftest import Lake, skip_or_fail
+from conftest import Lake, create_fdw_secret, skip_or_fail
 
 
 @pytest.fixture
 def s3lake(cluster, db, s3):
+    create_fdw_secret(cluster, db, s3)
     return Lake(cluster, db, s3)
 
 
@@ -46,9 +50,9 @@ async def test_parquet_objects_land_in_bucket(s3lake, s3conn, s3):
     objects = s3.object_names()
     assert objects, "no objects appeared in the bucket after INSERT"
     assert any(name.endswith(".parquet") for name in objects)
-    # rows read back from s3, not from any local cache of the insert
+    # rows read back from s3, not from any local cache of the insert: the
+    # recycled engine reloads the FDW secret from the catalog on next use
     await s3conn.execute("CALL ducklake.recycle_ddb()")
-    await s3lake.configure_s3(s3conn)  # recycle dropped the secret
     rows = await s3conn.fetch("SELECT id, name FROM t ORDER BY id")
     assert [tuple(r) for r in rows] == [(1, "alice"), (2, "bob")]
 
@@ -74,38 +78,46 @@ async def test_metadata_reports_s3_paths(s3lake, s3conn):
     assert out.strip().splitlines()[-1] == "t"
 
 
-async def test_fresh_backend_needs_secret(s3lake, s3conn):
+async def test_fresh_backend_reads_via_fdw_secret(s3lake, s3conn):
     await s3conn.execute("CREATE TABLE t (id int) USING ducklake")
     await s3conn.execute("INSERT INTO t VALUES (1), (2)")
 
-    # A brand-new backend has a brand-new DuckDB instance with no S3
-    # secret: reading s3-backed data must fail rather than silently
-    # succeed off some cache (AWS_* env is scrubbed by the harness).
+    # A brand-new backend has a brand-new DuckDB instance and runs no
+    # per-session secret setup, yet reads s3-backed data: the engine loads
+    # the FDW-backed credential from the PG catalog at init. This is also
+    # what lets the shared duckdb worker's engine access s3 (it never sees
+    # any backend's session-local CREATE SECRET).
     bare = await s3lake.connect(configure=False)
     try:
-        # match the bucket name so an unrelated error cannot satisfy the
-        # test: the failure must come from the s3 data-file access
-        with pytest.raises(asyncpg.PostgresError, match=s3lake.s3.bucket):
-            await bare.fetch("SELECT * FROM t")
-        await s3lake.configure_s3(bare)
         assert await bare.fetchval("SELECT count(*) FROM t") == 2
     finally:
         await bare.close()
 
 
-async def test_recycle_ddb_drops_secret(s3lake, s3conn):
-    await s3conn.execute("CREATE TABLE t (id int) USING ducklake")
-    await s3conn.execute("INSERT INTO t VALUES (1)")
-    assert await s3conn.fetchval("SELECT count(*) FROM t") == 1
+async def test_raw_session_secret_dies_on_recycle(cluster, db, s3):
+    # A raw CREATE SECRET (ducklake.raw_query) lives only in this backend's
+    # DuckDB instance: recycle_ddb tears the instance down and the secret
+    # with it, unlike the catalog-backed FDW secret (covered above and by
+    # test_helper_secret_reloads_after_recycle).
+    lake = Lake(cluster, db, s3)  # no FDW secret in this database
+    conn = await lake.connect(configure=False)
+    try:
+        await _load_httpfs(conn)
+        await conn.execute(f"SELECT ducklake.raw_query($e2e${s3.secret_sql()}$e2e$)")
+        await conn.execute(f"SET ducklake.default_table_path = '{lake.table_path}'")
+        await conn.execute("CALL ducklake.set_option('data_inlining_row_limit', 0)")
+        await conn.execute("CREATE TABLE t (id int) USING ducklake")
+        await conn.execute("INSERT INTO t VALUES (1)")
+        assert await conn.fetchval("SELECT count(*) FROM t") == 1
 
-    # recycle_ddb tears down the per-backend DuckDB instance; plain
-    # (non-persistent) secrets die with it
-    await s3conn.execute("CALL ducklake.recycle_ddb()")
-    with pytest.raises(asyncpg.PostgresError, match=s3lake.s3.bucket):
-        await s3conn.fetch("SELECT * FROM t")
+        await conn.execute("CALL ducklake.recycle_ddb()")
+        with pytest.raises(asyncpg.PostgresError, match=s3.bucket):
+            await conn.fetch("SELECT * FROM t")
 
-    await s3lake.configure_s3(s3conn)
-    assert await s3conn.fetchval("SELECT count(*) FROM t") == 1
+        await conn.execute(f"SELECT ducklake.raw_query($e2e${s3.secret_sql()}$e2e$)")
+        assert await conn.fetchval("SELECT count(*) FROM t") == 1
+    finally:
+        await conn.close()
 
 
 async def test_update_delete_against_s3(s3conn, s3):
@@ -145,10 +157,13 @@ async def test_time_travel_on_s3(s3conn):
     )
 
 
-async def test_create_s3_secret_round_trip(s3lake, s3):
+async def test_create_s3_secret_round_trip(cluster, db, s3):
     # Provision the S3 secret via the ducklake.create_s3_secret() wrapper
     # (a FOREIGN SERVER + USER MAPPING on the ducklake_secret FDW) instead of a
     # raw CREATE SECRET, then round-trip a table whose data lives in the bucket.
+    # Own database (no fixture-provisioned secret): the helper's server name is
+    # asserted below.
+    s3lake = Lake(cluster, db, s3)
     conn = await s3lake.connect(configure=False)
     try:
         # httpfs is not bundled; install it explicitly to avoid offline flakiness
@@ -183,9 +198,10 @@ async def test_create_s3_secret_round_trip(s3lake, s3):
         await conn.close()
 
 
-async def test_create_s3_secret_named_args(s3lake, s3):
+async def test_create_s3_secret_named_args(cluster, db, s3):
     # create_s3_secret accepts named-arg notation for the optional params and
     # still round-trips (complements the positional-arg test above).
+    s3lake = Lake(cluster, db, s3)  # own database: server name asserted
     conn = await s3lake.connect(configure=False)
     try:
         await _load_httpfs(conn)
@@ -210,9 +226,10 @@ async def test_create_s3_secret_named_args(s3lake, s3):
         await conn.close()
 
 
-async def test_two_s3_secrets_get_unique_names(s3lake):
+async def test_two_s3_secrets_get_unique_names(cluster, db, s3):
     # FindServerName: two create_s3_secret calls of the same type yield distinct
     # server names rather than colliding.
+    s3lake = Lake(cluster, db, s3)  # own database: exact server names asserted
     conn = await s3lake.connect(configure=False)
     try:
         await _load_httpfs(conn)
@@ -233,9 +250,10 @@ async def test_two_s3_secrets_get_unique_names(s3lake):
         await conn.close()
 
 
-async def test_drop_server_removes_secret(s3lake):
+async def test_drop_server_removes_secret(cluster, db, s3):
     # DROP SERVER invalidates the cached secrets; the next statement's
     # GetConnection drops the DuckDB secret, so s3 reads then fail.
+    s3lake = Lake(cluster, db, s3)  # own database: no other secret may cover the read
     conn = await s3lake.connect(configure=False)
     try:
         await _load_httpfs(conn)
@@ -262,10 +280,11 @@ async def test_drop_server_removes_secret(s3lake):
         await conn.close()
 
 
-async def test_helper_secret_reloads_after_recycle(s3lake):
+async def test_helper_secret_reloads_after_recycle(cluster, db, s3):
     # The PG-catalog SERVER+MAPPING persist across ducklake.recycle_ddb(); the
     # fresh DuckDB instance must reload the secret on the next GetConnection
     # (regression for DuckDBManager::Reset not clearing secrets_valid_).
+    s3lake = Lake(cluster, db, s3)  # own database: only the helper's secret may exist
     conn = await s3lake.connect(configure=False)
     try:
         await _load_httpfs(conn)

--- a/pg_ducklake/test/e2e/test_shared_worker.py
+++ b/pg_ducklake/test/e2e/test_shared_worker.py
@@ -1,0 +1,91 @@
+# Duckdb worker under real concurrency: N asyncpg clients dispatch reads
+# (and autocommit writes) to the one per-database DuckDB worker at the same time.
+# pg_regress and isolation drive statements serially, so this is the only place the
+# thread-per-session worker actually serves overlapping sessions.
+
+import asyncio
+
+READERS = 6
+WRITERS = 2
+ROUNDS = 5
+
+
+async def test_concurrent_worker_reads(lake):
+    conn = await lake.connect()
+    try:
+        await conn.execute("CREATE TABLE cw_r (a int, b text) USING ducklake")
+        await conn.execute(
+            "INSERT INTO cw_r SELECT g, 'r' || (g % 7) FROM generate_series(1, 5000) g"
+        )
+    finally:
+        await conn.close()
+
+    async def reader(i):
+        c = await lake.connect()
+        try:
+            await c.execute("SET ducklake.use_shared_worker = on")
+            for _ in range(ROUNDS):
+                # count/min/max only: their PG parser type matches the DuckDB result
+                # type. sum(int) does not (PG describes numeric) and trips the known,
+                # worker-independent extended-protocol type-mismatch seam.
+                assert await c.fetchval("SELECT count(*) FROM cw_r") == 5000
+                assert await c.fetchval("SELECT min(a) FROM cw_r") == 1
+                assert await c.fetchval("SELECT max(a) FROM cw_r") == 5000
+                rows = await c.fetch(
+                    "SELECT b, count(*) AS n FROM cw_r GROUP BY b ORDER BY b"
+                )
+                assert len(rows) == 7
+                assert sum(r["n"] for r in rows) == 5000
+        finally:
+            await c.close()
+
+    await asyncio.gather(*(reader(i) for i in range(READERS)))
+
+
+async def test_concurrent_worker_reads_and_writes(lake):
+    conn = await lake.connect()
+    try:
+        await conn.execute("CREATE TABLE cw_w (a int, tag int) USING ducklake")
+    finally:
+        await conn.close()
+
+    async def writer(tag):
+        c = await lake.connect()
+        try:
+            await c.execute("SET ducklake.use_shared_worker = on")
+            for r in range(ROUNDS):
+                # Autocommit DML dispatches; its DuckLake metadata commit runs on
+                # this backend, so concurrent writers exercise the conflict retry.
+                await c.execute(f"INSERT INTO cw_w SELECT g, {tag} FROM generate_series(1, 100) g")
+        finally:
+            await c.close()
+
+    async def reader(i):
+        c = await lake.connect()
+        try:
+            await c.execute("SET ducklake.use_shared_worker = on")
+            for _ in range(ROUNDS):
+                n = await c.fetchval("SELECT count(*) FROM cw_w")
+                assert n % 100 == 0  # only whole committed batches are visible
+        finally:
+            await c.close()
+
+    await asyncio.gather(
+        *(writer(t) for t in range(WRITERS)),
+        *(reader(i) for i in range(READERS)),
+    )
+
+    conn = await lake.connect()
+    try:
+        # Verify through the worker too: an in-process read of an inlined-data table
+        # goes DuckDB -> PostgresTableReader -> PG parallel workers, which hangs on
+        # macOS (the known ExecParallelFinish issue documented in regression.conf).
+        await conn.execute("SET ducklake.use_shared_worker = on")
+        assert await conn.fetchval("SELECT count(*) FROM cw_w") == WRITERS * ROUNDS * 100
+        for tag in range(WRITERS):
+            assert (
+                await conn.fetchval(f"SELECT count(*) FROM cw_w WHERE tag = {tag}")
+                == ROUNDS * 100
+            )
+    finally:
+        await conn.close()

--- a/pg_ducklake/test/isolation/expected/worker_concurrent_writes.out
+++ b/pg_ducklake/test/isolation/expected/worker_concurrent_writes.out
@@ -1,0 +1,37 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1_begin s1_insert s2_insert s2_count s1_commit s2_count
+step s1_begin: BEGIN;
+step s1_insert: INSERT INTO iso_worker_t VALUES (1);
+step s2_insert: INSERT INTO iso_worker_t VALUES (2);
+step s2_count: SELECT count(*) FROM iso_worker_t;
+count
+-----
+    1
+(1 row)
+
+step s1_commit: COMMIT;
+step s2_count: SELECT count(*) FROM iso_worker_t;
+count
+-----
+    2
+(1 row)
+
+
+starting permutation: s2_insert s1_begin s1_insert s2_count s1_commit s2_count
+step s2_insert: INSERT INTO iso_worker_t VALUES (2);
+step s1_begin: BEGIN;
+step s1_insert: INSERT INTO iso_worker_t VALUES (1);
+step s2_count: SELECT count(*) FROM iso_worker_t;
+count
+-----
+    1
+(1 row)
+
+step s1_commit: COMMIT;
+step s2_count: SELECT count(*) FROM iso_worker_t;
+count
+-----
+    2
+(1 row)
+

--- a/pg_ducklake/test/isolation/isolation.conf
+++ b/pg_ducklake/test/isolation/isolation.conf
@@ -10,3 +10,5 @@
 shared_preload_libraries = 'pg_ducklake'
 log_temp_files = -1
 ducklake.maintenance_enabled = false
+ducklake.max_worker_sessions = 8
+

--- a/pg_ducklake/test/isolation/schedule
+++ b/pg_ducklake/test/isolation/schedule
@@ -1,3 +1,4 @@
 test: explicit_transaction_commit
 test: concurrent_writes
 test: concurrent_cross_table_writes
+test: worker_concurrent_writes

--- a/pg_ducklake/test/isolation/specs/worker_concurrent_writes.spec
+++ b/pg_ducklake/test/isolation/specs/worker_concurrent_writes.spec
@@ -1,0 +1,31 @@
+# Shared-worker dispatch under concurrency: s1 writes in an in-process transaction
+# while s2 dispatches autocommit writes and reads to the shared DuckDB worker (its
+# DuckLake metadata commit runs back on s2's backend, inside s2's transaction).
+setup
+{
+  CREATE TABLE iso_worker_t (id int) USING ducklake;
+}
+
+session s1
+step s1_begin  { BEGIN; }
+step s1_insert { INSERT INTO iso_worker_t VALUES (1); }
+step s1_commit { COMMIT; }
+
+session s2
+setup { SET ducklake.use_shared_worker = on; }
+step s2_insert { INSERT INTO iso_worker_t VALUES (2); }
+step s2_count  { SELECT count(*) FROM iso_worker_t; }
+
+teardown
+{
+  DROP TABLE iso_worker_t;
+}
+
+# Dispatched write and read while s1's transaction is open: s2's autocommit insert
+# commits immediately (worker execution, backend-transaction metadata commit) and its
+# dispatched read sees it; s1 commits fine afterwards (snapshot conflict retry).
+permutation s1_begin s1_insert s2_insert s2_count s1_commit s2_count
+
+# Dispatched read before and after an in-process commit: the worker read runs under
+# s2's shipped snapshot, so it sees exactly what an in-process read would.
+permutation s2_insert s1_begin s1_insert s2_count s1_commit s2_count

--- a/pg_ducklake/test/regression/expected/worker_dispatch.out
+++ b/pg_ducklake/test/regression/expected/worker_dispatch.out
@@ -1,0 +1,224 @@
+-- Dispatch real read-only DuckLake queries to the shared DuckDB worker and confirm
+-- identical results to in-process execution. Writes stay in-process; only the
+-- read-only SELECTs are routed to the worker when ducklake.use_shared_worker is on.
+-- Each query is run in-process (off) then dispatched (on); the outputs must match.
+CREATE TABLE we_t (a int, b text) USING ducklake;
+INSERT INTO we_t VALUES (1, 'x'), (2, 'y'), (3, 'z');
+CREATE TABLE we_u (a int, c text) USING ducklake;
+INSERT INTO we_u VALUES (1, 'p'), (2, 'q');
+-- Scan + ORDER BY.
+SET ducklake.use_shared_worker = off;
+SELECT a, b FROM we_t ORDER BY a;
+ a | b 
+---+---
+ 1 | x
+ 2 | y
+ 3 | z
+(3 rows)
+
+SET ducklake.use_shared_worker = on;
+SELECT a, b FROM we_t ORDER BY a;
+ a | b 
+---+---
+ 1 | x
+ 2 | y
+ 3 | z
+(3 rows)
+
+-- Aggregation.
+SET ducklake.use_shared_worker = off;
+SELECT count(*), sum(a) FROM we_t;
+ count | sum 
+-------+-----
+     3 |   6
+(1 row)
+
+SET ducklake.use_shared_worker = on;
+SELECT count(*), sum(a) FROM we_t;
+ count | sum 
+-------+-----
+     3 |   6
+(1 row)
+
+-- Join.
+SET ducklake.use_shared_worker = off;
+SELECT t.a, t.b, u.c FROM we_t t JOIN we_u u USING (a) ORDER BY t.a;
+ a | b | c 
+---+---+---
+ 1 | x | p
+ 2 | y | q
+(2 rows)
+
+SET ducklake.use_shared_worker = on;
+SELECT t.a, t.b, u.c FROM we_t t JOIN we_u u USING (a) ORDER BY t.a;
+ a | b | c 
+---+---+---
+ 1 | x | p
+ 2 | y | q
+(2 rows)
+
+-- Grouped aggregation.
+SET ducklake.use_shared_worker = off;
+SELECT b, count(*) FROM we_t GROUP BY b ORDER BY b;
+ b | count 
+---+-------
+ x |     1
+ y |     1
+ z |     1
+(3 rows)
+
+SET ducklake.use_shared_worker = on;
+SELECT b, count(*) FROM we_t GROUP BY b ORDER BY b;
+ b | count 
+---+-------
+ x |     1
+ y |     1
+ z |     1
+(3 rows)
+
+-- The worker really served the dispatched query: the accepted-session count grew by
+-- exactly one (the stats call itself is not a DuckDB query, so it never dispatches).
+SET ducklake.use_shared_worker = on;
+SELECT ducklake.worker_stats() AS stats_before \gset
+SELECT count(*) FROM we_t;
+ count 
+-------
+     3
+(1 row)
+
+SELECT ducklake.worker_stats() - :stats_before AS dispatched_delta;
+ dispatched_delta 
+------------------
+                1
+(1 row)
+
+-- Hybrid: a DuckLake table joined with a regular PostgreSQL heap table. The query
+-- is offloaded because it references a DuckLake table; when dispatched, the worker
+-- reads the heap table under the backend's shipped snapshot.
+CREATE TABLE we_heap (a int, d text);
+INSERT INTO we_heap VALUES (1, 'h1'), (2, 'h2'), (3, 'h3');
+SET ducklake.use_shared_worker = off;
+SELECT t.a, t.b, h.d FROM we_t t JOIN we_heap h USING (a) ORDER BY t.a;
+ a | b | d  
+---+---+----
+ 1 | x | h1
+ 2 | y | h2
+ 3 | z | h3
+(3 rows)
+
+SET ducklake.use_shared_worker = on;
+SELECT t.a, t.b, h.d FROM we_t t JOIN we_heap h USING (a) ORDER BY t.a;
+ a | b | d  
+---+---+----
+ 1 | x | h1
+ 2 | y | h2
+ 3 | z | h3
+(3 rows)
+
+-- Hybrid with a temp table: backend-local, so the scan must run on the requesting
+-- backend (inversion path), never on the scan-producer pool.
+CREATE TEMP TABLE we_tmp (a int, d text);
+INSERT INTO we_tmp VALUES (1, 't1'), (3, 't3');
+SET ducklake.use_shared_worker = off;
+SELECT t.a, t.b, m.d FROM we_t t JOIN we_tmp m USING (a) ORDER BY t.a;
+ a | b | d  
+---+---+----
+ 1 | x | t1
+ 3 | z | t3
+(2 rows)
+
+SET ducklake.use_shared_worker = on;
+SELECT t.a, t.b, m.d FROM we_t t JOIN we_tmp m USING (a) ORDER BY t.a;
+ a | b | d  
+---+---+----
+ 1 | x | t1
+ 3 | z | t3
+(2 rows)
+
+-- Hybrid over bool/timestamp/timestamptz heap columns (Arrow scan transport coverage).
+CREATE TABLE we_types (a int, ok bool, ts timestamp, tstz timestamptz);
+INSERT INTO we_types VALUES
+    (1, true, '2024-01-02 03:04:05', '2024-01-02 03:04:05+00'),
+    (2, false, '1999-12-31 23:59:59', '1999-12-31 23:59:59+00'),
+    (3, NULL, NULL, NULL);
+SET timezone = 'UTC';
+SET ducklake.use_shared_worker = off;
+SELECT t.a, y.ok, y.ts, y.tstz FROM we_t t JOIN we_types y USING (a) ORDER BY t.a;
+ a | ok |            ts            |             tstz             
+---+----+--------------------------+------------------------------
+ 1 | t  | Tue Jan 02 03:04:05 2024 | Tue Jan 02 03:04:05 2024 UTC
+ 2 | f  | Fri Dec 31 23:59:59 1999 | Fri Dec 31 23:59:59 1999 UTC
+ 3 |    |                          | 
+(3 rows)
+
+SET ducklake.use_shared_worker = on;
+SELECT t.a, y.ok, y.ts, y.tstz FROM we_t t JOIN we_types y USING (a) ORDER BY t.a;
+ a | ok |            ts            |             tstz             
+---+----+--------------------------+------------------------------
+ 1 | t  | Tue Jan 02 03:04:05 2024 | Tue Jan 02 03:04:05 2024 UTC
+ 2 | f  | Fri Dec 31 23:59:59 1999 | Fri Dec 31 23:59:59 1999 UTC
+ 3 |    |                          | 
+(3 rows)
+
+RESET timezone;
+-- Autocommit write dispatched to the worker, then read back in-process to confirm
+-- the worker's write committed and is visible. (Transactional/DDL writes are not
+-- dispatched and stay in-process.)
+SET ducklake.use_shared_worker = on;
+INSERT INTO we_t VALUES (4, 'w');
+SET ducklake.use_shared_worker = off;
+SELECT a, b FROM we_t ORDER BY a;
+ a | b 
+---+---
+ 1 | x
+ 2 | y
+ 3 | z
+ 4 | w
+(4 rows)
+
+SELECT count(*) FROM we_t;
+ count 
+-------
+     4
+(1 row)
+
+-- UPDATE and DELETE dispatched to the worker, then read back.
+SET ducklake.use_shared_worker = on;
+UPDATE we_t SET b = 'W' WHERE a = 4;
+DELETE FROM we_t WHERE a = 4;
+SET ducklake.use_shared_worker = off;
+SELECT a, b FROM we_t ORDER BY a;
+ a | b 
+---+---
+ 1 | x
+ 2 | y
+ 3 | z
+(3 rows)
+
+-- Writes inside a transaction block or with RETURNING never dispatch (the
+-- accepted-session count stays flat); the gate keeps them in-process, where the
+-- transaction-block insert runs (and rolls back) and RETURNING is refused by DuckLake.
+SET ducklake.use_shared_worker = on;
+SELECT ducklake.worker_stats() AS stats_before \gset
+BEGIN;
+INSERT INTO we_t VALUES (5, 'txn');
+ROLLBACK;
+INSERT INTO we_t VALUES (6, 'ret') RETURNING a, b;
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: Binder Error: RETURNING clause not yet supported for insertion into DuckLake table
+SELECT ducklake.worker_stats() - :stats_before AS gated_delta;
+ gated_delta 
+-------------
+           0
+(1 row)
+
+SET ducklake.use_shared_worker = off;
+DELETE FROM we_t WHERE a = 6;
+SELECT a, b FROM we_t ORDER BY a;
+ a | b 
+---+---
+ 1 | x
+ 2 | y
+ 3 | z
+(3 rows)
+
+RESET ducklake.use_shared_worker;

--- a/pg_ducklake/test/regression/expected/worker_hardening.out
+++ b/pg_ducklake/test/regression/expected/worker_hardening.out
@@ -1,0 +1,69 @@
+-- Failure-path behavior of the shared DuckDB worker: worker-side errors surface as
+-- PG ERRORs, cancellation interrupts the running query, an Arrow-unsupported column
+-- fails loudly, and a killed worker respawns on the next dispatch.
+CREATE TABLE wh_t (a int, b text) USING ducklake;
+INSERT INTO wh_t SELECT g, 'row_' || g FROM generate_series(1, 1000) g;
+SET ducklake.use_shared_worker = on;
+-- A worker-side execution error surfaces as a PG ERROR with DuckDB's message,
+-- identical to the in-process error.
+SET ducklake.use_shared_worker = off;
+SELECT CAST(b AS int) FROM wh_t WHERE a = 1;
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Conversion Error: Could not convert string 'row_1' to INT32 when casting from source column b
+
+LINE 1:  SELECT (b)::integer AS b FROM pgducklake.public.wh_t WHERE (a = 1)
+                   ^
+SET ducklake.use_shared_worker = on;
+SELECT CAST(b AS int) FROM wh_t WHERE a = 1;
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: Conversion Error: Could not convert string 'row_1' to INT32 when casting from source column b
+
+LINE 1: SELECT (b)::integer AS b FROM pgducklake.public.wh_t WHERE (a = 1)
+                  ^
+-- Cancellation: a statement timeout cancels a dispatched long-running aggregate
+-- (the backend interrupts the worker session; the worker aborts the query).
+SET statement_timeout = '200ms';
+SELECT count(*) FROM wh_t x, wh_t y, wh_t z WHERE x.a + y.a + z.a > 0;
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: Query cancelled
+RESET statement_timeout;
+-- The worker survived the cancelled query and still serves new dispatches.
+SELECT count(*) FROM wh_t;
+ count 
+-------
+  1000
+(1 row)
+
+-- A heap column the Arrow scan transport does not support fails loudly, naming the
+-- column, instead of silently falling back.
+CREATE TABLE wh_uuid (a int, u uuid);
+INSERT INTO wh_uuid VALUES (1, '00000000-0000-0000-0000-000000000001');
+SELECT t.a, h.u FROM wh_t t JOIN wh_uuid h USING (a) ORDER BY t.a;
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: Executor Error: duckdb worker: column "u" (type oid 2950) is not supported by the Arrow scan transport
+-- Kill the duckdb worker; the next dispatch respawns it on demand.
+SELECT count(pg_terminate_backend(pid)) AS terminated
+FROM pg_stat_activity WHERE backend_type = 'pg_ducklake duckdb worker';
+ terminated 
+------------
+          1
+(1 row)
+
+SELECT pg_sleep(0.5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT count(*) FROM wh_t;
+ count 
+-------
+  1000
+(1 row)
+
+SELECT count(*) > 0 AS worker_running
+FROM pg_stat_activity WHERE backend_type = 'pg_ducklake duckdb worker';
+ worker_running 
+----------------
+ t
+(1 row)
+
+RESET ducklake.use_shared_worker;
+DROP TABLE wh_t;
+DROP TABLE wh_uuid;

--- a/pg_ducklake/test/regression/regression.conf
+++ b/pg_ducklake/test/regression/regression.conf
@@ -18,3 +18,4 @@ log_temp_files = -1
 max_parallel_workers_per_gather = 0
 max_parallel_workers = 0
 ducklake.maintenance_enabled = false
+ducklake.max_worker_sessions = 8

--- a/pg_ducklake/test/regression/schedule
+++ b/pg_ducklake/test/regression/schedule
@@ -53,3 +53,5 @@ test: import_foreign_schema
 test: secrets
 test: access_control
 test: quoted_names
+test: worker_dispatch
+test: worker_hardening

--- a/pg_ducklake/test/regression/sql/worker_dispatch.sql
+++ b/pg_ducklake/test/regression/sql/worker_dispatch.sql
@@ -1,0 +1,103 @@
+-- Dispatch real read-only DuckLake queries to the shared DuckDB worker and confirm
+-- identical results to in-process execution. Writes stay in-process; only the
+-- read-only SELECTs are routed to the worker when ducklake.use_shared_worker is on.
+-- Each query is run in-process (off) then dispatched (on); the outputs must match.
+CREATE TABLE we_t (a int, b text) USING ducklake;
+INSERT INTO we_t VALUES (1, 'x'), (2, 'y'), (3, 'z');
+CREATE TABLE we_u (a int, c text) USING ducklake;
+INSERT INTO we_u VALUES (1, 'p'), (2, 'q');
+
+-- Scan + ORDER BY.
+SET ducklake.use_shared_worker = off;
+SELECT a, b FROM we_t ORDER BY a;
+SET ducklake.use_shared_worker = on;
+SELECT a, b FROM we_t ORDER BY a;
+
+-- Aggregation.
+SET ducklake.use_shared_worker = off;
+SELECT count(*), sum(a) FROM we_t;
+SET ducklake.use_shared_worker = on;
+SELECT count(*), sum(a) FROM we_t;
+
+-- Join.
+SET ducklake.use_shared_worker = off;
+SELECT t.a, t.b, u.c FROM we_t t JOIN we_u u USING (a) ORDER BY t.a;
+SET ducklake.use_shared_worker = on;
+SELECT t.a, t.b, u.c FROM we_t t JOIN we_u u USING (a) ORDER BY t.a;
+
+-- Grouped aggregation.
+SET ducklake.use_shared_worker = off;
+SELECT b, count(*) FROM we_t GROUP BY b ORDER BY b;
+SET ducklake.use_shared_worker = on;
+SELECT b, count(*) FROM we_t GROUP BY b ORDER BY b;
+
+-- The worker really served the dispatched query: the accepted-session count grew by
+-- exactly one (the stats call itself is not a DuckDB query, so it never dispatches).
+SET ducklake.use_shared_worker = on;
+SELECT ducklake.worker_stats() AS stats_before \gset
+SELECT count(*) FROM we_t;
+SELECT ducklake.worker_stats() - :stats_before AS dispatched_delta;
+
+-- Hybrid: a DuckLake table joined with a regular PostgreSQL heap table. The query
+-- is offloaded because it references a DuckLake table; when dispatched, the worker
+-- reads the heap table under the backend's shipped snapshot.
+CREATE TABLE we_heap (a int, d text);
+INSERT INTO we_heap VALUES (1, 'h1'), (2, 'h2'), (3, 'h3');
+SET ducklake.use_shared_worker = off;
+SELECT t.a, t.b, h.d FROM we_t t JOIN we_heap h USING (a) ORDER BY t.a;
+SET ducklake.use_shared_worker = on;
+SELECT t.a, t.b, h.d FROM we_t t JOIN we_heap h USING (a) ORDER BY t.a;
+
+-- Hybrid with a temp table: backend-local, so the scan must run on the requesting
+-- backend (inversion path), never on the scan-producer pool.
+CREATE TEMP TABLE we_tmp (a int, d text);
+INSERT INTO we_tmp VALUES (1, 't1'), (3, 't3');
+SET ducklake.use_shared_worker = off;
+SELECT t.a, t.b, m.d FROM we_t t JOIN we_tmp m USING (a) ORDER BY t.a;
+SET ducklake.use_shared_worker = on;
+SELECT t.a, t.b, m.d FROM we_t t JOIN we_tmp m USING (a) ORDER BY t.a;
+
+-- Hybrid over bool/timestamp/timestamptz heap columns (Arrow scan transport coverage).
+CREATE TABLE we_types (a int, ok bool, ts timestamp, tstz timestamptz);
+INSERT INTO we_types VALUES
+    (1, true, '2024-01-02 03:04:05', '2024-01-02 03:04:05+00'),
+    (2, false, '1999-12-31 23:59:59', '1999-12-31 23:59:59+00'),
+    (3, NULL, NULL, NULL);
+SET timezone = 'UTC';
+SET ducklake.use_shared_worker = off;
+SELECT t.a, y.ok, y.ts, y.tstz FROM we_t t JOIN we_types y USING (a) ORDER BY t.a;
+SET ducklake.use_shared_worker = on;
+SELECT t.a, y.ok, y.ts, y.tstz FROM we_t t JOIN we_types y USING (a) ORDER BY t.a;
+RESET timezone;
+
+-- Autocommit write dispatched to the worker, then read back in-process to confirm
+-- the worker's write committed and is visible. (Transactional/DDL writes are not
+-- dispatched and stay in-process.)
+SET ducklake.use_shared_worker = on;
+INSERT INTO we_t VALUES (4, 'w');
+SET ducklake.use_shared_worker = off;
+SELECT a, b FROM we_t ORDER BY a;
+SELECT count(*) FROM we_t;
+
+-- UPDATE and DELETE dispatched to the worker, then read back.
+SET ducklake.use_shared_worker = on;
+UPDATE we_t SET b = 'W' WHERE a = 4;
+DELETE FROM we_t WHERE a = 4;
+SET ducklake.use_shared_worker = off;
+SELECT a, b FROM we_t ORDER BY a;
+
+-- Writes inside a transaction block or with RETURNING never dispatch (the
+-- accepted-session count stays flat); the gate keeps them in-process, where the
+-- transaction-block insert runs (and rolls back) and RETURNING is refused by DuckLake.
+SET ducklake.use_shared_worker = on;
+SELECT ducklake.worker_stats() AS stats_before \gset
+BEGIN;
+INSERT INTO we_t VALUES (5, 'txn');
+ROLLBACK;
+INSERT INTO we_t VALUES (6, 'ret') RETURNING a, b;
+SELECT ducklake.worker_stats() - :stats_before AS gated_delta;
+SET ducklake.use_shared_worker = off;
+DELETE FROM we_t WHERE a = 6;
+SELECT a, b FROM we_t ORDER BY a;
+
+RESET ducklake.use_shared_worker;

--- a/pg_ducklake/test/regression/sql/worker_hardening.sql
+++ b/pg_ducklake/test/regression/sql/worker_hardening.sql
@@ -1,0 +1,41 @@
+-- Failure-path behavior of the shared DuckDB worker: worker-side errors surface as
+-- PG ERRORs, cancellation interrupts the running query, an Arrow-unsupported column
+-- fails loudly, and a killed worker respawns on the next dispatch.
+CREATE TABLE wh_t (a int, b text) USING ducklake;
+INSERT INTO wh_t SELECT g, 'row_' || g FROM generate_series(1, 1000) g;
+
+SET ducklake.use_shared_worker = on;
+
+-- A worker-side execution error surfaces as a PG ERROR with DuckDB's message,
+-- identical to the in-process error.
+SET ducklake.use_shared_worker = off;
+SELECT CAST(b AS int) FROM wh_t WHERE a = 1;
+SET ducklake.use_shared_worker = on;
+SELECT CAST(b AS int) FROM wh_t WHERE a = 1;
+
+-- Cancellation: a statement timeout cancels a dispatched long-running aggregate
+-- (the backend interrupts the worker session; the worker aborts the query).
+SET statement_timeout = '200ms';
+SELECT count(*) FROM wh_t x, wh_t y, wh_t z WHERE x.a + y.a + z.a > 0;
+RESET statement_timeout;
+
+-- The worker survived the cancelled query and still serves new dispatches.
+SELECT count(*) FROM wh_t;
+
+-- A heap column the Arrow scan transport does not support fails loudly, naming the
+-- column, instead of silently falling back.
+CREATE TABLE wh_uuid (a int, u uuid);
+INSERT INTO wh_uuid VALUES (1, '00000000-0000-0000-0000-000000000001');
+SELECT t.a, h.u FROM wh_t t JOIN wh_uuid h USING (a) ORDER BY t.a;
+
+-- Kill the duckdb worker; the next dispatch respawns it on demand.
+SELECT count(pg_terminate_backend(pid)) AS terminated
+FROM pg_stat_activity WHERE backend_type = 'pg_ducklake duckdb worker';
+SELECT pg_sleep(0.5);
+SELECT count(*) FROM wh_t;
+SELECT count(*) > 0 AS worker_running
+FROM pg_stat_activity WHERE backend_type = 'pg_ducklake duckdb worker';
+
+RESET ducklake.use_shared_worker;
+DROP TABLE wh_t;
+DROP TABLE wh_uuid;

--- a/specs/tla/ControlProtocol.cfg
+++ b/specs/tla/ControlProtocol.cfg
@@ -1,0 +1,38 @@
+\* Full lifecycle, the real code: THREE backends contending for TWO slots
+\* with a pending ring of 1, so both capacity WAITS are exercised -- one
+\* backend must wait for a free slot (Acquire keeps returning -1; no
+\* in-process fallback), and a backend holding a slot must wait for the worker
+\* to drain the full pending ring before its enqueue lands. Aborts are allowed
+\* in every phase, including during either wait and while PENDING -- the abort
+\* that leaves a stale ring entry (which the TryAttachEnd generation check,
+\* ValidateGeneration = TRUE, must skip) AND possibly a session thread already
+\* parked in the handshake receive (which the cancel-flag write,
+\* AbortSetsCancel = TRUE, must unwedge). No worker crash, atomic
+\* acquire+attach.
+\* Expect PASS: refcounts never underflow or exceed 2, a FREE slot never has
+\* an attached end, no two backends hold one slot, every slot returns to FREE
+\* -- including one whose session thread was parked in the handshake when its
+\* backend aborted -- and every backend is eventually served or settles
+\* cleanly (no starvation: SessionSettles / Liveness hold).
+SPECIFICATION Spec
+
+CONSTANTS
+    Backends = {b1, b2, b3}
+    NSlots = 2
+    PendingCap = 1
+    AllowAbort = TRUE
+    AllowEarlyAbort = TRUE
+    AbortSetsCancel = TRUE
+    ValidateGeneration = TRUE
+    AllowWorkerCrash = FALSE
+    SplitAcquire = FALSE
+
+INVARIANT TypeOK
+INVARIANT NoUnderflow
+INVARIANT RefcountBounded
+INVARIANT FreeImpliesUnattached
+INVARIANT SingleBackendPerSlot
+
+PROPERTY NoSlotLeak
+PROPERTY SessionSettles
+PROPERTY Liveness

--- a/specs/tla/ControlProtocol.tla
+++ b/specs/tla/ControlProtocol.tla
@@ -1,0 +1,547 @@
+----------------------------- MODULE ControlProtocol -----------------------------
+(***************************************************************************)
+(* A TLA+ model of the SESSION-POOL SESSION LIFECYCLE of the shared        *)
+(* DuckDB duckdb worker (libpgduckdb/worker/duckdb_worker.cpp +            *)
+(* libpgduckdb/worker/transport/session_pool.cpp).                         *)
+(*                                                                         *)
+(* What is modelled: how a backend gets a session onto the per-database    *)
+(* worker and how the session slot is returned, under aborts, crashes, and *)
+(* capacity pressure. The data plane (frames, chunks, demux lanes) is      *)
+(* modelled separately in ScanInversion.tla; here a served session simply  *)
+(* "finishes".                                                             *)
+(*                                                                         *)
+(* The protocol (DuckdbWorker::OpenSession -> worker main loop ->          *)
+(* SessionThreadMain):                                                     *)
+(*   - SessionPool::Acquire takes the first FREE slot (state -> IN_USE,    *)
+(*     GENERATION bumped, attach refcount reset to 0) and the backend      *)
+(*     immediately AttachEnds (refcount 1) and re-creates the channel      *)
+(*     (SessionChannel::OpenSlot resets the header cancel flag). Nothing   *)
+(*     fallible sits between the calls, and from that moment the slot is   *)
+(*     tracked for cleanup (g_pending_conn_slot, then the open-stream      *)
+(*     registry), so acquire+attach+track is modelled as ONE atomic step.  *)
+(*     The SplitAcquire constant breaks that atomicity to show the bug     *)
+(*     class the code avoids.                                              *)
+(*   - CAPACITY WAITS, not fallback: when Acquire returns -1 (pool full)   *)
+(*     the backend retries in a cancellable wait loop (interrupt check +   *)
+(*     10ms latch wait) until a slot frees; it never falls back to         *)
+(*     in-process execution for capacity reasons. Modelled by Acquire      *)
+(*     simply not being enabled -- the backend takes no transition until a *)
+(*     slot is FREE (weak fairness on the acquire action stands in for the *)
+(*     retry loop). In-process execution happens only for statements the   *)
+(*     dispatch gate excludes semantically, which is outside this model.   *)
+(*   - The backend enqueues {slot index, slot generation} on the worker's  *)
+(*     pending-session ring (EnqueuePendingSession) and pokes the worker   *)
+(*     latch. A full ring or a missing worker also means WAIT-and-retry:   *)
+(*     if the worker registry slot is gone the backend calls               *)
+(*     EnsureWorkerForMyDatabase (which reclaims dead workers and          *)
+(*     respawns), then re-attempts the enqueue; if the ring is just full   *)
+(*     it waits for the worker to drain it. An abort during either wait is *)
+(*     fine: the pool-full wait holds nothing yet, and the ring-full wait  *)
+(*     holds a slot the cleanup callbacks release.                         *)
+(*   - THE HANDSHAKE: after the enqueue lands the backend sends the        *)
+(*     Snapshot and SQL frames and constructs the result stream            *)
+(*     (SendHandshake here; then it is "served"). Independently, the       *)
+(*     worker main loop drains the ring and spawns a session thread per    *)
+(*     entry; the thread calls SessionPool::TryAttachEnd(idx, gen), which  *)
+(*     attaches (refcount 2) only if the slot is still IN_USE at the       *)
+(*     enqueued generation -- a STALE entry, whose backend released the    *)
+(*     slot (or whose slot was re-acquired) after enqueueing, is skipped.  *)
+(*     The ValidateGeneration constant turns that check off to reproduce   *)
+(*     that pre-fix race. An attached thread then WAITS in the handshake   *)
+(*     receive (SerializedRecvControl in RunOneSession): a nowait-recv     *)
+(*     poll loop that observes EITHER a received frame OR the channel      *)
+(*     cancel flag / worker drain (on which it returns Detached).          *)
+(*     Modelled as the wwait counter and the HandshakeOk /                 *)
+(*     HandshakeCancelled steps. After the query the thread DetachEnds.    *)
+(*     Each side's DetachEnd decrements; the one that reaches 0 flips the  *)
+(*     slot back to FREE.                                                  *)
+(*   - Backend abort/exit: the xact-abort callbacks and before_shmem_exit  *)
+(*     run ReleaseOpenSessions -> the BackendSession destructor cancels,   *)
+(*     detaches, DetachEnds. Modelled as abort actions in each phase.      *)
+(*     An abort while the session is still pending (enqueued, handshake    *)
+(*     frames not yet sent) leaves a stale ring entry AND possibly a       *)
+(*     session thread already attached and parked in the handshake         *)
+(*     receive. The fixed cleanup path is TWO steps                        *)
+(*     (ReleaseOpenSessions, g_pending_conn_slot branch): FIRST            *)
+(*     SessionChannel::RequestCancelAt sets the channel cancel flag (the   *)
+(*     parked thread's poll sees it and detaches), THEN DetachEnd releases *)
+(*     the backend's own refcount. AbortSetsCancel = FALSE drops the       *)
+(*     cancel step (the pre-fix code, which only DetachEnd-ed): a thread   *)
+(*     already parked in the handshake then waits forever and its refcount *)
+(*     pins the slot -- the wedged-thread slot leak.                       *)
+(*     Subtransaction aborts release only streams created in that          *)
+(*     subtransaction -- a refinement below this model's granularity (it   *)
+(*     never releases a slot twice, so the accounting here is unaffected). *)
+(*   - Worker death: the duckdb worker drains its session threads in a     *)
+(*     before_shmem_exit callback, so ERROR/FATAL exits DetachEnd cleanly  *)
+(*     -- those look like ordinary SessionFinish steps here. A HARD kill   *)
+(*     (SIGKILL, segfault) skips the callback; in a real cluster the       *)
+(*     postmaster then crash-restarts and reinitializes shared memory.     *)
+(*     WorkerCrash models the counterfactual "hard kill with no shmem      *)
+(*     reset" to show why the drain callback (and the crash-restart)       *)
+(*     matter: without them, worker-attached refcounts strand their slots. *)
+(*     EnsureWorkerForMyDatabase's pid probe reclaims the REGISTRY slot so *)
+(*     a respawned worker starts with an empty pending ring                *)
+(*     (WorkerRespawn); it does not touch session-pool refcounts.          *)
+(*                                                                         *)
+(* CONSTANTS pick the adversary:                                           *)
+(*   Backends       - backend ids, one query each. Use one more backend    *)
+(*                    than NSlots to exercise the pool-full wait.          *)
+(*   NSlots         - session-pool slots.                                  *)
+(*   PendingCap     - pending-ring capacity (1024 in code; small here to   *)
+(*                    exercise the ring-full wait).                        *)
+(*   AllowAbort     - backend may abort while WAITING for a slot, while    *)
+(*                    ACQUIRED (incl. the ring-full wait), or while SERVED *)
+(*                    (cleanup callback releases whatever it holds).       *)
+(*   AllowEarlyAbort- backend may abort while PENDING (enqueued, handshake *)
+(*                    frames not yet sent), leaving a stale ring entry and *)
+(*                    possibly a parked session thread.                    *)
+(*   AbortSetsCancel- TRUE: the pending-abort path sets the channel cancel *)
+(*                    flag before DetachEnd (RequestCancelAt, the          *)
+(*                    implemented fix), so a parked handshake thread bails.*)
+(*                    FALSE: it only DetachEnds (pre-fix): expect FAIL     *)
+(*                    (deadlock at the wedged-thread slot leak).           *)
+(*   ValidateGeneration - TRUE: SessionThreadMain uses TryAttachEnd (the   *)
+(*                    implemented fix). FALSE: attach unconditionally (the *)
+(*                    pre-fix race): expect FAIL.                          *)
+(*   AllowWorkerCrash - hard worker kill with no drain and no shmem reset  *)
+(*                    (see above). Expect FAIL (deadlock at a leaked       *)
+(*                    slot): the counterfactual the drain callback and     *)
+(*                    postmaster crash-restart exist to prevent.           *)
+(*   SplitAcquire   - model Acquire and the backend's AttachEnd as two     *)
+(*                    steps with an untracked crash window between them.   *)
+(*                    Expect FAIL (leaked slot) -- the bug class the real  *)
+(*                    code prevents by making acquire+attach+track         *)
+(*                    effectively atomic.                                  *)
+(***************************************************************************)
+EXTENDS Integers, Sequences, FiniteSets
+
+CONSTANTS
+    Backends,          \* backend ids, e.g. {b1, b2, b3}
+    NSlots,            \* session-pool slots, e.g. 2
+    PendingCap,        \* pending-session ring capacity, e.g. 1
+    AllowAbort,        \* abort in IDLE-wait / ACQUIRED / SERVED phases
+    AllowEarlyAbort,   \* abort in PENDING phase (stale ring entry + parked thread)
+    AbortSetsCancel,   \* TRUE: pending-abort also sets the cancel flag (the fix)
+    ValidateGeneration,\* TRUE: TryAttachEnd generation check (the fix)
+    AllowWorkerCrash,  \* hard worker kill, no drain, no shmem reset
+    SplitAcquire       \* break acquire+attach atomicity (the _bug variant)
+
+Slots == 1 .. NSlots
+
+\* Backend phases. "idle" doubles as the pool-full wait (the backend holds
+\* nothing while Acquire keeps returning -1). "acquired" doubles as the
+\* ring-full / worker-missing wait (the backend holds the slot). "pending"
+\* is enqueued-but-handshake-not-sent; "served" is handshake sent + stream
+\* constructed. "aborting" is mid-ReleaseOpenSessions on a pending abort
+\* (cancel flag written, own DetachEnd not yet done). "acquired0" exists
+\* only under SplitAcquire (slot IN_USE, refcount 0, untracked).
+BPhases == {"idle","acquired0","acquired","pending","aborting","served","settled"}
+
+VARIABLES
+    \* --- the session pool (slot array in session_pool.cpp) ---
+    sstate,   \* [Slots -> {"FREE","INUSE"}]      slot state
+    sgen,     \* [Slots -> Nat]                   slot generation
+    att,      \* [Slots -> Int]                   attach refcount
+    \* --- the session channel header per slot ---
+    cancel,   \* [Slots -> BOOLEAN]: the channel cancel flag (reset by OpenSlot)
+    hs,       \* [Slots -> BOOLEAN]: handshake frames (Snapshot+SQL) are in the mq
+    \* --- the worker registry slot for this database ---
+    pending,  \* Seq of [slot, gen]: the pending-session ring (the code stores
+              \* PendingSession {conn_slot, conn_generation})
+    wup,      \* BOOLEAN: the duckdb worker process is alive
+    wgen,     \* Nat: worker incarnation (bumped by respawn)
+    crashes,  \* 0..1: crashes so far (bounds the state space)
+    wwait,    \* [Slots -> Nat]: attached session threads parked in the handshake recv
+    wheld,    \* [Slots -> Nat]: attached session threads past the handshake (running)
+    \* --- per backend ---
+    phase,    \* [Backends -> BPhases]
+    bslot,    \* [Backends -> Slots \cup {0}]: the slot this backend claimed
+    bwgen     \* [Backends -> Nat]: worker incarnation it enqueued under
+
+vars == << sstate, sgen, att, cancel, hs, pending, wup, wgen, crashes,
+           wwait, wheld, phase, bslot, bwgen >>
+
+----------------------------------------------------------------------------
+TypeOK ==
+    /\ sstate \in [Slots -> {"FREE","INUSE"}]
+    /\ sgen \in [Slots -> Nat]
+    /\ att \in [Slots -> Int]
+    /\ cancel \in [Slots -> BOOLEAN]
+    /\ hs \in [Slots -> BOOLEAN]
+    /\ \A i \in DOMAIN pending :
+         /\ pending[i].slot \in Slots
+         /\ pending[i].gen \in Nat
+    /\ wup \in BOOLEAN
+    /\ wgen \in Nat
+    /\ crashes \in 0 .. 1
+    /\ wwait \in [Slots -> Nat]
+    /\ wheld \in [Slots -> Nat]
+    /\ phase \in [Backends -> BPhases]
+    /\ bslot \in [Backends -> Slots \cup {0}]
+    /\ bwgen \in [Backends -> Nat]
+
+Init ==
+    /\ sstate = [s \in Slots |-> "FREE"]
+    /\ sgen = [s \in Slots |-> 0]
+    /\ att = [s \in Slots |-> 0]
+    /\ cancel = [s \in Slots |-> FALSE]
+    /\ hs = [s \in Slots |-> FALSE]
+    /\ pending = << >>
+    /\ wup = TRUE
+    /\ wgen = 0
+    /\ crashes = 0
+    /\ wwait = [s \in Slots |-> 0]
+    /\ wheld = [s \in Slots |-> 0]
+    /\ phase = [b \in Backends |-> "idle"]
+    /\ bslot = [b \in Backends |-> 0]
+    /\ bwgen = [b \in Backends |-> 0]
+
+\* First-fit, like SessionPool::Acquire's linear scan.
+FreeSlots  == { s \in Slots : sstate[s] = "FREE" }
+FirstFree  == CHOOSE s \in FreeSlots : \A t \in FreeSlots : s =< t
+
+\* DetachEnd: decrement; the end that reaches 0 flips the slot to FREE.
+\* (In C++ a fetch_sub whose result would be negative wraps -- NoUnderflow
+\* below is the invariant standing in for that. Modelled as one atomic step;
+\* in the code the decrement itself is outside the pool spinlock.)
+Detach(s) ==
+    /\ att' = [att EXCEPT ![s] = att[s] - 1]
+    /\ sstate' = IF att[s] - 1 = 0 THEN [sstate EXCEPT ![s] = "FREE"] ELSE sstate
+
+----------------------------------------------------------------------------
+(* --- Backend: DuckdbWorker::OpenSession --- *)
+
+\* Acquire + the backend's AttachEnd + channel OpenSlot (which re-inits the
+\* header, resetting the cancel flag) + cleanup tracking, as one atomic step
+\* (see the header note). Acquire bumps the slot generation and clobbers the
+\* refcount (pg_atomic_write_u32(&attached, 0)); the AttachEnd then makes it 1.
+\* When the pool is full this action is simply DISABLED: the backend sits in
+\* OpenSession's cancellable retry loop (no fallback) until a slot frees --
+\* the WF on backend progress below is the retry loop.
+AcquireAttach(b) ==
+    /\ ~SplitAcquire
+    /\ phase[b] = "idle"
+    /\ FreeSlots # {}
+    /\ LET s == FirstFree IN
+         /\ sstate' = [sstate EXCEPT ![s] = "INUSE"]
+         /\ sgen' = [sgen EXCEPT ![s] = sgen[s] + 1]
+         /\ att' = [att EXCEPT ![s] = 1]
+         /\ cancel' = [cancel EXCEPT ![s] = FALSE]
+         /\ hs' = [hs EXCEPT ![s] = FALSE]
+         /\ bslot' = [bslot EXCEPT ![b] = s]
+    /\ phase' = [phase EXCEPT ![b] = "acquired"]
+    /\ UNCHANGED << pending, wup, wgen, crashes, wwait, wheld, bwgen >>
+
+\* --- SplitAcquire (_bug) variant: the two halves as separate steps, with an
+\* --- untracked crash window between them. If the backend dies in that window
+\* --- nothing ever DetachEnds the slot: it stays INUSE/refcount-0 forever.
+AcquireOnly(b) ==
+    /\ SplitAcquire
+    /\ phase[b] = "idle"
+    /\ FreeSlots # {}
+    /\ LET s == FirstFree IN
+         /\ sstate' = [sstate EXCEPT ![s] = "INUSE"]
+         /\ sgen' = [sgen EXCEPT ![s] = sgen[s] + 1]
+         /\ att' = [att EXCEPT ![s] = 0]      \* Acquire resets the refcount
+         /\ cancel' = [cancel EXCEPT ![s] = FALSE]
+         /\ hs' = [hs EXCEPT ![s] = FALSE]
+         /\ bslot' = [bslot EXCEPT ![b] = s]
+    /\ phase' = [phase EXCEPT ![b] = "acquired0"]
+    /\ UNCHANGED << pending, wup, wgen, crashes, wwait, wheld, bwgen >>
+
+BackendAttach(b) ==
+    /\ phase[b] = "acquired0"
+    /\ att' = [att EXCEPT ![bslot[b]] = att[bslot[b]] + 1]
+    /\ phase' = [phase EXCEPT ![b] = "acquired"]
+    /\ UNCHANGED << sstate, sgen, cancel, hs, pending, wup, wgen, crashes,
+                    wwait, wheld, bslot, bwgen >>
+
+\* Backend dies between acquire and attach: the cleanup callback knows nothing
+\* about the slot (g_pending_conn_slot is only set after AttachEnd), so the
+\* slot is orphaned. Adversarial; only reachable under SplitAcquire.
+CrashBetween(b) ==
+    /\ phase[b] = "acquired0"
+    /\ phase' = [phase EXCEPT ![b] = "settled"]
+    /\ UNCHANGED << sstate, sgen, att, cancel, hs, pending, wup, wgen, crashes,
+                    wwait, wheld, bslot, bwgen >>
+
+\* EnqueuePendingSession succeeded: the session is pending on the worker,
+\* tagged with the slot's generation at enqueue time. When the ring is full or
+\* the worker is down this is DISABLED: the backend waits in OpenSession's
+\* enqueue retry loop, holding its slot (a dead worker is respawned by the
+\* same loop -- WorkerRespawn below).
+Enqueue(b) ==
+    /\ phase[b] = "acquired"
+    /\ wup
+    /\ Len(pending) < PendingCap
+    /\ pending' = Append(pending, [slot |-> bslot[b], gen |-> sgen[bslot[b]]])
+    /\ bwgen' = [bwgen EXCEPT ![b] = wgen]
+    /\ phase' = [phase EXCEPT ![b] = "pending"]
+    /\ UNCHANGED << sstate, sgen, att, cancel, hs, wup, wgen, crashes,
+                    wwait, wheld, bslot >>
+
+\* The backend ships the Snapshot and SQL frames and constructs the result
+\* stream (BackendSession); from here the open-stream registry owns the slot.
+\* Independent of the worker's ring drain: the frames just sit in the shm_mq
+\* until the session thread's handshake receive consumes them. (An abort
+\* between the two frame sends is below this model's granularity: the parked
+\* thread's poll observes frame-or-cancel either way.)
+SendHandshake(b) ==
+    /\ phase[b] = "pending"
+    /\ hs' = [hs EXCEPT ![bslot[b]] = TRUE]
+    /\ phase' = [phase EXCEPT ![b] = "served"]
+    /\ UNCHANGED << sstate, sgen, att, cancel, pending, wup, wgen, crashes,
+                    wwait, wheld, bslot, bwgen >>
+
+----------------------------------------------------------------------------
+(* --- Worker: main loop drain + SessionThreadMain --- *)
+
+\* Drain one pending entry and spawn its session thread. The thread calls
+\* TryAttachEnd(slot, gen): attach only if the slot is still IN_USE at the
+\* enqueued generation; a stale entry (its backend released the slot, or the
+\* slot was re-acquired -- Acquire bumped the generation) is skipped and the
+\* thread exits without touching the channel. ValidateGeneration = FALSE
+\* models the pre-fix unconditional AttachEnd. An attached thread parks in
+\* the handshake receive (wwait) until HandshakeOk / HandshakeCancelled.
+WorkerServe ==
+    /\ wup
+    /\ pending # << >>
+    /\ LET e == Head(pending)
+           matched == sstate[e.slot] = "INUSE" /\ sgen[e.slot] = e.gen
+       IN
+         /\ pending' = Tail(pending)
+         /\ IF ValidateGeneration /\ ~matched
+              THEN \* TryAttachEnd rejects the stale entry: skip.
+                   UNCHANGED << att, wwait >>
+              ELSE /\ wwait' = [wwait EXCEPT ![e.slot] = wwait[e.slot] + 1]
+                   /\ att' = [att EXCEPT ![e.slot] = att[e.slot] + 1]
+    /\ UNCHANGED << sstate, sgen, cancel, hs, wup, wgen, crashes, wheld,
+                    phase, bslot, bwgen >>
+
+\* The handshake receive (SerializedRecvControl polled in RunOneSession) sees
+\* the Snapshot frame: the thread proceeds to run the session.
+HandshakeOk ==
+    /\ wup
+    /\ \E s \in Slots :
+         /\ wwait[s] > 0
+         /\ hs[s]
+         /\ wwait' = [wwait EXCEPT ![s] = wwait[s] - 1]
+         /\ wheld' = [wheld EXCEPT ![s] = wheld[s] + 1]
+    /\ UNCHANGED << sstate, sgen, att, cancel, hs, pending, wup, wgen, crashes,
+                    phase, bslot, bwgen >>
+
+\* The handshake receive sees the channel cancel flag instead
+\* (SerializedRecvControl returns Detached): the thread detaches without ever
+\* running -- this is what frees the slot when the backend aborted mid-
+\* handshake. Only reachable when the abort path SET the flag
+\* (AbortSetsCancel); without it the parked thread has no exit.
+HandshakeCancelled ==
+    /\ wup
+    /\ \E s \in Slots :
+         /\ wwait[s] > 0
+         /\ cancel[s]
+         /\ wwait' = [wwait EXCEPT ![s] = wwait[s] - 1]
+         /\ Detach(s)
+    /\ UNCHANGED << sgen, cancel, hs, pending, wup, wgen, crashes, wheld,
+                    phase, bslot, bwgen >>
+
+\* A running session thread finishes (query complete, error, cancel, or peer
+\* detach) and DetachEnds its end.
+SessionFinish ==
+    /\ wup
+    /\ \E s \in Slots :
+         /\ wheld[s] > 0
+         /\ wheld' = [wheld EXCEPT ![s] = wheld[s] - 1]
+         /\ Detach(s)
+    /\ UNCHANGED << sgen, cancel, hs, pending, wup, wgen, crashes, wwait,
+                    phase, bslot, bwgen >>
+
+\* Counterfactual hard kill (see header): session threads vanish WITHOUT
+\* DetachEnd -- their refcounts stay behind -- and no shmem reset follows.
+\* (An ERROR/FATAL exit instead runs the worker's before_shmem_exit drain:
+\* every session thread is joined and DetachEnds, i.e. ordinary SessionFinish
+\* steps before the process goes away.)
+WorkerCrash ==
+    /\ AllowWorkerCrash
+    /\ crashes < 1
+    /\ wup
+    /\ wup' = FALSE
+    /\ crashes' = crashes + 1
+    /\ wwait' = [s \in Slots |-> 0]
+    /\ wheld' = [s \in Slots |-> 0]
+    /\ UNCHANGED << sstate, sgen, att, cancel, hs, pending, wgen, phase, bslot, bwgen >>
+
+\* EnsureWorkerForMyDatabase's pid probe reclaims the dead worker's REGISTRY
+\* slot and respawns it: the new worker starts with an empty pending ring
+\* (pending_head = pending_tail = 0). Session-pool refcounts are untouched.
+\* Any dispatching backend drives this -- OpenSession calls EnsureWorker at
+\* the top, and the enqueue retry loop calls it whenever the registry slot is
+\* gone -- so it gets weak fairness below.
+WorkerRespawn ==
+    /\ ~wup
+    /\ wup' = TRUE
+    /\ wgen' = wgen + 1
+    /\ pending' = << >>
+    /\ UNCHANGED << sstate, sgen, att, cancel, hs, crashes, wwait, wheld,
+                    phase, bslot, bwgen >>
+
+----------------------------------------------------------------------------
+(* --- Backend: session end and aborts --- *)
+
+\* Normal end (BackendSession destructor after Complete/Error) or an abort
+\* while streaming: either way ReleaseOpenSessions detaches the backend's end.
+\* (The destructor also sets the cancel flag when the query had not finished;
+\* a thread still parked in the handshake can equally proceed via the already-
+\* sent frames -- hs is TRUE in "served" -- so the flag write is omitted here
+\* to keep the state space small.)
+BackendFinish(b) ==
+    /\ phase[b] = "served"
+    /\ Detach(bslot[b])
+    /\ phase' = [phase EXCEPT ![b] = "settled"]
+    /\ UNCHANGED << sgen, cancel, hs, pending, wup, wgen, crashes, wwait, wheld,
+                    bslot, bwgen >>
+
+\* Abort during the pool-full wait (cancel / statement_timeout inside the
+\* Acquire retry loop): nothing is held yet, nothing to release.
+AbortIdle(b) ==
+    /\ AllowAbort
+    /\ phase[b] = "idle"
+    /\ phase' = [phase EXCEPT ![b] = "settled"]
+    /\ UNCHANGED << sstate, sgen, att, cancel, hs, pending, wup, wgen, crashes,
+                    wwait, wheld, bslot, bwgen >>
+
+\* Abort after acquiring but before the enqueue lands -- including a cancel
+\* inside the enqueue retry loop while the ring is full or the worker is
+\* down: the g_pending_conn_slot branch of ReleaseOpenSessions covers the
+\* slot -- RequestCancelAt (if AbortSetsCancel) then DetachEnd. No ring entry
+\* and no session thread exist yet, so nothing can observe the ordering:
+\* modelled as one atomic step.
+AbortAcquired(b) ==
+    /\ AllowAbort
+    /\ phase[b] = "acquired"
+    /\ cancel' = IF AbortSetsCancel THEN [cancel EXCEPT ![bslot[b]] = TRUE] ELSE cancel
+    /\ Detach(bslot[b])
+    /\ phase' = [phase EXCEPT ![b] = "settled"]
+    /\ UNCHANGED << sgen, hs, pending, wup, wgen, crashes, wwait, wheld,
+                    bslot, bwgen >>
+
+\* Abort (or backend FATAL exit) while the session is PENDING: the ring entry
+\* stays (stale; the generation check must reject it) and a session thread
+\* may ALREADY be attached and parked in the handshake receive. The cleanup
+\* path is two steps, modelled separately because the parked thread races
+\* with them: FIRST the cancel-flag write (RequestCancelAt -- skipped when
+\* AbortSetsCancel = FALSE, the pre-fix code)...
+EarlyAbortCancel(b) ==
+    /\ AllowEarlyAbort
+    /\ phase[b] = "pending"
+    /\ cancel' = IF AbortSetsCancel THEN [cancel EXCEPT ![bslot[b]] = TRUE] ELSE cancel
+    /\ phase' = [phase EXCEPT ![b] = "aborting"]
+    /\ UNCHANGED << sstate, sgen, att, hs, pending, wup, wgen, crashes,
+                    wwait, wheld, bslot, bwgen >>
+
+\* ...THEN the backend's own DetachEnd. Straight-line code inside the cleanup
+\* callback, so it is a fair progress step once "aborting".
+EarlyAbortDetach(b) ==
+    /\ phase[b] = "aborting"
+    /\ Detach(bslot[b])
+    /\ phase' = [phase EXCEPT ![b] = "settled"]
+    /\ UNCHANGED << sgen, cancel, hs, pending, wup, wgen, crashes, wwait, wheld,
+                    bslot, bwgen >>
+
+\* The backend's fetch loop probes the worker pid (PidIsAlive in Fetch) or its
+\* enqueue was lost to a respawn: give up, destructor DetachEnds. Models the
+\* "duckdb worker terminated unexpectedly" error path.
+DetectDeath(b) ==
+    /\ phase[b] \in {"pending","served"}
+    /\ (~wup \/ bwgen[b] # wgen)
+    /\ Detach(bslot[b])
+    /\ phase' = [phase EXCEPT ![b] = "settled"]
+    /\ UNCHANGED << sgen, cancel, hs, pending, wup, wgen, crashes, wwait, wheld,
+                    bslot, bwgen >>
+
+----------------------------------------------------------------------------
+(* --- Terminal / stutter --- *)
+
+AllSettled == \A b \in Backends : phase[b] = "settled"
+
+Quiescent ==
+    /\ AllSettled
+    /\ \A s \in Slots : sstate[s] = "FREE" /\ att[s] = 0 /\ wwait[s] = 0 /\ wheld[s] = 0
+    /\ pending = << >>
+
+Terminating == Quiescent /\ UNCHANGED vars
+
+BackendProgress(b) ==
+    \/ AcquireAttach(b)
+    \/ AcquireOnly(b) \/ BackendAttach(b)
+    \/ Enqueue(b)
+    \/ SendHandshake(b)
+    \/ EarlyAbortDetach(b)
+    \/ BackendFinish(b) \/ DetectDeath(b)
+
+WorkerProgress == WorkerServe \/ HandshakeOk \/ HandshakeCancelled \/ SessionFinish
+
+Next ==
+    \/ \E b \in Backends : BackendProgress(b)
+    \/ WorkerProgress
+    \/ WorkerRespawn
+    \/ \E b \in Backends : AbortIdle(b) \/ AbortAcquired(b) \/ EarlyAbortCancel(b)
+                           \/ CrashBetween(b)
+    \/ WorkerCrash
+    \/ Terminating
+
+\* Fairness on progress only; aborts and crashes are adversarial (never
+\* forced), but once an abort STARTED (EarlyAbortCancel) its DetachEnd is
+\* straight-line cleanup code and therefore fair. WorkerRespawn is fair
+\* because dispatching backends actively call EnsureWorkerForMyDatabase in
+\* their retry loops whenever the worker is down. The capacity waits need no
+\* extra machinery: a waiting backend's acquire / enqueue action becomes
+\* continuously enabled once the finitely many other sessions complete, and
+\* WF then forces it -- the model's retry loop. The handshake poll (a parked
+\* thread checking frame-or-cancel every iteration) is WF on HandshakeOk /
+\* HandshakeCancelled inside WorkerProgress.
+Fairness ==
+    /\ \A b \in Backends : WF_vars(BackendProgress(b))
+    /\ WF_vars(WorkerProgress)
+    /\ WF_vars(WorkerRespawn)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------
+(* --- Safety --- *)
+
+\* The refcount never underflows (a DetachEnd without a matching AttachEnd
+\* would wrap the C++ uint32 and strand the slot forever).
+NoUnderflow == \A s \in Slots : att[s] >= 0
+
+\* At most two ends ever attach: the backend's and the worker session's.
+RefcountBounded == \A s \in Slots : att[s] =< 2
+
+\* No double-free / no stale attach: a FREE slot has no attached ends. This is
+\* what breaks when the worker attaches a stale pending entry for a slot its
+\* enqueuer already released (ValidateGeneration = FALSE).
+FreeImpliesUnattached ==
+    \A s \in Slots : sstate[s] = "FREE" => (att[s] = 0 /\ wwait[s] = 0 /\ wheld[s] = 0)
+
+\* One backend per slot: two live backends never hold the same slot.
+Holding(b) == phase[b] \in {"acquired0","acquired","pending","aborting","served"}
+SingleBackendPerSlot ==
+    \A b1, b2 \in Backends :
+        (Holding(b1) /\ Holding(b2) /\ bslot[b1] = bslot[b2]) => b1 = b2
+
+----------------------------------------------------------------------------
+(* --- Liveness --- *)
+
+\* No slot leak: the pool always eventually returns (and stays) fully FREE.
+\* This is what breaks when a pending abort skips the cancel-flag write
+\* (AbortSetsCancel = FALSE): the parked handshake thread never detaches.
+NoSlotLeak == <>[](\A s \in Slots : sstate[s] = "FREE")
+
+\* No lost session, no starved wait: every backend -- including one that had
+\* to wait for pool or ring capacity -- is eventually served to completion or
+\* settles cleanly (abort / worker-death error).
+SessionSettles == \A b \in Backends : <>(phase[b] = "settled")
+
+Liveness == <>Quiescent
+=============================================================================

--- a/specs/tla/ControlProtocol_bug.cfg
+++ b/specs/tla/ControlProtocol_bug.cfg
@@ -1,0 +1,36 @@
+\* NEGATIVE config -- the bug class the implemented design PREVENTS.
+\* SplitAcquire models SessionPool::Acquire and the backend's AttachEnd as
+\* two separate steps with an untracked crash window between them: if the
+\* backend dies in that window, the cleanup callback knows nothing about the
+\* slot (g_pending_conn_slot is only set after AttachEnd), so nothing ever
+\* DetachEnds it -- the slot stays INUSE with refcount 0 forever.
+\* Expect FAIL: TLC reports a DEADLOCK at the leaked terminal state (slot
+\* INUSE, refcount 0, all backends settled) -- equivalently NoSlotLeak /
+\* Liveness are violated.
+\* The real code avoids this window: nothing fallible or interruptible sits
+\* between Acquire and AttachEnd in DuckdbWorker::OpenSession (even the snapshot
+\* palloc is done before Acquire), and the slot is tracked for cleanup
+\* (g_pending_conn_slot, then the open-stream registry) from the moment the
+\* attach exists. ControlProtocol.cfg checks that atomic version passes.
+SPECIFICATION Spec
+
+CONSTANTS
+    Backends = {b1, b2}
+    NSlots = 2
+    PendingCap = 1
+    AllowAbort = FALSE
+    AllowEarlyAbort = FALSE
+    AbortSetsCancel = TRUE
+    ValidateGeneration = TRUE
+    AllowWorkerCrash = FALSE
+    SplitAcquire = TRUE
+
+INVARIANT TypeOK
+INVARIANT NoUnderflow
+INVARIANT RefcountBounded
+INVARIANT FreeImpliesUnattached
+INVARIANT SingleBackendPerSlot
+
+PROPERTY NoSlotLeak
+PROPERTY SessionSettles
+PROPERTY Liveness

--- a/specs/tla/ControlProtocol_handshake_bug.cfg
+++ b/specs/tla/ControlProtocol_handshake_bug.cfg
@@ -1,0 +1,39 @@
+\* NEGATIVE config -- the pre-fix abort-during-handshake wedge (C1).
+\* AbortSetsCancel = FALSE models the old ReleaseOpenSessions pending-slot
+\* branch, which only DetachEnd-ed the backend's refcount. The race: the
+\* backend enqueues its session and the worker's session thread attaches
+\* (TryAttachEnd succeeds -- the slot is IN_USE at the right generation) and
+\* parks in the handshake receive; the backend then aborts BEFORE sending the
+\* Snapshot/SQL frames. The abort releases only the backend's refcount; the
+\* parked thread polls for a frame that will never arrive and never observes
+\* a cancel (the flag was never set), so its refcount pins the slot IN_USE
+\* forever -- the wedged-thread slot leak.
+\* Expect FAIL: TLC reports a DEADLOCK at the leaked terminal state (all
+\* backends settled, one slot INUSE with refcount 1 and a thread parked in
+\* wwait, nothing enabled) -- equivalently NoSlotLeak / Liveness are violated.
+\* The fix (checked by ControlProtocol.cfg with the same adversary): the abort
+\* path ALSO calls SessionChannel::RequestCancelAt before DetachEnd; the
+\* handshake poll (SerializedRecvControl) observes the flag, returns Detached,
+\* and the thread detaches -- HandshakeCancelled in the model.
+SPECIFICATION Spec
+
+CONSTANTS
+    Backends = {b1, b2}
+    NSlots = 2
+    PendingCap = 1
+    AllowAbort = FALSE
+    AllowEarlyAbort = TRUE
+    AbortSetsCancel = FALSE
+    ValidateGeneration = TRUE
+    AllowWorkerCrash = FALSE
+    SplitAcquire = FALSE
+
+INVARIANT TypeOK
+INVARIANT NoUnderflow
+INVARIANT RefcountBounded
+INVARIANT FreeImpliesUnattached
+INVARIANT SingleBackendPerSlot
+
+PROPERTY NoSlotLeak
+PROPERTY SessionSettles
+PROPERTY Liveness

--- a/specs/tla/ControlProtocol_staleentry_bug.cfg
+++ b/specs/tla/ControlProtocol_staleentry_bug.cfg
@@ -1,0 +1,42 @@
+\* NEGATIVE config -- the pre-fix stale-pending-entry race (found by this
+\* model, then FIXED in the code with slot generations + TryAttachEnd).
+\* ValidateGeneration = FALSE models the old SessionThreadMain, which attached
+\* the enqueued slot index unconditionally. A backend that aborts (or
+\* FATAL-exits) while its session is still PENDING releases the slot (refcount
+\* 0 -> FREE) but its ring entry stays; when the worker drains the stale entry:
+\*   - if the slot is still FREE, a FREE slot gains an attached end
+\*     (FreeImpliesUnattached violated); the thread's later DetachEnd can then
+\*     underflow the refcount if another backend re-acquired in between
+\*     (Acquire resets the refcount to 0);
+\*   - if another backend already re-acquired it, the worker attaches to the
+\*     NEW backend's session via the STALE entry, and the new backend's own
+\*     entry attaches a second thread (refcount reaches 3, RefcountBounded
+\*     violated).
+\* Expect FAIL: TLC reports FreeImpliesUnattached (or RefcountBounded)
+\* violated, with the stale-entry trace. The fixed code tags every pending
+\* entry with the slot generation Acquire bumped and the worker attaches via
+\* SessionPool::TryAttachEnd, which rejects a slot that is FREE or at a
+\* different generation -- ControlProtocol.cfg checks that version passes with
+\* the same early-abort adversary.
+SPECIFICATION Spec
+
+CONSTANTS
+    Backends = {b1, b2}
+    NSlots = 2
+    PendingCap = 2
+    AllowAbort = TRUE
+    AllowEarlyAbort = TRUE
+    AbortSetsCancel = TRUE
+    ValidateGeneration = FALSE
+    AllowWorkerCrash = FALSE
+    SplitAcquire = FALSE
+
+INVARIANT TypeOK
+INVARIANT NoUnderflow
+INVARIANT RefcountBounded
+INVARIANT FreeImpliesUnattached
+INVARIANT SingleBackendPerSlot
+
+PROPERTY NoSlotLeak
+PROPERTY SessionSettles
+PROPERTY Liveness

--- a/specs/tla/ControlProtocol_workercrash.cfg
+++ b/specs/tla/ControlProtocol_workercrash.cfg
@@ -1,0 +1,44 @@
+\* NEGATIVE config -- the counterfactual that shows why the worker's
+\* before_shmem_exit session drain (and the postmaster's crash-restart) matter.
+\* AllowWorkerCrash models a HARD worker kill: session threads vanish without
+\* DetachEnd and no shared-memory reset follows. A slot whose worker end was
+\* attached at kill time keeps refcount 1 after the backend detects the death
+\* and detaches its own end: the slot stays INUSE forever.
+\* EnsureWorkerForMyDatabase's pid probe reclaims only the worker REGISTRY slot
+\* (so the worker respawns with an empty pending ring); it does not repair
+\* session-pool refcounts.
+\* Expect FAIL: TLC reports a DEADLOCK at the leaked terminal state (all
+\* backends settled, one slot INUSE with refcount 1, nothing enabled) --
+\* equivalently NoSlotLeak / Liveness are violated.
+\* What the real code covers:
+\*   - ERROR/FATAL worker exits run the before_shmem_exit callback, which sets
+\*     the draining flag and joins every session thread (each DetachEnds) --
+\*     those exits are CLEAN and correspond to ordinary SessionFinish steps in
+\*     the passing ControlProtocol.cfg, not to this config's WorkerCrash.
+\*   - SIGKILL / segfault skip the callback, but the postmaster then
+\*     crash-restarts the cluster and reinitializes shared memory, so the
+\*     stranded refcounts do not persist.
+\* The modelled leak is exactly the state that would persist if NEITHER
+\* mechanism existed.
+SPECIFICATION Spec
+
+CONSTANTS
+    Backends = {b1, b2}
+    NSlots = 2
+    PendingCap = 1
+    AllowAbort = FALSE
+    AllowEarlyAbort = FALSE
+    AbortSetsCancel = TRUE
+    ValidateGeneration = TRUE
+    AllowWorkerCrash = TRUE
+    SplitAcquire = FALSE
+
+INVARIANT TypeOK
+INVARIANT NoUnderflow
+INVARIANT RefcountBounded
+INVARIANT FreeImpliesUnattached
+INVARIANT SingleBackendPerSlot
+
+PROPERTY NoSlotLeak
+PROPERTY SessionSettles
+PROPERTY Liveness

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -1,0 +1,351 @@
+# TLA+ models of the shared DuckDB duckdb worker
+
+Formal models of the three concurrency cores of the shared per-database DuckDB
+duckdb worker (design: `libpgduckdb/worker/DESIGN.md`, vocabulary:
+`libpgduckdb/worker/GLOSSARY.md`). Each TLA+ action is commented with the C++
+operation it stands for. Constants are kept small so every check finishes in
+seconds.
+
+## Run
+
+```sh
+JAR=<path>/tla2tools.jar   # e.g. the VS Code/Cursor TLA+ extension's tools/tla2tools.jar
+cd specs/tla
+java -XX:+UseParallelGC -cp "$JAR" tlc2.TLC -config <cfg> -workers auto <spec>.tla
+```
+
+Expected-PASS configs report "No error has been found"; the negative configs
+fail exactly as described below.
+
+---
+
+# ControlProtocol.tla: session-pool session lifecycle
+
+Models the lifecycle by which a backend gets a session onto the worker and
+the session slot is returned (`DuckdbWorker::OpenSession` / the worker main
+loop / `SessionThreadMain` in `libpgduckdb/worker/duckdb_worker.cpp`, refcounts
+in `libpgduckdb/worker/transport/session_pool.cpp`): slot Acquire (which
+bumps the slot generation) + the backend's AttachEnd + channel OpenSlot (which
+resets the header cancel flag), the pending-session ring enqueue of
+`{slot, generation}`, the backend's HANDSHAKE send (Snapshot + SQL frames,
+after which the result stream exists), the worker draining the ring and a
+session thread attaching via `TryAttachEnd(idx, generation)` (stale entries
+are skipped) and then PARKING in the handshake receive, both ends
+DetachEnd-ing, and the detach that reaches refcount 0 freeing the slot.
+
+The handshake receive is modelled as it is coded (`SerializedRecvControl` in
+`RunOneSession`): a nowait-recv poll that observes EITHER a received frame
+(`HandshakeOk`) OR the channel cancel flag / worker drain
+(`HandshakeCancelled`, on which the thread detaches without running). The
+backend's abort-while-pending cleanup is correspondingly split into its two
+real steps (`ReleaseOpenSessions`, pending-slot branch): FIRST
+`SessionChannel::RequestCancelAt` sets the cancel flag, THEN `DetachEnd`
+releases the backend's own refcount. The `AbortSetsCancel` constant drops the
+first step to reproduce the pre-fix wedge (C1): a session thread already
+parked in the handshake then polls a frame that never arrives, observes no
+cancel, and its refcount pins the slot IN_USE forever.
+
+Capacity never falls back to in-process execution: `OpenSession` WAITS. A full
+pool means the backend retries `Acquire` in a cancellable loop (interrupt
+check + 10ms latch wait) until a slot frees; a full pending ring or a missing
+worker at enqueue time means the backend retries the enqueue, respawning a
+dead worker via `EnsureWorkerForMyDatabase` first. In the model a waiting
+backend simply has no enabled transition until capacity appears (weak fairness
+on its acquire/enqueue actions is the retry loop); in-process execution exists
+only for statements the dispatch gate excludes semantically, outside this
+model. Failure surface: backend abort in every phase (the xact-abort /
+shmem-exit cleanup callbacks) -- during the pool-full wait (nothing held yet),
+during the ring-full wait (the claimed slot is released), and while pending
+(the two-step cancel+detach above, racing an already-attached thread) -- plus
+worker crash + registry reclaim/respawn (the pid probe in
+`EnsureWorkerForMyDatabase`).
+
+The data plane is modelled separately in ScanInversion.tla.
+
+## What it checks
+
+- `NoUnderflow` / `RefcountBounded` (safety): the attach refcount stays in
+  0..2 -- no DetachEnd without a matching attach (which would wrap the C++
+  uint32), at most the two legitimate ends.
+- `FreeImpliesUnattached` (safety): a FREE slot has no attached ends --
+  neither running (`wheld`) nor parked in the handshake (`wwait`) -- no
+  double-free, no attach to a slot that was already returned.
+- `SingleBackendPerSlot` (safety): two live backends never hold one slot.
+- `NoSlotLeak` (liveness): the pool eventually returns (and stays) fully FREE
+  -- including a slot whose session thread was parked in the handshake when
+  its backend aborted (the C1 fix is load-bearing here).
+- `SessionSettles` (liveness): every backend -- including one waiting out a
+  full pool or a full pending ring -- is eventually served to completion or
+  settles cleanly (abort, worker-death error). No starved wait, no backend
+  blocked forever, no enqueued session silently lost.
+
+## Configs
+
+- `ControlProtocol.cfg` -- the real protocol: 3 backends, 2 slots, pending ring
+  of 1, so both capacity WAITS are exercised (one backend waits for a free
+  slot, one waits holding its slot for the ring to drain); aborts allowed in
+  EVERY backend phase including during either wait and while PENDING (the
+  stale ring entry the generation check must reject, plus the parked-thread
+  race the cancel flag must resolve), `AbortSetsCancel = TRUE`,
+  `ValidateGeneration = TRUE`, no worker crash. **PASS** -- including
+  `SessionSettles`/`Liveness`, i.e. the waits cannot starve and the handshake
+  cannot wedge. Last run: 19,994 states generated, 6,335 distinct, no error.
+- `ControlProtocol_handshake_bug.cfg` -- the pre-fix abort-during-handshake
+  wedge (C1). `AbortSetsCancel = FALSE`: the old pending-abort path only
+  DetachEnd-ed. A session thread attaches (valid entry, right generation) and
+  parks in the handshake receive; the backend aborts before sending the
+  Snapshot/SQL frames; the parked thread never sees a frame and never sees a
+  cancel, so its refcount pins the slot. **FAILS: deadlock at the
+  wedged-thread state** (all backends settled, one slot INUSE at refcount 1
+  with a thread parked in `wwait`) -- equivalently `NoSlotLeak`/`Liveness`.
+  The fix (`RequestCancelAt` before `DetachEnd` in `ReleaseOpenSessions`;
+  the handshake poll returns Detached on cancel) is what the passing main
+  config exercises under the same adversary.
+  Last run: deadlock trace found (trace length and state counts at detection
+  vary with -workers).
+- `ControlProtocol_staleentry_bug.cfg` -- the pre-fix stale-entry race
+  (`ValidateGeneration = FALSE`: the old `SessionThreadMain` attached the
+  enqueued slot index unconditionally). A backend abort while PENDING frees
+  the slot but leaves its ring entry; serving it attaches a FREE or
+  re-acquired slot. **FAILS `FreeImpliesUnattached`** (other interleavings
+  reach refcount 3 or an underflow). This race was found by this model and is
+  now FIXED in the code with slot generations + `TryAttachEnd` -- the passing
+  main config checks the fix under the same adversary.
+  Last run: violation found at depth 6 (state counts at detection vary with
+  -workers).
+- `ControlProtocol_workercrash.cfg` -- counterfactual HARD worker kill: session
+  threads (parked or running) vanish without DetachEnd and no shmem reset
+  follows, so a slot whose worker end was attached at kill time keeps
+  refcount 1 forever. **FAILS: deadlock at the leaked terminal state**
+  (equivalently `NoSlotLeak`/`Liveness`). What the real code covers:
+  ERROR/FATAL worker exits run a `before_shmem_exit` drain that joins every
+  session thread (each DetachEnds) -- those are ordinary `SessionFinish`
+  steps in the passing config; SIGKILL/segfault skip the callback but trigger
+  a postmaster crash-restart that reinitializes shared memory. The modeled
+  leak is the state that would persist if neither mechanism existed -- i.e.
+  why the drain matters. Kill *before* the worker attached is handled cleanly
+  either way (backend pid-probes and detaches to 0).
+  Last run: deadlock trace found (state counts at detection vary with
+  -workers).
+- `ControlProtocol_bug.cfg` -- the bug class the implemented design prevents:
+  Acquire and the backend's AttachEnd as two steps with an untracked crash
+  window between them. **FAILS: deadlock at a leaked slot** (INUSE, refcount
+  0, nobody will ever detach it). The real code closes the window by putting
+  nothing fallible between Acquire and AttachEnd (the snapshot palloc happens
+  before Acquire) and tracking the slot for cleanup from the attach onward
+  (`g_pending_session_slot`, then the open-stream registry).
+  Last run: deadlock trace found (state counts at detection vary with
+  -workers).
+
+---
+
+# ScanInversion.tla: scan read-ahead + channel demux
+
+Models the scan-inversion sub-protocol *and the channel demux*:
+`InversionScanStream::Next` (worker consumer, `worker/scan_producer.cpp`)
+talking to `BackendSession::ServiceScanFetch`/`SendScanReply` (backend
+producer, `worker/duckdb_worker.cpp`) over the session channel, with replies
+routed by `SessionChannel::RoutedRecv` (`worker/transport/session_channel.cpp`).
+Every scan reply carries a uint32 scan_id prefix and is demultiplexed into a
+per-scan lane; metadata replies go to the single meta lane. This lifted the
+old constraint that two scans on one channel were only safe if DuckDB drove
+them sequentially: the model checks two scans running CONCURRENTLY, plus
+an interleaved metadata round-trip (`MetadataRoundTrip` in
+`session_protocol.cpp`, serialized per channel by `MetaRequestMutex`).
+
+Teardown is modelled as it is coded: the destructor drains outstanding
+fetches, but the drain can BAIL (Detached on backend cancel / worker drain),
+so `CloseScanLane` can run with replies still on the wire. The close
+TOMBSTONES the scan_id (`closed_scans`, the C2a fix) -- `WorkerCloseLane`
+moves the stream to a terminal "closed" state -- and `RoutedRecv` DROPS a
+late reply for a tombstoned scan, freeing its Arrow page, instead of
+re-creating ("resurrecting") the lane and pinning the page forever. The
+`DropLateReplies` constant reverts to the pre-fix resurrection.
+(`~SessionChannel` also frees pages of frames still buffered in live lanes;
+channel teardown is below this model's granularity -- the close covers it.)
+
+## What it checks
+
+- `WindowBounded` / `RequestsBounded` (safety): at most W (WINDOW) fetches
+  outstanding per scan; the result FIFO holds at most W per scan + 1 meta
+  request.
+- `FIFOMatching` (safety): each scan consumes exactly the 0,1,2,... prefix of
+  its own produced chunks -- no reorder, loss, duplication, or cross-scan
+  mis-route. The demux guarantees this for concurrent scans; `RouteByScanId =
+  FALSE` shows it breaking without the demux.
+- `MetaLaneClean` (safety): routing never puts a scan reply on the meta lane
+  or vice versa.
+- `ClosedLaneEmpty` (safety): a closed lane stays empty -- a late reply is
+  dropped (page freed), never resurrects the lane. This is the C2a tombstone;
+  `DropLateReplies = FALSE` shows it breaking.
+- `PageConservation` + the `Quiescent` terminal (safety + liveness): every
+  Arrow page handed out is released -- by the import, by `DrainOutstanding`,
+  by `CloseScanLane` freeing routed-but-unconsumed frames, or by the
+  tombstone dropping a late reply.
+- `TerminalStableInv` / `TerminalStable` (safety): a finished/errored backend
+  scan is kept, not re-opened; extra windowed fetches get the same terminal.
+- `Termination` (liveness): the protocol always reaches the clean terminal
+  (every scan's lane closed, FIFOs drained, lanes empty, pages reclaimed, no
+  metadata round-trip stuck).
+
+## Configs
+
+- `ScanInversion.cfg` -- one scan, W=2, 2 chunks + ScanDone, Arrow on (1 pool
+  page, so fast path and inline fallback both occur), early teardown allowed,
+  `DropLateReplies = TRUE` -- includes closes with fetches outstanding, whose
+  late replies the tombstone drops. **PASS.**
+  Last run: 262 states generated, 139 distinct, no error.
+- `ScanInversion_twoscan.cfg` -- two scans CONCURRENT on one channel (a join's
+  two inputs; no sequencing assumption) plus one metadata round-trip
+  interleaving (a DuckLake GetFilesForTable from a scheduler thread), Arrow +
+  teardown on. Replaces the old `ScanInversion_twoscan_seq.cfg`, whose
+  "sequential drive" assumption the demux made unnecessary. **PASS.**
+  Last run: 493,137 states generated, 136,692 distinct, no error (~10 s).
+- `ScanInversion_noroute_bug.cfg` -- the pre-demux bug class (`RouteByScanId =
+  FALSE`): a scan consumes the wire head no matter which scan it was intended
+  for. Replaces the old `ScanInversion_alias.cfg`. **FAILS `FIFOMatching`**
+  with a cross-scan mis-routing trace -- exactly what the scan_id prefix +
+  demux lanes prevent. Last run: violation found at depth 10 (state counts at
+  detection vary with -workers).
+- `ScanInversion_lateclose_bug.cfg` -- the pre-fix late-reply resurrection
+  (C2a): `DropLateReplies = FALSE`. A chunk carrying a pool page is still on
+  the wire when the torn-down scan's drain bails and `CloseScanLane` runs;
+  routing the late reply re-creates the closed lane, where nothing will ever
+  consume it -- the page is pinned forever. **FAILS `ClosedLaneEmpty`** (the
+  resurrected lane; `Termination` would equally flag the never-freed page).
+  Last run: violation found at depth 10 (state counts at detection vary with
+  -workers).
+
+---
+
+# ScanPool.tla: shared scan-producer pool
+
+Models the page lifecycle and the producer/consumer/teardown protocol for one
+pool scan: scan workers (`ProcessScanRange` in `worker/scan_producer.cpp`,
+spawned by `DuckdbWorker::ScanWorkerMain` in `worker/duckdb_worker.cpp`) produce
+Arrow pages into the scan's ready-ring (`worker/transport/scan_ring.cpp`,
+pages from `worker/transport/page_pool.cpp`); the worker's consumer
+(`PoolScanStream::Next`) drains it via `ScanRing::TryNext` and
+`ScanRing::Close` reclaims queued pages on teardown.
+
+Producer failure comes in two modelled flavours matching the code:
+
+- `ProducerError` -- a PG ERROR inside `ProcessScanRange`; the PG_TRY there
+  releases the held page and calls `ScanRing::SetError`. Always reported.
+- `ProducerFatal` -- the scan-worker PROCESS dies (elog FATAL, SIGTERM
+  mid-task). FATAL skips PG_CATCH but runs shmem-exit callbacks: the
+  `before_shmem_exit` hook in `ScanWorkerMain` errors out the active range
+  (`g_active_range` -> `SetError`). The `FatalReportsError` constant toggles
+  the hook; FALSE is the pre-fix silent death and the consumer hang.
+
+Cancellation / worker drain is a separate signal (`stopReq`): scan workers do
+not poll the session cancel flag, and on a worker drain a QUEUED task may
+never be claimed (`StopExit`: no TaskDone, no error). The fixed consumer polls
+`IsCancelRequested() || IsWorkerDraining()` in its nothing-ready branch
+(`AbortOnCancel`) and errors out, closing the ring; the `ObserveCancel`
+constant toggles the poll -- FALSE is the pre-fix consumer that spins forever
+on a ring nobody will fill.
+
+(A FATAL while a producer holds a pool page additionally leaks that page --
+no callback releases producer-held pages; `ProducerFatal` is modelled between
+pages, and the leak is a separate known gap outside this model.)
+
+## What it checks
+
+- `PageConservation` (safety): the four page locations -- free stack, held by a
+  producer, queued in the ready-ring, in-flight in the consumer -- always
+  partition the pool. Catches page leaks and double-free.
+- `RingBounded` (safety): the ready-ring never exceeds its capacity.
+- `Termination` (liveness): the scan always reaches a quiescent terminal --
+  consumer finished or aborted, every producer stopped, every page back on the
+  free stack -- under errors, FATAL deaths, and cancellation with tasks still
+  outstanding.
+
+## Configs
+
+- `ScanPool.cfg` -- the fixed protocol under the full failure adversary:
+  PG ERRORs (reported via PG_TRY), FATAL deaths (reported via the shmem-exit
+  hook, `FatalReportsError = TRUE`), stop requests with abandoned tasks
+  (observed by the consumer poll, `ObserveCancel = TRUE`), no external
+  rescue. **PASS.** Last run: 3,905 states generated, 1,071 distinct.
+- `ScanPool_bug.cfg` -- pre-fix silent producer death: `FatalReportsError =
+  FALSE` (no shmem-exit SetError), all other failures off. **FAILS: deadlock**
+  at the hung state (`done < NP`, no error, ring empty, consumer draining):
+  the consumer polls forever. This is the hang the `before_shmem_exit` hook
+  in `ScanWorkerMain` prevents.
+  Last run: deadlock trace found (trace length and state counts at detection
+  vary with -workers).
+- `ScanPool_cancel_bug.cfg` -- pre-fix consumer without the stop poll:
+  `ObserveCancel = FALSE`, `AllowCancel = TRUE`, other failures off. A stop
+  request arrives and the scan workers exit without claiming their tasks;
+  the consumer never observes the cancel and spins on the empty ring.
+  **FAILS: deadlock** at the hung state (stop requested, producers exited,
+  `done < NP`, no error, ring empty, consumer draining). This is the hang the
+  `IsCancelRequested`/`IsWorkerDraining` poll in `PoolScanStream::Next`
+  prevents. Last run: deadlock trace found (trace length and state counts at
+  detection vary with -workers).
+- `ScanPool_teardown.cfg` -- everything at once: cancel/LIMIT teardown, both
+  failure flavours, and stop requests mid-flight, exercising `ScanRing::Close`
+  and producers releasing held pages. **PASS.** Last run: 5,992 states
+  generated, 1,487 distinct.
+
+---
+
+# Model-vs-code findings
+
+Races surfaced by modelling and review; all have since been addressed in the
+code, and the models now check the fixes (each fix has a negative config that
+fails when the fix's constant is flipped off, so a regression in the code
+corresponds to a failing model):
+
+1. **Stale pending-ring entry after an early backend abort** -- FIXED. Pending
+   entries now carry `{conn_slot, conn_generation}` (the session slot index +
+   generation); `SessionPool::Acquire` bumps the slot generation, and the
+   worker's `SessionThreadMain` attaches via `TryAttachEnd(idx, generation)`,
+   which rejects a slot that is FREE or at a different generation.
+   `ControlProtocol.cfg` (PASS) includes the abort-while-pending adversary;
+   `ControlProtocol_staleentry_bug.cfg` (FAIL) preserves the pre-fix behavior
+   as the regression illustration.
+
+2. **Session-slot refcount stranded by worker death** -- addressed for the
+   reachable cases. The duckdb worker now drains its session threads from a
+   `before_shmem_exit` callback, so ERROR/FATAL exits DetachEnd cleanly; hard
+   kills (SIGKILL, segfault) skip the callback but cause a postmaster
+   crash-restart that reinitializes shared memory, so no stranded refcount
+   persists. `ControlProtocol_workercrash.cfg` (FAIL) keeps the counterfactual
+   "hard kill, no drain, no shmem reset" as the illustration of why the drain
+   exists.
+
+3. **C1: abort during the handshake wedged the session thread** -- FIXED. The
+   original model bundled "session thread finishes" into one always-enabled
+   action, hiding that the thread was actually parked in the handshake
+   receive with no exit when its backend aborted after the enqueue but before
+   the frames were sent. The abort path now also sets the channel cancel flag
+   (`RequestCancelAt`), which the handshake poll observes
+   (`SerializedRecvControl` returns Detached). The refined model splits the
+   abort into cancel-then-detach and the handshake wait into
+   frame-or-cancel; `ControlProtocol.cfg` (PASS) checks the fix,
+   `ControlProtocol_handshake_bug.cfg` (FAIL, deadlock) is the pre-fix wedge.
+
+4. **Silent scan-producer death / unobserved cancellation hung the pool-scan
+   consumer** -- FIXED twice over. A FATAL producer exit now reports
+   `SetError` from a shmem-exit hook (`g_active_range`), and the consumer's
+   nothing-ready branch polls the session cancel flag and the worker draining
+   flag. `ScanPool.cfg` (PASS) checks both; `ScanPool_bug.cfg` and
+   `ScanPool_cancel_bug.cfg` (FAIL, deadlock) are the two pre-fix hangs.
+
+5. **C2a: late scan replies resurrected closed demux lanes** -- FIXED. The
+   original model only allowed `CloseScanLane` after a completed drain, so
+   the late-reply case was unreachable. The drain can in fact bail (cancel /
+   worker drain), leaving replies on the wire; `CloseScanLane` now tombstones
+   the scan_id (`closed_scans`) and `RoutedRecv` drops late replies for
+   closed scans, freeing their Arrow pages (`~SessionChannel` also frees
+   pages still buffered in lanes). `ScanInversion.cfg` (PASS) includes bailed
+   drains; `ScanInversion_lateclose_bug.cfg` (FAIL, `ClosedLaneEmpty`) is the
+   pre-fix resurrection leak.
+
+The model treats `DetachEnd` as one atomic step; the code matches it:
+`DetachEnd`'s decrement and its free decision both run under the pool
+spinlock, so they are atomic against `TryAttachEnd`'s check + increment
+(a decrement landing between them could otherwise free a slot the worker
+just attached).

--- a/specs/tla/ScanInversion.cfg
+++ b/specs/tla/ScanInversion.cfg
@@ -1,0 +1,35 @@
+\* Primary model: ONE scan on the channel, read-ahead window W=2, 2 data chunks
+\* then ScanDone, no mid-scan error, Arrow pages on (1 page in the pool so the
+\* fast path and the inline fallback both occur), early teardown allowed, demux
+\* routing on (the real code). Exercises the window bound, FIFO matching,
+\* terminal stability, page balance on drain, and clean termination --
+\* including a CloseScanLane that runs with fetches still outstanding (a
+\* bailed drain), whose late replies the tombstone must drop and free
+\* (DropLateReplies = TRUE, the real code).
+\* Expect: all invariants + Termination hold.
+CONSTANTS
+    NScans = 1
+    W = 2
+    Chunks1 = 2
+    Chunks2 = 0
+    Error1 = 0
+    Error2 = 0
+    NumPages = 1
+    AllowArrow = TRUE
+    AllowTeardown = TRUE
+    AllowMeta = FALSE
+    RouteByScanId = TRUE
+    DropLateReplies = TRUE
+SPECIFICATION Spec
+INVARIANTS
+    TypeOK
+    WindowBounded
+    RequestsBounded
+    PageConservation
+    FIFOMatching
+    MetaLaneClean
+    ClosedLaneEmpty
+    TerminalStableInv
+PROPERTIES
+    TerminalStable
+    Termination

--- a/specs/tla/ScanInversion.tla
+++ b/specs/tla/ScanInversion.tla
@@ -1,0 +1,466 @@
+----------------------------- MODULE ScanInversion -----------------------------
+(***************************************************************************)
+(* A TLA+ model of the SCAN-INVERSION read-ahead sub-protocol of the       *)
+(* shared DuckDB duckdb worker:                                            *)
+(*   InversionScanStream (libpgduckdb/worker/scan_producer.cpp, worker/    *)
+(*   consumer side) <-> BackendSession::ServiceScanFetch            *)
+(*   (libpgduckdb/worker/duckdb_worker.cpp, backend/producer side) over the   *)
+(*   session channel's two shm_mq FIFOs, with the worker-side demux of      *)
+(*   SessionChannel::RoutedRecv (libpgduckdb/worker/transport/              *)
+(*   session_channel.cpp).                                                  *)
+(*                                                                          *)
+(* Direction of the two queues (named from the duckdb worker's view):       *)
+(*   result  : worker --ScanFetch/MetaQuery--> backend  (the result queue)  *)
+(*   control : backend --ScanChunk*/ScanDone/ScanError/MetaResult--> worker *)
+(*                                                                          *)
+(* Every scan reply now carries a uint32 scan_id prefix (SendScanReply in   *)
+(* duckdb_worker.cpp). The worker demultiplexes the control FIFO into per-    *)
+(* scan LANES plus one META lane (RoutedRecv in session_channel.cpp): a     *)
+(* receiving thread holds the demux lock across recv+route, so a lane's     *)
+(* frame order matches wire order. This lets several scans (a join's two    *)
+(* inputs on different DuckDB threads) and metadata round-trips share ONE   *)
+(* channel CONCURRENTLY -- the property this model checks.                  *)
+(*                                                                          *)
+(* What is modelled, per scan_id:                                           *)
+(*   - Worker Next() (InversionScanStream::Next): top up `outstanding` to  *)
+(*     WINDOW ScanFetch sends (first carries count_only+SQL), then consume  *)
+(*     ONE reply from THIS scan's lane (RecvScanReply), outstanding--. On   *)
+(*     ScanChunkArrow a pool page rides along (acquired by the backend,     *)
+(*     released when the worker drops the chunk). On ScanDone/ScanError set *)
+(*     done_ and DrainOutstanding(). Early teardown (LIMIT/cancel) -> the   *)
+(*     destructor DrainOutstanding() then CloseScanLane. The drain can BAIL *)
+(*     with replies still outstanding (SerializedRecvControl/RoutedRecv     *)
+(*     return Detached on backend cancel or worker drain), so CloseScanLane *)
+(*     must cope with replies that arrive AFTER the close: it tombstones    *)
+(*     the scan_id (closed_scans) and frees the pages of frames already     *)
+(*     routed to the lane; RoutedRecv then DROPS a late reply for a         *)
+(*     tombstoned scan (freeing its page) instead of re-creating ("resur-   *)
+(*     recting") the lane and pinning the page forever. (~SessionChannel    *)
+(*     also frees pages of frames still buffered in live lanes -- channel   *)
+(*     teardown is below this model's granularity; the close covers it.)    *)
+(*   - RouteFrame: RoutedRecv's route step -- pop the wire head, strip the  *)
+(*     scan_id prefix, append to that scan's lane (or the meta lane).       *)
+(*   - Backend ServiceScanFetch: per-scan_id BackendScanState in            *)
+(*     open_scans_; on first fetch InitBackendScan; produce one chunk       *)
+(*     (Arrow page or inline) or ScanDone at EOF, or ScanError; a scan that *)
+(*     has finished/errored is KEPT (not erased) and replies the SAME       *)
+(*     terminal to extra windowed fetches (the "kept, not re-opened"        *)
+(*     invariant).                                                          *)
+(*   - Metadata round-trip (optional): WorkerMetadataQuery/MetadataRoundTrip *)
+(*     in session_protocol.cpp -- send one MetaQuery on the result queue    *)
+(*     (serialized per channel by MetaRequestMutex, so at most one is in    *)
+(*     flight), receive the MetaResult off the meta lane. Models a DuckLake *)
+(*     GetFilesForTable issued from a scheduler thread mid-scan.            *)
+(*                                                                          *)
+(* Pages are modelled abstractly as a conserved resource: every Arrow page  *)
+(* the backend hands out must eventually be released -- by the worker       *)
+(* importing+dropping the chunk, by DrainOutstanding freeing a drained      *)
+(* Arrow frame, or by CloseScanLane freeing a routed-but-unconsumed frame.  *)
+(*                                                                          *)
+(* CONSTANTS pick the adversary:                                            *)
+(*   NScans       = scan_ids sharing the ONE channel (2 = a join, driven    *)
+(*                  CONCURRENTLY -- no sequencing assumption).              *)
+(*   W            = read-ahead window (the C++ WINDOW = 8; we use 2).       *)
+(*   Chunks1/2, Error1/2 = per-scan chunk counts / error injection points.  *)
+(*   NumPages     = pool pages available for the Arrow fast path.           *)
+(*   AllowArrow   = TRUE: chunks may ride an Arrow page (resource).         *)
+(*   AllowTeardown= TRUE: a scan may tear down early (destructor drain).    *)
+(*   AllowMeta    = TRUE: one metadata round-trip may interleave.           *)
+(*   RouteByScanId= TRUE (the real code): replies are routed to lanes by    *)
+(*                  their scan_id prefix. FALSE (the pre-demux bug class):  *)
+(*                  a receiving scan consumes the wire head no matter whom  *)
+(*                  it was for -- concurrent scans then mis-route.          *)
+(*   DropLateReplies = TRUE (the real code): a reply routed after           *)
+(*                  CloseScanLane is dropped and its page freed (the        *)
+(*                  closed_scans tombstone). FALSE (the pre-fix bug): the   *)
+(*                  late reply resurrects the closed lane, and the page is  *)
+(*                  pinned forever -- expect FAIL.                          *)
+(***************************************************************************)
+EXTENDS Naturals, Sequences, FiniteSets
+
+CONSTANTS
+    NScans,           \* number of scan_ids sharing the channel
+    W,                \* read-ahead window (WINDOW), e.g. 2
+    Chunks1,          \* data chunks scan 1 produces before ScanDone
+    Chunks2,          \* data chunks scan 2 produces (ignored if NScans = 1)
+    Error1,           \* chunk index at which scan 1 errors (0 = never)
+    Error2,           \* chunk index at which scan 2 errors (0 = never)
+    NumPages,         \* Arrow pool pages available
+    AllowArrow,       \* TRUE: chunks may use an Arrow page (resource)
+    AllowTeardown,    \* TRUE: a scan may tear down early
+    AllowMeta,        \* TRUE: a metadata round-trip may share the channel
+    RouteByScanId,    \* TRUE: the demux (real code); FALSE: consume wire head
+    DropLateReplies   \* TRUE: tombstone closed scans (the fix); FALSE: resurrect
+
+\* scan_ids are 1..NScans; per-scan chunk counts and error points are selected
+\* from the flat scalar constants above (cfg files cannot hold function literals).
+Scans      == 1 .. NScans
+ChunksOf   == [s \in Scans |-> IF s = 1 THEN Chunks1 ELSE Chunks2]
+ErrorsAt   == [s \in Scans |-> IF s = 1 THEN Error1  ELSE Error2]
+
+(* Reply frames on the control FIFO. `sid` is the scan_id prefix the wire
+   frame now CARRIES (0 = a metadata reply, which has no prefix but is routed
+   to the meta lane by its tag). `page` = does this frame own an Arrow page. *)
+ChunkF(sid, ix, pg)  == [kind |-> "chunk", sid |-> sid, ix |-> ix, page |-> pg]
+DoneF(sid)           == [kind |-> "done",  sid |-> sid, ix |-> 0,  page |-> FALSE]
+ErrF(sid)            == [kind |-> "error", sid |-> sid, ix |-> 0,  page |-> FALSE]
+MetaF                == [kind |-> "meta",  sid |-> 0,   ix |-> 0,  page |-> FALSE]
+
+(* Request frames on the result FIFO. *)
+FetchF(sid) == [kind |-> "fetch", sid |-> sid]
+MetaReqF    == [kind |-> "metaq", sid |-> 0]
+
+VARIABLES
+    result,     \* Seq of requests: worker --> backend (the result queue)
+    control,    \* Seq of reply frames: backend --> worker (the control queue)
+    lanes,      \* [Scans -> Seq of replies]: the per-scan demux lanes
+    metaLane,   \* Seq of replies: the metadata demux lane
+    bstate,     \* [Scans -> {"unopened","open","done","errored"}]: BackendScanState
+    bnext,      \* [Scans -> Nat]: next data-chunk index the backend will produce
+    started,    \* [Scans -> BOOLEAN]: worker has sent the first (SQL-carrying) fetch
+    outstanding,\* [Scans -> Nat]: worker's outstanding ScanFetch count
+    wstate,     \* [Scans -> {"run","done","torndown","closed"}]: worker stream
+                \* state; "closed" = CloseScanLane ran (the tombstone)
+    recvd,      \* [Scans -> Seq of Nat]: data-chunk indices the worker has consumed
+    pagesOut,   \* number of Arrow pages handed out but not yet released
+    mstate      \* {"idle","sent","done"}: the (single) metadata round-trip
+
+vars == << result, control, lanes, metaLane, bstate, bnext, started,
+           outstanding, wstate, recvd, pagesOut, mstate >>
+
+----------------------------------------------------------------------------
+ErrorsHere(sid)   == ErrorsAt[sid] # 0 /\ bnext[sid] = ErrorsAt[sid]
+AtEOF(sid)        == bnext[sid] >= ChunksOf[sid]
+
+\* A page may be attached only if the Arrow path is on and a page is free.
+CanPage           == AllowArrow /\ pagesOut < NumPages
+
+----------------------------------------------------------------------------
+TypeOK ==
+    /\ \A i \in DOMAIN result :
+         /\ result[i].kind \in {"fetch","metaq"}
+         /\ result[i].sid \in Scans \cup {0}
+    /\ \A i \in DOMAIN control :
+         /\ control[i].kind \in {"chunk","done","error","meta"}
+         /\ control[i].sid \in Scans \cup {0}
+         /\ control[i].ix \in Nat
+         /\ control[i].page \in BOOLEAN
+    /\ \A s \in Scans : \A i \in DOMAIN lanes[s] : lanes[s][i].kind \in {"chunk","done","error"}
+    /\ \A i \in DOMAIN metaLane : metaLane[i].kind = "meta"
+    /\ bstate \in [Scans -> {"unopened","open","done","errored"}]
+    /\ bnext \in [Scans -> Nat]
+    /\ started \in [Scans -> BOOLEAN]
+    /\ outstanding \in [Scans -> Nat]
+    /\ wstate \in [Scans -> {"run","done","torndown","closed"}]
+    /\ \A s \in Scans : \A i \in DOMAIN recvd[s] : recvd[s][i] \in Nat
+    /\ pagesOut \in 0 .. NumPages
+    /\ mstate \in {"idle","sent","done"}
+
+Init ==
+    /\ result = << >>
+    /\ control = << >>
+    /\ lanes = [s \in Scans |-> << >>]
+    /\ metaLane = << >>
+    /\ bstate = [s \in Scans |-> "unopened"]
+    /\ bnext = [s \in Scans |-> 0]
+    /\ started = [s \in Scans |-> FALSE]
+    /\ outstanding = [s \in Scans |-> 0]
+    /\ wstate = [s \in Scans |-> "run"]
+    /\ recvd = [s \in Scans |-> << >>]
+    /\ pagesOut = 0
+    /\ mstate = "idle"
+
+----------------------------------------------------------------------------
+(* --- Worker side: InversionScanStream::Next (scan_producer.cpp) --- *)
+
+\* Top-up loop in Next(): `while (outstanding_ < WINDOW) SerializedSendResult
+\* (ScanFetch)`. The first fetch flips started_ (carries count_only + SQL).
+\* One send per step. NO cross-scan gate: scans interleave freely -- the demux
+\* makes that safe.
+WorkerSendFetch(s) ==
+    /\ wstate[s] = "run"
+    /\ outstanding[s] < W
+    /\ result' = Append(result, FetchF(s))
+    /\ outstanding' = [outstanding EXCEPT ![s] = outstanding[s] + 1]
+    /\ started' = [started EXCEPT ![s] = TRUE]
+    /\ UNCHANGED << control, lanes, metaLane, bstate, bnext, wstate, recvd, pagesOut, mstate >>
+
+\* RoutedRecv's ROUTE step (session_channel.cpp): pop the wire head under the
+\* demux lock and append it to the lane its scan_id prefix selects (meta
+\* replies go to the meta lane). Holding the lock across recv+route means a
+\* lane's order equals wire order -- modelled by routing only the wire HEAD.
+\* A LATE reply -- routed after CloseScanLane tombstoned its scan_id -- is
+\* DROPPED and its Arrow page freed (the closed_scans check, the fix);
+\* DropLateReplies = FALSE reverts to the pre-fix resurrection: the frame is
+\* appended to the closed lane, where nothing will ever consume it.
+RouteFrame ==
+    /\ RouteByScanId
+    /\ control # << >>
+    /\ LET f == Head(control) IN
+         /\ control' = Tail(control)
+         /\ IF f.kind = "meta"
+              THEN /\ metaLane' = Append(metaLane, f)
+                   /\ lanes' = lanes
+                   /\ pagesOut' = pagesOut
+              ELSE IF wstate[f.sid] = "closed" /\ DropLateReplies
+              THEN /\ lanes' = lanes
+                   /\ metaLane' = metaLane
+                   /\ pagesOut' = pagesOut - (IF f.page THEN 1 ELSE 0)
+              ELSE /\ lanes' = [lanes EXCEPT ![f.sid] = Append(lanes[f.sid], f)]
+                   /\ metaLane' = metaLane
+                   /\ pagesOut' = pagesOut
+    /\ UNCHANGED << result, bstate, bnext, started, outstanding, wstate, recvd, mstate >>
+
+\* RecvScanReply in Next(): consume the head of THIS scan's lane.
+WorkerRecvLane(s) ==
+    /\ RouteByScanId
+    /\ wstate[s] = "run"
+    /\ outstanding[s] > 0
+    /\ lanes[s] # << >>
+    /\ LET f == Head(lanes[s]) IN
+         /\ lanes' = [lanes EXCEPT ![s] = Tail(lanes[s])]
+         /\ outstanding' = [outstanding EXCEPT ![s] = outstanding[s] - 1]
+         /\ IF f.kind = "chunk"
+              THEN \* import the chunk; if it carried a page it is released on drop
+                   /\ recvd' = [recvd EXCEPT ![s] = Append(recvd[s], f.ix)]
+                   /\ pagesOut' = pagesOut - (IF f.page THEN 1 ELSE 0)
+                   /\ UNCHANGED << wstate >>
+              ELSE \* ScanDone / ScanError: set done_, then DrainOutstanding()
+                   /\ wstate' = [wstate EXCEPT ![s] = "done"]
+                   /\ recvd' = recvd
+                   /\ pagesOut' = pagesOut
+    /\ UNCHANGED << result, control, metaLane, bstate, bnext, started, mstate >>
+
+\* DrainOutstanding(): consume one leftover reply off this scan's lane,
+\* freeing its Arrow page. Reached after done_ (terminal seen) or teardown.
+WorkerDrainLane(s) ==
+    /\ RouteByScanId
+    /\ wstate[s] \in {"done","torndown"}
+    /\ outstanding[s] > 0
+    /\ lanes[s] # << >>
+    /\ LET f == Head(lanes[s]) IN
+         /\ lanes' = [lanes EXCEPT ![s] = Tail(lanes[s])]
+         /\ outstanding' = [outstanding EXCEPT ![s] = outstanding[s] - 1]
+         /\ pagesOut' = pagesOut - (IF f.page THEN 1 ELSE 0)
+    /\ UNCHANGED << result, control, metaLane, bstate, bnext, started, wstate, recvd, mstate >>
+
+\* CloseScanLane in ~InversionScanStream: tombstone the scan_id (closed_scans),
+\* drop the lane, and free the Arrow pages of any frame routed there but never
+\* consumed. Enabled with outstanding > 0 because the destructor's drain can
+\* BAIL (Detached on backend cancel / worker drain) and close anyway -- the
+\* replies for those fetches then arrive LATE, after the tombstone, and
+\* RouteFrame must drop them. The stream is gone afterwards: no more drain.
+WorkerCloseLane(s) ==
+    /\ RouteByScanId
+    /\ wstate[s] \in {"done","torndown"}
+    /\ wstate' = [wstate EXCEPT ![s] = "closed"]
+    /\ pagesOut' = pagesOut -
+         Cardinality({ i \in DOMAIN lanes[s] : lanes[s][i].page })
+    /\ lanes' = [lanes EXCEPT ![s] = << >>]
+    /\ UNCHANGED << result, control, metaLane, bstate, bnext, started, outstanding, recvd, mstate >>
+
+\* --- Pre-demux bug class (RouteByScanId = FALSE): the worker consumes the ---
+\* --- wire HEAD and attributes it to ITSELF, whoever it was intended for.  ---
+WorkerRecvWire(s) ==
+    /\ ~RouteByScanId
+    /\ wstate[s] = "run"
+    /\ outstanding[s] > 0
+    /\ control # << >>
+    /\ LET f == Head(control) IN
+         /\ control' = Tail(control)
+         /\ outstanding' = [outstanding EXCEPT ![s] = outstanding[s] - 1]
+         /\ IF f.kind = "chunk"
+              THEN /\ recvd' = [recvd EXCEPT ![s] = Append(recvd[s], f.ix)]
+                   /\ pagesOut' = pagesOut - (IF f.page THEN 1 ELSE 0)
+                   /\ UNCHANGED << wstate >>
+              ELSE /\ wstate' = [wstate EXCEPT ![s] = "done"]
+                   /\ recvd' = recvd
+                   /\ pagesOut' = pagesOut
+    /\ UNCHANGED << result, lanes, metaLane, bstate, bnext, started, mstate >>
+
+WorkerDrainWire(s) ==
+    /\ ~RouteByScanId
+    /\ wstate[s] \in {"done","torndown"}
+    /\ outstanding[s] > 0
+    /\ control # << >>
+    /\ LET f == Head(control) IN
+         /\ control' = Tail(control)
+         /\ outstanding' = [outstanding EXCEPT ![s] = outstanding[s] - 1]
+         /\ pagesOut' = pagesOut - (IF f.page THEN 1 ELSE 0)
+    /\ UNCHANGED << result, lanes, metaLane, bstate, bnext, started, wstate, recvd, mstate >>
+
+\* ~InversionScanStream(): early teardown (LIMIT/cancel) while !done_.
+WorkerTeardown(s) ==
+    /\ AllowTeardown
+    /\ wstate[s] = "run"
+    /\ wstate' = [wstate EXCEPT ![s] = "torndown"]
+    /\ UNCHANGED << result, control, lanes, metaLane, bstate, bnext, started, outstanding, recvd, pagesOut, mstate >>
+
+----------------------------------------------------------------------------
+(* --- Metadata round-trip (MetadataRoundTrip in session_protocol.cpp) --- *)
+(* One at a time per channel (MetaRequestMutex); may fire mid-scan from a    *)
+(* DuckDB scheduler thread (e.g. DuckLake GetFilesForTable).                 *)
+
+MetaSend ==
+    /\ AllowMeta
+    /\ mstate = "idle"
+    /\ result' = Append(result, MetaReqF)
+    /\ mstate' = "sent"
+    /\ UNCHANGED << control, lanes, metaLane, bstate, bnext, started, outstanding, wstate, recvd, pagesOut >>
+
+\* RecvMetaReply: consume the head of the meta lane.
+MetaRecv ==
+    /\ mstate = "sent"
+    /\ metaLane # << >>
+    /\ metaLane' = Tail(metaLane)
+    /\ mstate' = "done"
+    /\ UNCHANGED << result, control, lanes, bstate, bnext, started, outstanding, wstate, recvd, pagesOut >>
+
+----------------------------------------------------------------------------
+(* --- Backend side: BackendSession::Fetch loop (duckdb_worker.cpp) --- *)
+(* The Fetch loop dequeues frames from the result FIFO IN ORDER; a ScanFetch  *)
+(* goes to ServiceScanFetch (one SendScanReply per fetch, scan_id-prefixed),  *)
+(* a MetaQuery to the extension's serve_frame (one MetaResult).               *)
+
+BackendService ==
+    /\ result # << >>
+    /\ LET f == Head(result) IN
+       IF f.kind = "metaq"
+       THEN \* ServeDuckLakeFrame -> SendMetadataReply
+            /\ result' = Tail(result)
+            /\ control' = Append(control, MetaF)
+            /\ UNCHANGED << bstate, bnext, pagesOut >>
+       ELSE LET sid == f.sid IN
+            /\ result' = Tail(result)
+            /\ CASE
+                 \* Kept-and-errored: reply the SAME ScanError (no re-run).
+                 bstate[sid] = "errored" ->
+                   /\ control' = Append(control, ErrF(sid))
+                   /\ UNCHANGED << bstate, bnext, pagesOut >>
+                 \* Kept-and-done: reply the SAME ScanDone (no re-open).
+                 [] bstate[sid] = "done" ->
+                   /\ control' = Append(control, DoneF(sid))
+                   /\ UNCHANGED << bstate, bnext, pagesOut >>
+                 \* Unopened/open: open on first fetch, produce chunk/terminal.
+                 [] OTHER ->
+                   /\ IF ErrorsHere(sid)
+                        THEN /\ bstate' = [bstate EXCEPT ![sid] = "errored"]
+                             /\ control' = Append(control, ErrF(sid))
+                             /\ UNCHANGED << bnext, pagesOut >>
+                        ELSE IF AtEOF(sid)
+                          THEN /\ bstate' = [bstate EXCEPT ![sid] = "done"]
+                               /\ control' = Append(control, DoneF(sid))
+                               /\ UNCHANGED << bnext, pagesOut >>
+                          ELSE /\ LET usePage == CanPage IN
+                                    /\ control' = Append(control, ChunkF(sid, bnext[sid], usePage))
+                                    /\ pagesOut' = pagesOut + (IF usePage THEN 1 ELSE 0)
+                               /\ bstate' = [bstate EXCEPT ![sid] = "open"]
+                               /\ bnext' = [bnext EXCEPT ![sid] = bnext[sid] + 1]
+    /\ UNCHANGED << lanes, metaLane, started, outstanding, wstate, recvd, mstate >>
+
+----------------------------------------------------------------------------
+(* --- Terminal / stutter --- *)
+
+\* A scan is retired once its lane is closed (the destructor always runs). In
+\* the no-demux bug variant there are no lanes to close: terminal wstate is
+\* enough. `outstanding` is NOT required to be 0: a bailed drain leaves the
+\* counter behind; the tombstone (not the counter) retires those replies.
+Retired(s) == IF RouteByScanId THEN wstate[s] = "closed"
+                               ELSE wstate[s] \in {"done","torndown"}
+
+AllRetired ==
+    /\ \A s \in Scans : Retired(s)
+    /\ \A s \in Scans : lanes[s] = << >>
+    /\ result = << >>
+    /\ control = << >>
+    /\ metaLane = << >>
+    /\ mstate # "sent"
+
+\* Clean terminal: all scans retired and every Arrow page reclaimed.
+Quiescent ==
+    /\ AllRetired
+    /\ pagesOut = 0
+
+Terminating == Quiescent /\ UNCHANGED vars
+
+ProgressNext ==
+    \/ \E s \in Scans : WorkerSendFetch(s) \/ WorkerRecvLane(s) \/ WorkerDrainLane(s)
+                        \/ WorkerCloseLane(s) \/ WorkerRecvWire(s) \/ WorkerDrainWire(s)
+    \/ RouteFrame
+    \/ MetaRecv
+    \/ BackendService
+
+Next ==
+    \/ ProgressNext
+    \/ \E s \in Scans : WorkerTeardown(s)   \* adversarial: not forced
+    \/ MetaSend                             \* adversarial: not forced
+    \/ Terminating
+
+\* Fairness on progress actions only. WorkerTeardown and MetaSend are
+\* adversarial (never forced): the protocol must terminate either way.
+Fairness ==
+    /\ \A s \in Scans :
+         /\ WF_vars(WorkerSendFetch(s))
+         /\ WF_vars(WorkerRecvLane(s))
+         /\ WF_vars(WorkerDrainLane(s))
+         /\ WF_vars(WorkerCloseLane(s))
+         /\ WF_vars(WorkerRecvWire(s))
+         /\ WF_vars(WorkerDrainWire(s))
+    /\ WF_vars(RouteFrame)
+    /\ WF_vars(MetaRecv)
+    /\ WF_vars(BackendService)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------
+(* --- Safety --- *)
+
+\* WindowBounded: at most W ScanFetches outstanding per scan.
+WindowBounded == \A s \in Scans : outstanding[s] =< W
+
+\* RequestsBounded: the result FIFO holds at most W per scan + 1 meta request.
+RequestsBounded == Len(result) =< W * Cardinality(Scans) + 1
+
+\* PageConservation: pages handed out but not released stay within the pool.
+PageConservation == pagesOut \in 0 .. NumPages
+
+\* FIFOMatching: the data chunks a scan has consumed are exactly the prefix
+\* 0,1,2,... of its produced sequence -- no reorder, no loss, no duplication,
+\* no foreign chunk. This is what the scan_id demux guarantees for CONCURRENT
+\* scans, and what breaks when RouteByScanId = FALSE.
+PrefixOk(s) == \A i \in DOMAIN recvd[s] : recvd[s][i] = i - 1
+FIFOMatching == \A s \in Scans : PrefixOk(s)
+
+\* MetaNotOnScanLane: routing never puts a metadata reply on a scan lane or a
+\* scan reply on the meta lane (checked structurally via TypeOK's lane types).
+MetaLaneClean == \A i \in DOMAIN metaLane : metaLane[i].kind = "meta"
+
+\* ClosedLaneEmpty: a closed lane stays empty -- a late reply must never
+\* resurrect it (its page would be pinned forever: nothing consumes a closed
+\* lane). This is what the closed_scans tombstone in RoutedRecv guarantees
+\* and what DropLateReplies = FALSE breaks.
+ClosedLaneEmpty == \A s \in Scans : (wstate[s] = "closed") => lanes[s] = << >>
+
+----------------------------------------------------------------------------
+(* --- Terminal-stability safety (TerminalStable) --- *)
+\* Once the backend marks a scan done/errored it never produces a fresh data
+\* chunk for it again ("kept, not re-opened", ServiceScanFetch).
+TerminalStableInv ==
+    \A s \in Scans :
+        /\ (bstate[s] = "done")    => (bnext[s] >= ChunksOf[s] \/ bnext[s] = 0)
+        /\ (bstate[s] = "errored") => (ErrorsAt[s] = 0 \/ bnext[s] = ErrorsAt[s])
+
+TerminalStable ==
+    [][ \A s \in Scans :
+          (bstate[s] \in {"done","errored"}) =>
+            (bnext'[s] = bnext[s] /\ bstate'[s] = bstate[s]) ]_vars
+
+----------------------------------------------------------------------------
+(* --- Liveness --- *)
+
+\* Termination: the protocol always reaches the clean terminal -- every scan
+\* retired (lane closed), both FIFOs drained, lanes empty, every page
+\* reclaimed, no metadata round-trip stuck in flight. Fails when a late reply
+\* resurrects a closed lane (its page is never freed).
+Termination == <>Quiescent
+=============================================================================

--- a/specs/tla/ScanInversion_lateclose_bug.cfg
+++ b/specs/tla/ScanInversion_lateclose_bug.cfg
@@ -1,0 +1,41 @@
+\* NEGATIVE config -- the pre-fix late-reply lane resurrection (C2a).
+\* DropLateReplies = FALSE models the old RoutedRecv, which had no
+\* closed_scans tombstone: a scan reply arriving AFTER CloseScanLane re-created
+\* the lane entry in the demux map. Nothing ever consumes a closed scan's lane,
+\* so the Arrow page riding on that frame was pinned forever (and the old
+\* ~SessionChannel did not free lane-buffered pages either).
+\* The race: the scan sends windowed fetches, the backend replies a chunk
+\* carrying a pool page; the scan is torn down early (LIMIT/cancel), its
+\* destructor's drain BAILS (Detached on cancel / worker drain) and
+\* CloseScanLane runs with the reply still on the wire; RouteFrame then routes
+\* the late reply into the closed lane.
+\* Expect FAIL: TLC reports ClosedLaneEmpty VIOLATED (the resurrected lane),
+\* with the page still counted in pagesOut -- the leak Termination would also
+\* flag. The fixed code (DropLateReplies = TRUE, checked by ScanInversion.cfg
+\* under the same adversary) drops the frame and frees its page instead.
+CONSTANTS
+    NScans = 1
+    W = 2
+    Chunks1 = 2
+    Chunks2 = 0
+    Error1 = 0
+    Error2 = 0
+    NumPages = 1
+    AllowArrow = TRUE
+    AllowTeardown = TRUE
+    AllowMeta = FALSE
+    RouteByScanId = TRUE
+    DropLateReplies = FALSE
+SPECIFICATION Spec
+INVARIANTS
+    TypeOK
+    WindowBounded
+    RequestsBounded
+    PageConservation
+    FIFOMatching
+    MetaLaneClean
+    ClosedLaneEmpty
+    TerminalStableInv
+PROPERTIES
+    TerminalStable
+    Termination

--- a/specs/tla/ScanInversion_noroute_bug.cfg
+++ b/specs/tla/ScanInversion_noroute_bug.cfg
@@ -1,0 +1,38 @@
+\* NEGATIVE config: the pre-demux bug class. RouteByScanId = FALSE models the
+\* old transport where scan replies carried no scan_id and a scan's Next()
+\* consumed the head of the control FIFO no matter which scan it was intended
+\* for. With two scans CONCURRENT on one channel, a reply meant for scan 1 is
+\* consumed by scan 2 (and vice versa), so the consumed data-chunk indices stop
+\* being the clean 0,1,... prefix of that scan's produced sequence.
+\* Expect: FIFOMatching VIOLATED, with a trace showing the cross-scan
+\* mis-routing. This is exactly what the scan_id prefix + demux lanes
+\* (SendScanReply in duckdb_worker.cpp, RoutedRecv in session_channel.cpp)
+\* prevent -- and why the old code needed DuckDB to drive join inputs
+\* sequentially, a constraint the demux lifted.
+\* AllowArrow/AllowTeardown/AllowMeta = FALSE keep the violation trace minimal.
+CONSTANTS
+    NScans = 2
+    W = 2
+    Chunks1 = 2
+    Chunks2 = 2
+    Error1 = 0
+    Error2 = 0
+    NumPages = 1
+    AllowArrow = FALSE
+    AllowTeardown = FALSE
+    AllowMeta = FALSE
+    RouteByScanId = FALSE
+    DropLateReplies = TRUE
+SPECIFICATION Spec
+INVARIANTS
+    TypeOK
+    WindowBounded
+    RequestsBounded
+    PageConservation
+    FIFOMatching
+    MetaLaneClean
+    ClosedLaneEmpty
+    TerminalStableInv
+PROPERTIES
+    TerminalStable
+    Termination

--- a/specs/tla/ScanInversion_twoscan.cfg
+++ b/specs/tla/ScanInversion_twoscan.cfg
@@ -1,0 +1,37 @@
+\* Two scans (a join's two inputs) sharing the ONE channel and running
+\* CONCURRENTLY -- fetches and receives interleave freely, with NO sequencing
+\* assumption -- plus one metadata round-trip (a DuckLake GetFilesForTable from
+\* a scheduler thread) interleaving on the same channel. This is the situation
+\* the scan_id-prefixed replies + RoutedRecv demux lanes exist for: each scan
+\* consumes only its own lane, the metadata reply lands on the meta lane, so
+\* FIFO-per-lane matching, page conservation, terminal stability, and clean
+\* termination all hold. (Replaces the old ScanInversion_twoscan_seq.cfg,
+\* whose "scan 1 must fully drain before scan 2 starts" assumption the demux
+\* made unnecessary.)
+\* Expect: all invariants + Termination hold.
+CONSTANTS
+    NScans = 2
+    W = 2
+    Chunks1 = 2
+    Chunks2 = 1
+    Error1 = 0
+    Error2 = 0
+    NumPages = 1
+    AllowArrow = TRUE
+    AllowTeardown = TRUE
+    AllowMeta = TRUE
+    RouteByScanId = TRUE
+    DropLateReplies = TRUE
+SPECIFICATION Spec
+INVARIANTS
+    TypeOK
+    WindowBounded
+    RequestsBounded
+    PageConservation
+    FIFOMatching
+    MetaLaneClean
+    ClosedLaneEmpty
+    TerminalStableInv
+PROPERTIES
+    TerminalStable
+    Termination

--- a/specs/tla/ScanPool.cfg
+++ b/specs/tla/ScanPool.cfg
@@ -1,0 +1,24 @@
+\* Primary model: the fixed protocol under the full failure adversary. Producers
+\* may hit a PG ERROR (PG_TRY -> SetError) or die FATALly (the shmem-exit hook
+\* reports the active range, FatalReportsError = TRUE); a stop request (backend
+\* cancel / worker drain) may arrive, after which producers may abandon
+\* unclaimed tasks -- the fixed consumer's nothing-ready poll (ObserveCancel =
+\* TRUE) aborts the scan instead of spinning. No external rescue (AllowAbort =
+\* FALSE): every terminal is reached through the protocol itself.
+\* Expect PASS: all invariants hold and Termination holds -- the consumer
+\* terminates via the reported error or the observed stop, and pages never
+\* leak or double-free.
+CONSTANTS
+    Producers = {p1, p2}
+    NumPages = 2
+    RingCap = 2
+    ChunksPerTask = 2
+    AllowFail = TRUE
+    AllowFatal = TRUE
+    FatalReportsError = TRUE
+    AllowCancel = TRUE
+    ObserveCancel = TRUE
+    AllowAbort = FALSE
+SPECIFICATION Spec
+INVARIANTS TypeOK PageConservation RingBounded
+PROPERTIES Termination

--- a/specs/tla/ScanPool.tla
+++ b/specs/tla/ScanPool.tla
@@ -1,0 +1,355 @@
+-------------------------------- MODULE ScanPool --------------------------------
+(***************************************************************************)
+(* A TLA+ model of the shared scan-producer pool of the shared DuckDB      *)
+(* duckdb worker (libpgduckdb/worker/scan_producer.cpp +                   *)
+(* libpgduckdb/worker/duckdb_worker.cpp, over the transport in             *)
+(* libpgduckdb/worker/transport/{scan_ring,scan_queue,page_pool}.cpp).     *)
+(*                                                                         *)
+(* What is modelled: the page lifecycle and the producer/consumer/teardown *)
+(* protocol for ONE scan -- the concurrency core where the code reviews    *)
+(* found consumer hangs and page leaks.                                    *)
+(*                                                                         *)
+(*   - A fixed page pool (PagePool::Acquire/Release): a page is in         *)
+(*     exactly one place at a time -- free, held by a producer, queued in   *)
+(*     the scan's ready-ring, or in-flight in the consumer (referenced by a *)
+(*     live DuckDB chunk, freed later by the Arrow release callback).      *)
+(*   - N scan workers (DuckdbWorker::ScanWorkerMain), each running one     *)
+(*     block-range task (ProcessScanRange): acquire a page, fill it, push  *)
+(*     it to the ready-ring (ScanRing::Push); after ChunksPerTask pushes   *)
+(*     the task is done (ScanRing::TaskDone).                              *)
+(*   - Producer failure comes in two flavours:                             *)
+(*       ProducerError -- a PostgreSQL ERROR inside ProcessScanRange. The  *)
+(*         PG_TRY there catches the longjmp, releases the held page and    *)
+(*         calls ScanRing::SetError: ALWAYS reported.                      *)
+(*       ProducerFatal -- the scan-worker PROCESS dies (elog FATAL,        *)
+(*         SIGTERM mid-task). FATAL skips PG_CATCH but runs shmem-exit     *)
+(*         callbacks: the before_shmem_exit hook in ScanWorkerMain errors  *)
+(*         out the active range (g_active_range -> ScanRing::SetError).    *)
+(*         FatalReportsError toggles that hook; FALSE is the pre-fix       *)
+(*         silent death -- no TaskDone, no SetError -- after which the     *)
+(*         consumer polls the ready-ring forever (the hang).               *)
+(*   - The duckdb worker's consumer (PoolScanStream::Next) drains the      *)
+(*     ready-ring (ScanRing::TryNext), releases pages, and finishes when   *)
+(*     every task is done and the ring is empty, or aborts on error /      *)
+(*     external cancel, then closes the scan (ScanRing::Close reclaims     *)
+(*     queued pages and bumps the generation so in-flight producers stop). *)
+(*   - CANCELLATION / WORKER DRAIN: a stop request (the session channel's  *)
+(*     cancel flag set by the backend, or the worker's draining flag on    *)
+(*     shutdown) can arrive at any time. Scan workers do not poll the      *)
+(*     session cancel flag, so they may keep producing; on a worker drain  *)
+(*     a QUEUED task may simply never be claimed (StopExit: the scan       *)
+(*     worker exits with the task still in the scan queue -- no TaskDone,  *)
+(*     no error). The FIXED consumer polls the stop conditions in its      *)
+(*     nothing-ready branch (IsCancelRequested / IsWorkerDraining in       *)
+(*     PoolScanStream::Next) and errors out, closing the ring; the         *)
+(*     ObserveCancel constant toggles that poll -- FALSE is the pre-fix    *)
+(*     consumer, which spins on the never-to-be-filled ring forever.       *)
+(*                                                                         *)
+(* CONSTANTS pick the adversary:                                           *)
+(*   AllowFail  - producers may hit a PG ERROR mid-task (always reported). *)
+(*   AllowFatal - a producer process may die FATALly mid-task.             *)
+(*   FatalReportsError - TRUE: the shmem-exit hook reports the FATAL as a  *)
+(*     scan error (the fix). FALSE: silent death (pre-fix): expect FAIL.   *)
+(*   AllowCancel - a stop request (backend cancel / worker drain) may      *)
+(*     arrive; producers may then exit without claiming their task.        *)
+(*   ObserveCancel - TRUE: the consumer's nothing-ready branch polls the   *)
+(*     stop conditions (the fix). FALSE: it does not (pre-fix): expect     *)
+(*     FAIL when a task is abandoned.                                      *)
+(*   AllowAbort - the consumer may externally abort at any time (DuckDB    *)
+(*     cancel / LIMIT reached), exercising the teardown/reclaim path.      *)
+(***************************************************************************)
+EXTENDS Naturals, Sequences, FiniteSets
+
+CONSTANTS
+    Producers,      \* set of pool-worker ids; one task each. e.g. {p1, p2}
+    NumPages,       \* size of the global page pool. e.g. 2
+    RingCap,        \* per-scan ready-ring capacity. e.g. 2
+    ChunksPerTask,  \* pages each task produces before TaskDone. e.g. 2
+    AllowFail,      \* TRUE: producers may hit a PG ERROR mid-task
+    AllowFatal,     \* TRUE: a producer process may die FATALly
+    FatalReportsError, \* TRUE: shmem-exit hook -> SetError (the fix)
+    AllowCancel,    \* TRUE: a stop request (cancel / worker drain) may arrive
+    ObserveCancel,  \* TRUE: consumer polls the stop conditions (the fix)
+    AllowAbort      \* TRUE: the consumer may externally abort (cancel/LIMIT)
+
+Pages == 1 .. NumPages
+
+VARIABLES
+    free,       \* SUBSET Pages: pages on the free stack
+    held,       \* [Producers -> Pages \cup {0}]: page a producer is filling (0 = none)
+    ring,       \* Seq(Pages): the scan's ready-ring (head = next to consume)
+    inflight,   \* SUBSET Pages: popped by the consumer, referenced by a live chunk
+    pstate,     \* [Producers -> {"work","exit"}]
+    produced,   \* [Producers -> 0..ChunksPerTask]: pages this task has pushed
+    done,       \* number of tasks that reached TaskDone
+    errored,    \* BOOLEAN: the scan's error flag
+    stopReq,    \* BOOLEAN: backend cancel / worker draining requested
+    cstate      \* {"drain","finished","aborted"}: consumer state
+
+vars == <<free, held, ring, inflight, pstate, produced, done, errored, stopReq, cstate>>
+
+NP == Cardinality(Producers)
+RingSet  == { ring[i] : i \in DOMAIN ring }
+NumHeld  == Cardinality({ p \in Producers : held[p] # 0 })
+
+----------------------------------------------------------------------------
+TypeOK ==
+    /\ free \subseteq Pages
+    /\ held \in [Producers -> Pages \cup {0}]
+    /\ ring \in Seq(Pages)
+    /\ inflight \subseteq Pages
+    /\ pstate \in [Producers -> {"work","exit"}]
+    /\ produced \in [Producers -> 0 .. ChunksPerTask]
+    /\ done \in 0 .. NP
+    /\ errored \in BOOLEAN
+    /\ stopReq \in BOOLEAN
+    /\ cstate \in {"drain","finished","aborted"}
+
+Init ==
+    /\ free = Pages
+    /\ held = [p \in Producers |-> 0]
+    /\ ring = << >>
+    /\ inflight = {}
+    /\ pstate = [p \in Producers |-> "work"]
+    /\ produced = [p \in Producers |-> 0]
+    /\ done = 0
+    /\ errored = FALSE
+    /\ stopReq = FALSE
+    /\ cstate = "drain"
+
+----------------------------------------------------------------------------
+(* --- Producer actions (one per pool worker) --- *)
+
+\* PagePool::Acquire: grab a free page to fill the next chunk. A stop request
+\* does NOT gate this: scan workers do not poll the session cancel flag.
+Acquire(p) ==
+    /\ pstate[p] = "work"
+    /\ held[p] = 0
+    /\ produced[p] < ChunksPerTask
+    /\ cstate = "drain"
+    /\ ~errored
+    /\ free # {}
+    /\ \E pg \in free :
+         /\ free' = free \ {pg}
+         /\ held' = [held EXCEPT ![p] = pg]
+    /\ UNCHANGED <<ring, inflight, pstate, produced, done, errored, stopReq, cstate>>
+
+\* ScanRing::Push (scan alive, not errored): enqueue the filled page; the last
+\* push is followed by ScanRing::TaskDone.
+PushOk(p) ==
+    /\ pstate[p] = "work"
+    /\ held[p] # 0
+    /\ cstate = "drain"
+    /\ ~errored
+    /\ Len(ring) < RingCap
+    /\ ring' = Append(ring, held[p])
+    /\ held' = [held EXCEPT ![p] = 0]
+    /\ produced' = [produced EXCEPT ![p] = produced[p] + 1]
+    /\ IF produced[p] + 1 = ChunksPerTask
+         THEN /\ pstate' = [pstate EXCEPT ![p] = "exit"]
+              /\ done' = done + 1
+         ELSE /\ pstate' = [pstate EXCEPT ![p] = "work"]
+              /\ done' = done
+    /\ UNCHANGED <<free, inflight, errored, stopReq, cstate>>
+
+\* ScanRing::Push returns false -- the scan was closed (generation bumped) or
+\* another producer errored the scan: free the page, stop.
+PushTorndown(p) ==
+    /\ pstate[p] = "work"
+    /\ held[p] # 0
+    /\ (cstate = "aborted" \/ errored)
+    /\ free' = free \cup {held[p]}
+    /\ held' = [held EXCEPT ![p] = 0]
+    /\ pstate' = [pstate EXCEPT ![p] = "exit"]
+    /\ UNCHANGED <<ring, inflight, produced, done, errored, stopReq, cstate>>
+
+\* Producer notices the scan was torn down before acquiring another page: stop.
+StopOnAbort(p) ==
+    /\ pstate[p] = "work"
+    /\ held[p] = 0
+    /\ cstate = "aborted"
+    /\ pstate' = [pstate EXCEPT ![p] = "exit"]
+    /\ UNCHANGED <<free, held, ring, inflight, produced, done, errored, stopReq, cstate>>
+
+\* A PostgreSQL ERROR inside ProcessScanRange: the PG_TRY catches the longjmp,
+\* releases the held page, and reports via ScanRing::SetError -- unconditional.
+ProducerError(p) ==
+    /\ AllowFail
+    /\ pstate[p] = "work"
+    /\ free' = free \cup (IF held[p] # 0 THEN {held[p]} ELSE {})
+    /\ held' = [held EXCEPT ![p] = 0]
+    /\ pstate' = [pstate EXCEPT ![p] = "exit"]
+    /\ errored' = TRUE
+    /\ UNCHANGED <<ring, inflight, produced, done, stopReq, cstate>>
+
+\* The scan-worker PROCESS dies mid-task (elog FATAL, SIGTERM): PG_CATCH is
+\* skipped, but shmem-exit callbacks run -- with the fix the ScanWorkerMain
+\* hook errors out g_active_range (FatalReportsError = TRUE); pre-fix the
+\* producer just disappears. Modelled between pages (held = 0): a FATAL while
+\* holding a page additionally leaks that page (no callback releases it) -- a
+\* separate, known gap outside this model's scope.
+ProducerFatal(p) ==
+    /\ AllowFatal
+    /\ pstate[p] = "work"
+    /\ held[p] = 0
+    /\ pstate' = [pstate EXCEPT ![p] = "exit"]
+    /\ errored' = IF FatalReportsError THEN TRUE ELSE errored
+    /\ UNCHANGED <<free, held, ring, inflight, produced, done, stopReq, cstate>>
+
+\* Worker drain with the task never claimed: the scan worker exits with the
+\* task still queued in the scan queue -- no TaskDone, no SetError. (A drain
+\* signal DURING a task surfaces as ProducerFatal instead: SIGTERM ->
+\* CHECK_FOR_INTERRUPTS -> FATAL -> the shmem-exit hook.)
+StopExit(p) ==
+    /\ stopReq
+    /\ pstate[p] = "work"
+    /\ held[p] = 0
+    /\ produced[p] = 0
+    /\ pstate' = [pstate EXCEPT ![p] = "exit"]
+    /\ UNCHANGED <<free, held, ring, inflight, produced, done, errored, stopReq, cstate>>
+
+----------------------------------------------------------------------------
+(* --- Stop request (backend cancel / worker draining) --- *)
+
+CancelRequest ==
+    /\ AllowCancel
+    /\ ~stopReq
+    /\ cstate = "drain"
+    /\ stopReq' = TRUE
+    /\ UNCHANGED <<free, held, ring, inflight, pstate, produced, done, errored, cstate>>
+
+----------------------------------------------------------------------------
+(* --- Consumer actions (the duckdb worker draining the ready-ring) --- *)
+
+\* ScanRing::TryNext == 1: pop a ready page; it becomes a live chunk (in-flight).
+\* The real code checks the error flag before the ring, so Pop is disabled once errored.
+Pop ==
+    /\ cstate = "drain"
+    /\ ~errored
+    /\ ring # << >>
+    /\ inflight' = inflight \cup {Head(ring)}
+    /\ ring' = Tail(ring)
+    /\ UNCHANGED <<free, held, pstate, produced, done, errored, stopReq, cstate>>
+
+\* The Arrow release callback (or the serialized-path immediate free) returns a page.
+\* Can fire any time after the page was popped, including after the scan is terminal.
+Release ==
+    /\ inflight # {}
+    /\ \E pg \in inflight :
+         /\ inflight' = inflight \ {pg}
+         /\ free' = free \cup {pg}
+    /\ UNCHANGED <<held, ring, pstate, produced, done, errored, stopReq, cstate>>
+
+\* ScanRing::TryNext == 0: ring drained and every task done -> end of scan.
+Finish ==
+    /\ cstate = "drain"
+    /\ ~errored
+    /\ ring = << >>
+    /\ done = NP
+    /\ cstate' = "finished"
+    /\ UNCHANGED <<free, held, ring, inflight, pstate, produced, done, errored, stopReq>>
+
+\* ScanRing::TryNext == -1: the scan errored -> consumer throws and tears down.
+AbortOnError ==
+    /\ cstate = "drain"
+    /\ errored
+    /\ cstate' = "aborted"
+    /\ UNCHANGED <<free, held, ring, inflight, pstate, produced, done, errored, stopReq>>
+
+\* The NOTHING-READY branch of PoolScanStream::Next (ring empty, tasks still
+\* outstanding, no error): the fixed consumer polls IsCancelRequested /
+\* IsWorkerDraining and errors out instead of spinning on a ring nobody may
+\* ever fill. ObserveCancel = FALSE removes the poll (the pre-fix hang).
+AbortOnCancel ==
+    /\ ObserveCancel
+    /\ cstate = "drain"
+    /\ stopReq
+    /\ ~errored
+    /\ ring = << >>
+    /\ done < NP
+    /\ cstate' = "aborted"
+    /\ UNCHANGED <<free, held, ring, inflight, pstate, produced, done, errored, stopReq>>
+
+\* DuckDB cancels / a LIMIT is satisfied: the scan stream is destroyed early.
+ExternalAbort ==
+    /\ AllowAbort
+    /\ cstate = "drain"
+    /\ cstate' = "aborted"
+    /\ UNCHANGED <<free, held, ring, inflight, pstate, produced, done, errored, stopReq>>
+
+\* ScanRing::Close: reclaim every page still queued in the ready-ring.
+Unregister ==
+    /\ cstate = "aborted"
+    /\ ring # << >>
+    /\ free' = free \cup RingSet
+    /\ ring' = << >>
+    /\ UNCHANGED <<held, inflight, pstate, produced, done, errored, stopReq, cstate>>
+
+----------------------------------------------------------------------------
+\* The system always reaches a quiescent terminal: the consumer has finished or
+\* aborted, every producer has stopped, nothing is queued or in-flight, and every
+\* page is back on the free stack.
+AllExited == \A p \in Producers : pstate[p] = "exit"
+
+Quiescent ==
+    /\ cstate \in {"finished","aborted"}
+    /\ ring = << >>
+    /\ inflight = {}
+    /\ AllExited
+    /\ free = Pages
+
+ProducerProgress(p) == Acquire(p) \/ PushOk(p) \/ PushTorndown(p) \/ StopOnAbort(p)
+ConsumerProgress    == Pop \/ Release \/ Finish \/ AbortOnError \/ AbortOnCancel \/ Unregister
+
+\* Once quiescent, the scan is fully torn down; stutter here so the intended terminal
+\* is not flagged as a deadlock. A genuinely stuck state (a pre-fix hang) is NOT
+\* quiescent, has no other successor, and so is still reported as a deadlock.
+Terminating == Quiescent /\ UNCHANGED vars
+
+Next ==
+    \/ \E p \in Producers : ProducerProgress(p) \/ ProducerError(p) \/ ProducerFatal(p)
+                            \/ StopExit(p)
+    \/ ConsumerProgress
+    \/ CancelRequest
+    \/ ExternalAbort
+    \/ Terminating
+
+\* Fairness on progress actions only. ProducerError, ProducerFatal, StopExit,
+\* CancelRequest, and ExternalAbort are adversarial (never forced): liveness
+\* must hold no matter how they interleave. AbortOnCancel is fair progress:
+\* the fixed consumer runs the poll on every nothing-ready iteration.
+Fairness ==
+    /\ \A p \in Producers : WF_vars(ProducerProgress(p))
+    /\ WF_vars(ConsumerProgress)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------
+(* --- Safety --- *)
+
+\* The four page locations partition the pool: no page is lost, and none is in
+\* two places at once (so no double-free and no leak). NoLeak uses NumHeld and
+\* Len(ring) (not the deduped sets) so a duplicated page would push the count > NumPages.
+NoLeak == Cardinality(free) + NumHeld + Len(ring) + Cardinality(inflight) = NumPages
+
+Disjoint ==
+    LET heldSet == { held[p] : p \in Producers } \ {0} IN
+    /\ free \cap heldSet  = {}
+    /\ free \cap RingSet  = {}
+    /\ free \cap inflight = {}
+    /\ heldSet \cap RingSet  = {}
+    /\ heldSet \cap inflight = {}
+    /\ RingSet \cap inflight = {}
+
+PageConservation == NoLeak /\ Disjoint
+
+RingBounded == Len(ring) =< RingCap
+
+----------------------------------------------------------------------------
+(* --- Liveness --- *)
+
+\* The system always reaches the quiescent terminal (Quiescent, defined above).
+\* This fails iff the consumer can hang (a silent producer death or an
+\* unobserved stop request with tasks outstanding) or a page can leak.
+Termination == <>Quiescent
+=============================================================================

--- a/specs/tla/ScanPool_bug.cfg
+++ b/specs/tla/ScanPool_bug.cfg
@@ -1,0 +1,26 @@
+\* NEGATIVE config -- the pre-fix silent producer death. A scan worker dies
+\* FATALly mid-task (ProducerFatal) and FatalReportsError = FALSE removes the
+\* before_shmem_exit hook that errors out g_active_range: no TaskDone, no
+\* SetError. PG ERRORs, cancellation, and external rescue are all off so the
+\* FATAL is the only failure in play.
+\* Safety still holds (the dead producer held no page), but the consumer hangs:
+\* it drains the ring and then polls forever because done < NP and no error was
+\* ever reported. Expect FAIL: TLC reports a DEADLOCK at the hung state (done <
+\* NP, no error, ring empty, consumer still draining) -- equivalently
+\* Termination is violated. This is the hang the shmem-exit SetError hook in
+\* DuckdbWorker::ScanWorkerMain prevents; ScanPool.cfg checks the hook under
+\* the same adversary.
+CONSTANTS
+    Producers = {p1, p2}
+    NumPages = 2
+    RingCap = 2
+    ChunksPerTask = 2
+    AllowFail = FALSE
+    AllowFatal = TRUE
+    FatalReportsError = FALSE
+    AllowCancel = FALSE
+    ObserveCancel = TRUE
+    AllowAbort = FALSE
+SPECIFICATION Spec
+INVARIANTS TypeOK PageConservation RingBounded
+PROPERTIES Termination

--- a/specs/tla/ScanPool_cancel_bug.cfg
+++ b/specs/tla/ScanPool_cancel_bug.cfg
@@ -1,0 +1,27 @@
+\* NEGATIVE config -- the pre-fix consumer that never polls the stop
+\* conditions. A stop request arrives (backend cancel / worker drain,
+\* AllowCancel = TRUE) and scan workers exit without claiming their queued
+\* tasks (StopExit): no TaskDone, no error, and nothing will ever fill the
+\* ring. ObserveCancel = FALSE removes the IsCancelRequested /
+\* IsWorkerDraining poll from the consumer's nothing-ready branch, so the
+\* consumer spins on the empty ring forever even though the query was
+\* cancelled. Producer failures and external rescue are off so the abandoned
+\* task is the only failure in play.
+\* Expect FAIL: TLC reports a DEADLOCK at the hung state (stop requested,
+\* every producer exited, done < NP, no error, ring empty, consumer still
+\* draining) -- equivalently Termination is violated. The fixed consumer
+\* (ScanPool.cfg, ObserveCancel = TRUE) aborts the scan from that same state.
+CONSTANTS
+    Producers = {p1, p2}
+    NumPages = 2
+    RingCap = 2
+    ChunksPerTask = 2
+    AllowFail = FALSE
+    AllowFatal = FALSE
+    FatalReportsError = TRUE
+    AllowCancel = TRUE
+    ObserveCancel = FALSE
+    AllowAbort = FALSE
+SPECIFICATION Spec
+INVARIANTS TypeOK PageConservation RingBounded
+PROPERTIES Termination

--- a/specs/tla/ScanPool_teardown.cfg
+++ b/specs/tla/ScanPool_teardown.cfg
@@ -1,0 +1,22 @@
+\* Teardown stress: everything at once. The consumer may abort at any time
+\* (DuckDB cancel / LIMIT, AllowAbort = TRUE), producers may error or die
+\* FATALly (reported via PG_TRY / the shmem-exit hook), and a stop request may
+\* arrive mid-flight. Exercises ScanRing::Close reclaiming queued pages,
+\* producers releasing held pages on teardown, and the consumer's stop poll
+\* racing the external abort. Expect PASS: PageConservation holds throughout
+\* (no leak, no double-free) and Termination holds (every page returns to the
+\* free stack and the consumer reaches a terminal state).
+CONSTANTS
+    Producers = {p1, p2}
+    NumPages = 2
+    RingCap = 2
+    ChunksPerTask = 2
+    AllowFail = TRUE
+    AllowFatal = TRUE
+    FatalReportsError = TRUE
+    AllowCancel = TRUE
+    ObserveCancel = TRUE
+    AllowAbort = TRUE
+SPECIFICATION Spec
+INVARIANTS TypeOK PageConservation RingBounded
+PROPERTIES Termination


### PR DESCRIPTION
## What

Runs DuckDB analytical queries in one shared background worker per database instead of a full DuckDB instance inside every PostgreSQL backend. Under concurrency, per-backend instances multiply memory until the host OOMs; with this PR, eligible queries from any number of backends share a single engine whose footprint is bounded and configurable.

A backend ships its deparsed SQL and its MVCC snapshot to the worker over shared memory and streams result chunks back. The worker serves many sessions concurrently -- one thread per in-flight query -- on one DuckDB instance, and is completely PostgreSQL-free at execution time: everything that needs PostgreSQL (catalog lookups, heap reads, DuckLake metadata SQL) is shipped back to the requesting backend, or to a pool of scan-producer workers, over the same channel.

The feature is off by default. Setting `max_worker_sessions > 0` (postmaster GUC) provisions the shared memory and enables dispatch; `use_shared_worker` (per session) then routes eligible queries to the worker.

## How it works

- **Sessions and seats.** A fixed pool of session slots lives in main shared memory, one per in-flight dispatched query. A backend that finds the pool full waits (cancellably) for a free seat rather than falling back to in-process execution -- a per-backend engine per overflow query is exactly the memory growth this exists to prevent. In-process execution happens only for statements the dispatch gate excludes by semantics.
- **PG-free worker.** The worker holds no PostgreSQL transaction or snapshot. Catalog binds go through a DescribeRel RPC answered by the backend; heap scans are inverted (produced on the backend, or in parallel by scan-producer workers over disjoint CTID block ranges under the shipped snapshot); DuckLake metadata SQL is remoted to the backend. This is what makes N concurrent sessions on one PostgreSQL background worker possible.
- **Zero-copy scan transport.** Heap tuples are converted straight into Arrow record batches in shared-memory pages that the worker's vectors reference directly (int2/4/8, float4/8, bool, date, timestamp[tz], text, bytea, decimals; anything else fails loudly naming the column). Per-column append functions are resolved once at batch setup, so the per-row loop has no type dispatch. With 4-8 scan producers, TPC-H Q1 over a 4M-row heap table runs 3-4x faster than in-process execution.
- **One channel per session, demultiplexed.** Scan replies carry a scan id and are routed into per-scan lanes; catalog and metadata replies into a serialized metadata lane -- so concurrent scans and mid-execution metadata RPCs (DuckLake reads on DuckDB scheduler threads) share the channel safely.
- **DuckLake writes stay atomic.** An autocommit INSERT/UPDATE/DELETE executes in the worker, but its DuckLake metadata commit runs on the requesting backend inside the backend's transaction, so the commit is atomic with the statement and commit conflicts surface as `TransactionException` for DuckLake's retry. Transactional writes and DDL stay in-process by design.
- **Lifecycle.** Dead workers are detected by pid probe and respawned on demand. Backend abort callbacks and process-exit hooks release sessions and shared pages in every ordering (including a longjmp mid-handshake or a producer dying while holding a page); the worker drains its session threads on any exit and interrupts cancelled queries. Code that runs in exactly one process type is namespaced accordingly: `pgddb::backend`, `pgddb::worker`, `pgddb::producer`; cross-process code stays in `pgddb`.

## What's in the series

1. `feat: shared-memory transports for the duckdb worker` -- session channel + demux, session pool, Arrow page pool and codec, scan task queue/rings, the RPC protocol, `RelationDesc`.
2. `feat: the duckdb worker base class in the kernel` -- the reusable `pgddb::DuckdbWorker` base class (registry, spawn/respawn, service loops, session threads, scan producers, cleanup) plus kernel catalog/scan/executor integration. `libpgduckdb/worker/DESIGN.md` and `GLOSSARY.md` document the architecture and its known limits.
3. `feat: pg_duckdb duckdb worker` -- thin subclass: dispatch gate (read-only heap SELECTs), GUCs, tests.
4. `feat: pg_ducklake duckdb worker` -- subclass dispatching SELECTs and autocommit DML, DuckLake metadata RPCs, the `ducklake.worker_stats()` test hook (1.1.0 SQL), tests.
5. `test: TLA+ models of the duckdb worker concurrency protocol` -- TLC-checked models of the session lifecycle, scan demux, and scan pool: 13 configs, 6 proving the invariants (including liveness of the capacity waits) and 7 bug-mode configs that reproduce, with a single constant flipped, the failure classes the implementation prevents.

## Configuration

Per extension (`duckdb.*` / `ducklake.*`): `use_shared_worker` (session, default off), `max_worker_sessions` (postmaster, default 0 = feature disabled, no shared memory reserved), `arrow_pool_pages` / `arrow_page_size` (scan-transport pool), `scan_pool_size` (scan-producer workers per database, 0 = produce on the requesting backend), `scan_producers` (per-scan parallelism), and for pg_duckdb `shared_worker_threads` (the worker engine's compute threads).

## Verification

- pg_duckdb regression 66/66; the `shared_worker` test covers off/on result parity, type coverage, unsupported-type failure, error surfacing, cancellation, and worker kill + respawn, running through the scan-producer pool in CI.
- pg_ducklake regression 52/52 (`worker_dispatch`: off/on parity including hybrid and temp-table joins and dispatched DML with read-back, dispatch-gate assertions via `ducklake.worker_stats()`; `worker_hardening`: failure paths), isolation 4/4 (`worker_concurrent_writes`), plus an e2e test driving concurrent readers and writers through one worker.
- `specs/tla`: all 13 TLC configs behave as documented.

Known limits are documented in `DESIGN.md` (planning still runs in each backend; scan producers blocking on heavyweight locks can form an undetectable lock-queue chain, mitigate with `lock_timeout`; a slow consumer pins its Arrow pages; the MetaExec durability window matches DuckLake's retry semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
