### PR TITLE
feat: optional Apache Arrow support via WITH_NANOARROW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,21 @@ PGDDB_OBJS := $(PGDDB_CPP_SRCS:.cpp=.o) $(PGDDB_C_SRCS:.c=.o)
 DUCKDB_GEN ?= ninja
 DUCKDB_VERSION = v1.5.4
 
-DUCKDB_CMAKE_VARS = -DCXX_EXTRA=-fvisibility=default -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0 -DOVERRIDE_GIT_DESCRIBE=$(DUCKDB_VERSION)
+# Optional Apache Arrow support via the bundled nanoarrow DuckDB extension.
+# Default OFF -- when enabled, the cmake EXTENSION_CONFIGS file selects the
+# nanoarrow extension and PG_DUCKDB_WITH_NANOARROW is defined for the C++
+# compile so read_arrow() routes to DuckDB rather than ereport'ing.
+WITH_NANOARROW ?= 0
+
+# Escape hatch for extra cmake vars to forward to the DuckDB build (e.g. to
+# pin SDK libcurl, or to opt in to a third-party extension).
+EXTRA_DUCKDB_CMAKE_VARS ?=
+
+ifeq ($(WITH_NANOARROW),1)
+    EXTRA_DUCKDB_CMAKE_VARS += -DWITH_NANOARROW=ON
+endif
+
+DUCKDB_CMAKE_VARS = -DCXX_EXTRA=-fvisibility=default -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0 -DOVERRIDE_GIT_DESCRIBE=$(DUCKDB_VERSION) $(EXTRA_DUCKDB_CMAKE_VARS)
 DUCKDB_DISABLE_ASSERTIONS ?= 0
 
 # Optional compiler cache (e.g. sccache) for the DuckDB build.
@@ -54,7 +68,7 @@ endif
 # duckdb extensions baked in.
 EXTENSION_CONFIGS ?=
 
-DUCKDB_BUILD_TAG := $(if $(EXTENSION_CONFIGS),$(basename $(notdir $(EXTENSION_CONFIGS)))-$(shell shasum -a 256 '$(EXTENSION_CONFIGS)' 2>/dev/null | cut -c1-8),default)
+DUCKDB_BUILD_TAG := $(if $(EXTENSION_CONFIGS),$(basename $(notdir $(EXTENSION_CONFIGS)))-$(shell shasum -a 256 '$(EXTENSION_CONFIGS)' 2>/dev/null | cut -c1-8),default)$(if $(filter 1,$(WITH_NANOARROW)),-arrow,)
 DUCKDB_BUILD_DIR := $(PGDDB_DIR)/duckdb/build/$(DUCKDB_BUILD_TYPE)-$(DUCKDB_BUILD_TAG)
 FULL_DUCKDB_LIB = $(DUCKDB_BUILD_DIR)/libduckdb_bundle.a
 
@@ -92,6 +106,11 @@ $(FULL_DUCKDB_LIB): $(PGDDB_DIR)/.git/modules/duckdb/HEAD $(EXTENSION_CONFIGS)
 		$(foreach n,$(EXTENSION_BUNDLE_EXCLUDE),-not -name 'lib$(n)_extension.a' -not -name 'lib$(n)_duckdb.a') \
 		-exec cp {} $(DUCKDB_BUILD_DIR)/bundle/. \;
 	find $(DUCKDB_BUILD_DIR)/vcpkg_installed -name '*.a' -exec cp {} $(DUCKDB_BUILD_DIR)/bundle/. \;
+	# Extensions vendored via cmake FetchContent (e.g. nanoarrow's libnanoarrow,
+	# libnanoarrow_ipc, libflatccrt) land under _deps/; bundle their archives too.
+	if [ -d $(DUCKDB_BUILD_DIR)/_deps ]; then \
+		find $(DUCKDB_BUILD_DIR)/_deps -name 'lib*.a' -exec cp {} $(DUCKDB_BUILD_DIR)/bundle/. \;; \
+	fi
 	cd $(DUCKDB_BUILD_DIR)/bundle && \
 		find . -name '*.a' -exec mkdir -p {}.objects \; -exec mv {} {}.objects \; && \
 		find . -name '*.a' -execdir $(AR) -x {} \;

--- a/pg_duckdb/Makefile
+++ b/pg_duckdb/Makefile
@@ -58,6 +58,12 @@ COMPILER_FLAGS=-Wno-sign-compare -Wshadow -Wswitch -Wunused-parameter -Wunreacha
 
 override PG_CPPFLAGS += -Iinclude $(PGDDB_INCLUDE) $(PGDDB_DUCKDB_INCLUDE) -isystem $(INCLUDEDIR_SERVER) ${COMPILER_FLAGS}
 override PG_CXXFLAGS += -std=c++17 ${DUCKDB_BUILD_CXX_FLAGS} ${COMPILER_FLAGS} -Wno-register -Weffc++
+
+# Opt-in Apache Arrow support (see root Makefile WITH_NANOARROW).
+ifeq ($(WITH_NANOARROW),1)
+    override PG_CPPFLAGS += -DPG_DUCKDB_WITH_NANOARROW=1
+    override PG_CXXFLAGS += -DPG_DUCKDB_WITH_NANOARROW=1
+endif
 # Ignore declaration-after-statement warnings in our code. Postgres enforces
 # this because their ancient style guide requires it, but we don't care. It
 # would only apply to C files anyway, and we don't have many of those. The only

--- a/pg_duckdb/pg_duckdb.control
+++ b/pg_duckdb/pg_duckdb.control
@@ -1,4 +1,4 @@
 comment = 'DuckDB Embedded in Postgres'
-default_version = '1.1.0'
+default_version = '1.2.0'
 module_pathname = '$libdir/pg_duckdb'
 relocatable = false

--- a/pg_duckdb/sql/pg_duckdb--1.1.0--1.2.0.sql
+++ b/pg_duckdb/sql/pg_duckdb--1.1.0--1.2.0.sql
@@ -1,0 +1,20 @@
+-- Apache Arrow file/stream reader (delegated to DuckDB's nanoarrow extension).
+--
+-- The SQL function is created unconditionally so user scripts can call
+-- read_arrow() regardless of how pg_duckdb was built. The underlying
+-- C function (pgduckdb_read_arrow) emits a friendly ereport when pg_duckdb
+-- was compiled without WITH_NANOARROW; when built with it, the planner
+-- hook routes the query to DuckDB where the bundled nanoarrow extension
+-- handles the read.
+
+CREATE FUNCTION @extschema@.read_arrow(path text)
+RETURNS SETOF duckdb.row
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'pgduckdb_read_arrow'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.read_arrow(path text[])
+RETURNS SETOF duckdb.row
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'pgduckdb_read_arrow'
+LANGUAGE C;

--- a/pg_duckdb/src/pgduckdb_hooks.cpp
+++ b/pg_duckdb/src/pgduckdb_hooks.cpp
@@ -415,7 +415,11 @@ static bool
 ContainsDuckdbRowReturningFunction(const char *query_string) {
 	return strstr(query_string, "read_parquet") || strstr(query_string, "read_csv") ||
 	       strstr(query_string, "read_json") || strstr(query_string, "delta_scan") ||
-	       strstr(query_string, "iceberg_scan") || strstr(query_string, "duckdb.query");
+	       strstr(query_string, "iceberg_scan") ||
+#ifdef PG_DUCKDB_WITH_NANOARROW
+	       strstr(query_string, "read_arrow") ||
+#endif
+	       strstr(query_string, "duckdb.query");
 }
 
 static void

--- a/pg_duckdb/src/pgduckdb_metadata_cache.cpp
+++ b/pg_duckdb/src/pgduckdb_metadata_cache.cpp
@@ -153,6 +153,9 @@ BuildDuckdbOnlyFunctions() {
 	                                "iceberg_snapshots",
 	                                "delta_scan",
 	                                "read_json",
+#ifdef PG_DUCKDB_WITH_NANOARROW
+	                                "read_arrow",
+#endif
 	                                "approx_count_distinct",
 	                                "query",
 	                                "view",

--- a/pg_duckdb/src/pgduckdb_options.cpp
+++ b/pg_duckdb/src/pgduckdb_options.cpp
@@ -298,6 +298,18 @@ DECLARE_PG_FUNCTION(duckdb_only_function) {
 	elog(ERROR, "Function '%s' only works with DuckDB execution", function_name);
 }
 
+DECLARE_PG_FUNCTION(pgduckdb_read_arrow) {
+#ifdef PG_DUCKDB_WITH_NANOARROW
+	char *function_name = DatumGetCString(DirectFunctionCall1(regprocout, fcinfo->flinfo->fn_oid));
+	elog(ERROR, "Function '%s' only works with DuckDB execution", function_name);
+#else
+	ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+	                errmsg("read_arrow() requires pg_duckdb built with Apache Arrow (nanoarrow) support"),
+	                errhint("Rebuild pg_duckdb with WITH_NANOARROW=1 to enable read_arrow().")));
+#endif
+	PG_RETURN_VOID();
+}
+
 DECLARE_PG_FUNCTION(duckdb_row_subscript) {
 	PG_RETURN_POINTER(&pgddb::pg::duckdb_row_subscript_routines);
 }

--- a/pg_duckdb/test/regression/expected/arrow.out
+++ b/pg_duckdb/test/regression/expected/arrow.out
@@ -1,0 +1,33 @@
+-- Apache Arrow support test.
+--
+-- pg_duckdb exposes read_arrow() unconditionally. When pg_duckdb is
+-- built with WITH_NANOARROW=1 the call is routed to DuckDB's bundled
+-- nanoarrow extension; otherwise the C function ereport's with a
+-- build-time hint instructing the user how to enable it.
+--
+-- pg_regress matches expected/arrow.out (default build, hint path) first,
+-- then expected/arrow_1.out (WITH_NANOARROW=1 build, success path).
+-- The SQL function ships in both builds (text and text[] overloads).
+SELECT proname, pg_get_function_arguments(p.oid)
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE proname = 'read_arrow' AND n.nspname = 'public'
+ORDER BY 2;
+  proname   | pg_get_function_arguments 
+------------+---------------------------
+ read_arrow | path text
+ read_arrow | path text[]
+(2 rows)
+
+-- Calling read_arrow():
+--   * Default build: our C function ereport's with the rebuild hint.
+--   * WITH_NANOARROW build: DuckDB attempts to open the path; the file
+--     does not exist, so DuckDB raises an IOException instead.
+SELECT r['x'] FROM read_arrow('/tmp/pgduckdb_no_such_file.arrows') r;
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Table Function with name read_arrow does not exist!
+Did you mean "read_parquet"?
+
+LINE 1: SELECT r.x FROM read_arrow('/tmp/pgduckdb_no_such_file.arrows'::text) r
+                        ^
+ERROR:  read_arrow() requires pg_duckdb built with Apache Arrow (nanoarrow) support
+HINT:  Rebuild pg_duckdb with WITH_NANOARROW=1 to enable read_arrow().

--- a/pg_duckdb/test/regression/expected/arrow_1.out
+++ b/pg_duckdb/test/regression/expected/arrow_1.out
@@ -1,0 +1,27 @@
+-- Apache Arrow support test.
+--
+-- pg_duckdb exposes read_arrow() unconditionally. When pg_duckdb is
+-- built with WITH_NANOARROW=1 the call is routed to DuckDB's bundled
+-- nanoarrow extension; otherwise the C function ereport's with a
+-- build-time hint instructing the user how to enable it.
+--
+-- pg_regress matches expected/arrow.out (default build, hint path) first,
+-- then expected/arrow_1.out (WITH_NANOARROW=1 build, success path).
+-- The SQL function ships in both builds (text and text[] overloads).
+SELECT proname, pg_get_function_arguments(p.oid)
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE proname = 'read_arrow' AND n.nspname = 'public'
+ORDER BY 2;
+  proname   | pg_get_function_arguments
+------------+---------------------------
+ read_arrow | path text
+ read_arrow | path text[]
+(2 rows)
+
+-- Calling read_arrow():
+--   * Default build: our C function ereport's with the rebuild hint.
+--   * WITH_NANOARROW build: DuckDB attempts to open the path; the file
+--     does not exist, so DuckDB raises an IOException instead.
+SELECT r['x'] FROM read_arrow('/tmp/pgduckdb_no_such_file.arrows') r;
+ERROR:  IO Error: No files found that match the pattern "/tmp/pgduckdb_no_such_file.arrows"

--- a/pg_duckdb/test/regression/expected/extensions_1.out
+++ b/pg_duckdb/test/regression/expected/extensions_1.out
@@ -1,0 +1,207 @@
+DROP EXTENSION pg_duckdb CASCADE;
+CREATE EXTENSION pg_duckdb;
+SET duckdb.force_execution TO false;
+SET duckdb.allow_community_extensions = true;
+SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installed_from FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
+ extension_name | loaded | installed | installed_from 
+----------------+--------+-----------+----------------
+ core_functions | t      | t         | 
+ httpfs         | t      | t         | 
+ icu            | t      | t         | 
+ json           | t      | t         | 
+ nanoarrow      | t      | t         | 
+ parquet        | t      | t         | 
+ pgduckdb       | t      | f         | 
+(7 rows)
+
+SELECT last_value FROM duckdb.extensions_table_seq;
+ last_value 
+------------
+          1
+(1 row)
+
+-- INSERT SHOULD TRIGGER UPDATE OF EXTENSIONS
+SELECT duckdb.install_extension('icu');
+ install_extension 
+-------------------
+ 
+(1 row)
+
+-- Increases the sequence twice because we use ON CONFLICT DO UPDATE. So
+-- the trigger fires for both INSERT and UPDATE internally.
+SELECT last_value FROM duckdb.extensions_table_seq;
+ last_value 
+------------
+          3
+(1 row)
+
+SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installed_from FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
+ extension_name | loaded | installed | installed_from 
+----------------+--------+-----------+----------------
+ core_functions | t      | t         | 
+ httpfs         | t      | t         | 
+ icu            | t      | t         | core
+ json           | t      | t         | 
+ nanoarrow      | t      | t         | 
+ parquet        | t      | t         | 
+ pgduckdb       | t      | f         | 
+(7 rows)
+
+-- Check that we can rerun this without issues
+SELECT duckdb.install_extension('icu');
+ install_extension 
+-------------------
+ 
+(1 row)
+
+-- Increases the sequence twice because we use ON CONFLICT DO UPDATE. So
+-- the trigger fires for both INSERT and UPDATE internally.
+SELECT last_value FROM duckdb.extensions_table_seq;
+ last_value 
+------------
+          5
+(1 row)
+
+SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installed_from FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
+ extension_name | loaded | installed | installed_from 
+----------------+--------+-----------+----------------
+ core_functions | t      | t         | 
+ httpfs         | t      | t         | 
+ icu            | t      | t         | core
+ json           | t      | t         | 
+ nanoarrow      | t      | t         | 
+ parquet        | t      | t         | 
+ pgduckdb       | t      | f         | 
+(7 rows)
+
+SELECT duckdb.install_extension('aws');
+ install_extension 
+-------------------
+ 
+(1 row)
+
+SELECT last_value FROM duckdb.extensions_table_seq;
+ last_value 
+------------
+          7
+(1 row)
+
+SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installed_from FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
+ extension_name | loaded | installed | installed_from 
+----------------+--------+-----------+----------------
+ aws            | t      | t         | core
+ core_functions | t      | t         | 
+ httpfs         | t      | t         | 
+ icu            | t      | t         | core
+ json           | t      | t         | 
+ nanoarrow      | t      | t         | 
+ parquet        | t      | t         | 
+ pgduckdb       | t      | f         | 
+(8 rows)
+
+-- autoload_extension and load_extension function should work as expected
+SELECT * FROM duckdb.query($$ FROM duckdb_extensions() SELECT installed, loaded WHERE extension_name = 'aws' $$);
+ installed | loaded 
+-----------+--------
+ t         | t
+(1 row)
+
+SELECT duckdb.autoload_extension('aws', 'false');
+ autoload_extension 
+--------------------
+ 
+(1 row)
+
+CALL duckdb.recycle_ddb();
+SELECT * FROM duckdb.query($$ FROM duckdb_extensions() SELECT installed, loaded WHERE extension_name = 'aws' $$);
+ installed | loaded 
+-----------+--------
+ t         | f
+(1 row)
+
+SELECT duckdb.load_extension('aws');
+ load_extension 
+----------------
+ 
+(1 row)
+
+SELECT * FROM duckdb.query($$ FROM duckdb_extensions() SELECT installed, loaded WHERE extension_name = 'aws' $$);
+ installed | loaded 
+-----------+--------
+ t         | t
+(1 row)
+
+-- Turning it back on should autoload it again
+SELECT duckdb.autoload_extension('aws', 'true');
+ autoload_extension 
+--------------------
+ 
+(1 row)
+
+CALL duckdb.recycle_ddb();
+SELECT * FROM duckdb.query($$ FROM duckdb_extensions() SELECT installed, loaded WHERE extension_name = 'aws' $$);
+ installed | loaded 
+-----------+--------
+ t         | t
+(1 row)
+
+-- Autoloading is only supported for already known extensions
+SELECT duckdb.autoload_extension('doesnotexist', 'true');
+ERROR:  (PGDuckDB/duckdb_autoload_extension_cpp) Invalid Input Error: Extension 'doesnotexist' does not exist
+-- DELETE SHOULD TRIGGER UPDATE OF EXTENSIONS
+DELETE FROM duckdb.extensions WHERE name = 'aws';
+SELECT last_value FROM duckdb.extensions_table_seq;
+ last_value 
+------------
+         11
+(1 row)
+
+SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installed_from FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
+ extension_name | loaded | installed | installed_from 
+----------------+--------+-----------+----------------
+ aws            | t      | t         | core
+ core_functions | t      | t         | 
+ httpfs         | t      | t         | 
+ icu            | t      | t         | core
+ json           | t      | t         | 
+ nanoarrow      | t      | t         | 
+ parquet        | t      | t         | 
+ pgduckdb       | t      | f         | 
+(8 rows)
+
+-- Reconnecting should cause the extension not to be loaded anymore
+CALL duckdb.recycle_ddb();
+SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installed_from FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
+ extension_name | loaded | installed | installed_from 
+----------------+--------+-----------+----------------
+ core_functions | t      | t         | 
+ httpfs         | t      | t         | 
+ icu            | t      | t         | core
+ json           | t      | t         | 
+ nanoarrow      | t      | t         | 
+ parquet        | t      | t         | 
+ pgduckdb       | t      | f         | 
+(7 rows)
+
+-- TODO: re-enable when community extensions are published for v1.5.2
+-- SELECT duckdb.install_extension('quack', 'community');
+SELECT last_value FROM duckdb.extensions_table_seq;
+ last_value 
+------------
+         11
+(1 row)
+
+SELECT * FROM duckdb.query($$ SELECT extension_name, loaded, installed, installed_from FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
+ extension_name | loaded | installed | installed_from 
+----------------+--------+-----------+----------------
+ core_functions | t      | t         | 
+ httpfs         | t      | t         | 
+ icu            | t      | t         | core
+ json           | t      | t         | 
+ nanoarrow      | t      | t         | 
+ parquet        | t      | t         | 
+ pgduckdb       | t      | f         | 
+(7 rows)
+
+-- cleanup
+TRUNCATE duckdb.extensions;

--- a/pg_duckdb/test/regression/schedule
+++ b/pg_duckdb/test/regression/schedule
@@ -3,6 +3,7 @@ test: altered_tables
 test: approx_count_distinct
 test: array_problems
 test: array_type_support
+test: arrow
 test: basic
 test: case_insensitivity
 test: concurrency

--- a/pg_duckdb/test/regression/sql/arrow.sql
+++ b/pg_duckdb/test/regression/sql/arrow.sql
@@ -1,0 +1,22 @@
+-- Apache Arrow support test.
+--
+-- pg_duckdb exposes read_arrow() unconditionally. When pg_duckdb is
+-- built with WITH_NANOARROW=1 the call is routed to DuckDB's bundled
+-- nanoarrow extension; otherwise the C function ereport's with a
+-- build-time hint instructing the user how to enable it.
+--
+-- pg_regress matches expected/arrow.out (default build, hint path) first,
+-- then expected/arrow_1.out (WITH_NANOARROW=1 build, success path).
+
+-- The SQL function ships in both builds (text and text[] overloads).
+SELECT proname, pg_get_function_arguments(p.oid)
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE proname = 'read_arrow' AND n.nspname = 'public'
+ORDER BY 2;
+
+-- Calling read_arrow():
+--   * Default build: our C function ereport's with the rebuild hint.
+--   * WITH_NANOARROW build: DuckDB attempts to open the path; the file
+--     does not exist, so DuckDB raises an IOException instead.
+SELECT r['x'] FROM read_arrow('/tmp/pgduckdb_no_such_file.arrows') r;

--- a/pg_duckdb/third_party/pg_duckdb_extensions.cmake
+++ b/pg_duckdb/third_party/pg_duckdb_extensions.cmake
@@ -4,3 +4,13 @@ duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG 9de3296f40ed03e8e063394887f0d6a46144e847
 )
+
+# Optional Apache Arrow support: bundle paleolimbot/duckdb-nanoarrow so
+# read_arrow() works on .arrow / .arrows files (and streams via httpfs).
+# Toggled via the WITH_NANOARROW make/cmake variable; default OFF.
+if(WITH_NANOARROW)
+    duckdb_extension_load(nanoarrow
+        GIT_URL https://github.com/paleolimbot/duckdb-nanoarrow
+        GIT_TAG 42e4199a67c4cd0789087562a025e87e7130fdc3
+    )
+endif()


### PR DESCRIPTION
## Summary
- add WITH_NANOARROW build flag for optional Apache Arrow support
- wire pg_duckdb Arrow extension registration and metadata options
- add regression coverage for Arrow behavior and extension listing
- #210 is a previous PR with non-conditional Arrow support, it was closed per discussion with maintainer 

## Testing
- not run in this session