### PR TITLE
fix: data loss when inlined-data flush races concurrent inserts

### DIFF
--- a/pg_ducklake/src/maintenance_worker.cpp
+++ b/pg_ducklake/src/maintenance_worker.cpp
@@ -130,13 +130,21 @@ Q(const std::string &s) {
 	return duckdb::KeywordHelper::WriteQuoted(s, '\'');
 }
 
-/* Phase 1: in-process maintenance (needs PG backend). */
+/*
+ * Phase 1: in-process maintenance (needs PG backend).
+ *
+ * Every helper returns false on failure and the caller must then ABORT the
+ * PG transaction: DuckLake maintenance functions issue metadata writes via
+ * SPI as they execute (e.g. the flush deletes inlined rows before its
+ * DuckLake commit), so committing after a failure persists those writes
+ * without the rest of the operation -- silent data loss (issue #215).
+ */
 
 /* Flush inlined data from PG metadata tables to parquet files. */
-void
+bool
 MaintainTableInProcess(const char *schema_name, const char *table_name) {
 	if (!pgducklake::maintenance_flush_inlined_data)
-		return;
+		return true;
 
 	std::string query = "SELECT * FROM ducklake_flush_inlined_data(" + Q(PGDUCKLAKE_DUCKDB_CATALOG) +
 	                    ", schema_name=" + Q(schema_name) + ", table_name=" + Q(table_name) + ")";
@@ -145,21 +153,25 @@ MaintainTableInProcess(const char *schema_name, const char *table_name) {
 	} catch (const std::exception &e) {
 		elog(WARNING, "ducklake maintenance: flush_inlined_data failed for \"%s\".\"%s\": %s", schema_name, table_name,
 		     pgducklake::DuckDBErrorMessage(e).c_str());
+		return false;
 	}
+	return true;
 }
 
 /* Expire old snapshots (pure metadata update, no file I/O). */
-void
+bool
 MaintainCatalogInProcess() {
 	if (!pgducklake::maintenance_expire_snapshots)
-		return;
+		return true;
 
 	std::string query = "SELECT * FROM ducklake_expire_snapshots(" + Q(PGDUCKLAKE_DUCKDB_CATALOG) + ")";
 	try {
 		pgducklake::DuckDBQueryOrThrow(query);
 	} catch (const std::exception &e) {
 		elog(WARNING, "ducklake maintenance: expire_snapshots failed: %s", pgducklake::DuckDBErrorMessage(e).c_str());
+		return false;
 	}
+	return true;
 }
 
 /*
@@ -169,7 +181,7 @@ MaintainCatalogInProcess() {
  */
 
 /* Rewrite data files (remove deleted rows) + merge small files. */
-void
+bool
 CompactTable(const char *schema_name, const char *table_name) {
 	std::string db(PGDUCKLAKE_DUCKDB_CATALOG);
 	std::string schema(schema_name);
@@ -184,6 +196,7 @@ CompactTable(const char *schema_name, const char *table_name) {
 		} catch (const std::exception &e) {
 			elog(WARNING, "ducklake maintenance: rewrite_data_files failed for \"%s\".\"%s\": %s", schema_name,
 			     table_name, pgducklake::DuckDBErrorMessage(e).c_str());
+			return false;
 		}
 	}
 
@@ -195,15 +208,17 @@ CompactTable(const char *schema_name, const char *table_name) {
 		} catch (const std::exception &e) {
 			elog(WARNING, "ducklake maintenance: merge_adjacent_files failed for \"%s\".\"%s\": %s", schema_name,
 			     table_name, pgducklake::DuckDBErrorMessage(e).c_str());
+			return false;
 		}
 	}
+	return true;
 }
 
 /* Remove unreferenced data files from storage. */
-void
+bool
 CompactCatalog() {
 	if (!pgducklake::maintenance_cleanup_old_files)
-		return;
+		return true;
 
 	std::string query =
 	    "SELECT * FROM ducklake_cleanup_old_files(" + Q(PGDUCKLAKE_DUCKDB_CATALOG) + ", cleanup_all => true)";
@@ -211,7 +226,9 @@ CompactCatalog() {
 		pgducklake::DuckDBQueryOrThrow(query);
 	} catch (const std::exception &e) {
 		elog(WARNING, "ducklake maintenance: cleanup_old_files failed: %s", pgducklake::DuckDBErrorMessage(e).c_str());
+		return false;
 	}
+	return true;
 }
 
 } // anonymous namespace
@@ -298,16 +315,19 @@ ducklake_maintenance_worker_main(Datum main_arg) {
 		CommitTransactionCommand();
 	}
 
-	/* Phase 1: in-process maintenance (must run inside the PG backend). */
+	/* Phase 1: in-process maintenance (must run inside the PG backend).
+	 * On failure ABORT the transaction: the failed operation may have issued
+	 * SPI writes that must not outlive it (see the phase-1 helper comment). */
 	for (int i = 0; i < ntables; i++) {
 		CHECK_FOR_INTERRUPTS();
 
 		StartTransactionCommand();
 		PushActiveSnapshot(GetTransactionSnapshot());
 
+		volatile bool ok = false;
 		PG_TRY();
 		{
-			MaintainTableInProcess(schemas[i], tables[i]);
+			ok = MaintainTableInProcess(schemas[i], tables[i]);
 		}
 		PG_CATCH();
 		{
@@ -325,7 +345,10 @@ ducklake_maintenance_worker_main(Datum main_arg) {
 		PG_END_TRY();
 
 		PopActiveSnapshot();
-		CommitTransactionCommand();
+		if (ok)
+			CommitTransactionCommand();
+		else
+			AbortCurrentTransaction();
 	}
 
 	{
@@ -333,9 +356,10 @@ ducklake_maintenance_worker_main(Datum main_arg) {
 		StartTransactionCommand();
 		PushActiveSnapshot(GetTransactionSnapshot());
 
+		volatile bool ok = false;
 		PG_TRY();
 		{
-			MaintainCatalogInProcess();
+			ok = MaintainCatalogInProcess();
 		}
 		PG_CATCH();
 		{
@@ -353,7 +377,10 @@ ducklake_maintenance_worker_main(Datum main_arg) {
 		PG_END_TRY();
 
 		PopActiveSnapshot();
-		CommitTransactionCommand();
+		if (ok)
+			CommitTransactionCommand();
+		else
+			AbortCurrentTransaction();
 	}
 
 	/* Phase 2: compaction. TODO: offload to an external DuckDB process. */
@@ -365,9 +392,10 @@ ducklake_maintenance_worker_main(Datum main_arg) {
 		StartTransactionCommand();
 		PushActiveSnapshot(GetTransactionSnapshot());
 
+		volatile bool ok = false;
 		PG_TRY();
 		{
-			CompactTable(schemas[i], tables[i]);
+			ok = CompactTable(schemas[i], tables[i]);
 		}
 		PG_CATCH();
 		{
@@ -385,7 +413,10 @@ ducklake_maintenance_worker_main(Datum main_arg) {
 		PG_END_TRY();
 
 		PopActiveSnapshot();
-		CommitTransactionCommand();
+		if (ok)
+			CommitTransactionCommand();
+		else
+			AbortCurrentTransaction();
 	}
 
 	{
@@ -393,9 +424,10 @@ ducklake_maintenance_worker_main(Datum main_arg) {
 		StartTransactionCommand();
 		PushActiveSnapshot(GetTransactionSnapshot());
 
+		volatile bool ok = false;
 		PG_TRY();
 		{
-			CompactCatalog();
+			ok = CompactCatalog();
 		}
 		PG_CATCH();
 		{
@@ -413,7 +445,10 @@ ducklake_maintenance_worker_main(Datum main_arg) {
 		PG_END_TRY();
 
 		PopActiveSnapshot();
-		CommitTransactionCommand();
+		if (ok)
+			CommitTransactionCommand();
+		else
+			AbortCurrentTransaction();
 	}
 
 	for (int i = 0; i < ntables; i++) {

--- a/pg_ducklake/src/pgducklake_metadata_manager.cpp
+++ b/pg_ducklake/src/pgducklake_metadata_manager.cpp
@@ -748,13 +748,15 @@ CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int64_t r
 		elog(ERROR, "CreateSnapshotForDirectInsert: failed to insert snapshot: %d", ret);
 	}
 
+	/* Must be spelled 'inlined_insert:<table_id>': DuckLake's ParseChangesMade
+	 * rejects unknown change types, aborting any concurrent commit retry. */
 	StringInfoData changes_insert;
 	initStringInfo(&changes_insert);
 	appendStringInfo(&changes_insert,
 	                 "INSERT INTO ducklake.ducklake_snapshot_changes "
 	                 "(snapshot_id, changes_made, author, commit_message, commit_extra_info) "
-	                 "VALUES (%llu, 'inlined_data_insert', NULL, NULL, NULL)",
-	                 (unsigned long long)snapshot_id);
+	                 "VALUES (%llu, 'inlined_insert:%llu', NULL, NULL, NULL)",
+	                 (unsigned long long)snapshot_id, (unsigned long long)table_id);
 
 	elog(DEBUG1, "CreateSnapshotForDirectInsert: executing %s", changes_insert.data);
 	ret = SPI_execute(changes_insert.data, false, 0);

--- a/pg_ducklake/test/isolation/expected/concurrent_inline_flush.out
+++ b/pg_ducklake/test/isolation/expected/concurrent_inline_flush.out
@@ -1,0 +1,91 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1_begin s1_pin s1_flush s1_commit s1_count s1_inlined s1_files
+step s1_begin: BEGIN;
+step s1_pin: SELECT count(*) FROM iso_inline_flush_t;
+count
+-----
+    3
+(1 row)
+
+step s1_flush: SELECT * FROM ducklake.flush_inlined_data('iso_inline_flush_t'::regclass);
+schema_name|table_name        |rows_flushed
+-----------+------------------+------------
+public     |iso_inline_flush_t|           3
+(1 row)
+
+step s1_commit: COMMIT;
+step s1_count: SELECT count(*) FROM iso_inline_flush_t;
+count
+-----
+    3
+(1 row)
+
+step s1_inlined: 
+  SELECT row_id, live, id, val FROM iso_inline_flush_inlined ORDER BY row_id;
+
+row_id|live|id|val
+------+----+--+---
+(0 rows)
+
+step s1_files: 
+  SELECT ddf.record_count, ddf.end_snapshot IS NULL AS live
+  FROM ducklake.ducklake_data_file ddf
+  JOIN ducklake.ducklake_table dt ON ddf.table_id = dt.table_id
+  WHERE dt.table_name = 'iso_inline_flush_t' AND dt.end_snapshot IS NULL
+  ORDER BY ddf.data_file_id;
+
+record_count|live
+------------+----
+           3|t   
+(1 row)
+
+
+starting permutation: s1_begin s1_pin s2_insert s1_flush s1_commit s1_count s2_count s1_inlined s1_files
+step s1_begin: BEGIN;
+step s1_pin: SELECT count(*) FROM iso_inline_flush_t;
+count
+-----
+    3
+(1 row)
+
+step s2_insert: INSERT INTO iso_inline_flush_t VALUES (4, 'd');
+step s1_flush: SELECT * FROM ducklake.flush_inlined_data('iso_inline_flush_t'::regclass);
+schema_name|table_name        |rows_flushed
+-----------+------------------+------------
+public     |iso_inline_flush_t|           3
+(1 row)
+
+step s1_commit: COMMIT;
+step s1_count: SELECT count(*) FROM iso_inline_flush_t;
+count
+-----
+    4
+(1 row)
+
+step s2_count: SELECT count(*) FROM iso_inline_flush_t;
+count
+-----
+    4
+(1 row)
+
+step s1_inlined: 
+  SELECT row_id, live, id, val FROM iso_inline_flush_inlined ORDER BY row_id;
+
+row_id|live|id|val
+------+----+--+---
+     3|t   | 4|d  
+(1 row)
+
+step s1_files: 
+  SELECT ddf.record_count, ddf.end_snapshot IS NULL AS live
+  FROM ducklake.ducklake_data_file ddf
+  JOIN ducklake.ducklake_table dt ON ddf.table_id = dt.table_id
+  WHERE dt.table_name = 'iso_inline_flush_t' AND dt.end_snapshot IS NULL
+  ORDER BY ddf.data_file_id;
+
+record_count|live
+------------+----
+           3|t   
+(1 row)
+

--- a/pg_ducklake/test/isolation/schedule
+++ b/pg_ducklake/test/isolation/schedule
@@ -1,3 +1,4 @@
 test: explicit_transaction_commit
 test: concurrent_writes
 test: concurrent_cross_table_writes
+test: concurrent_inline_flush

--- a/pg_ducklake/test/isolation/specs/concurrent_inline_flush.spec
+++ b/pg_ducklake/test/isolation/specs/concurrent_inline_flush.spec
@@ -1,0 +1,73 @@
+# Inlined-data flush racing a concurrent fast-path (direct) insert.
+# The insert commits a snapshot between the flush's snapshot pin and its
+# commit, so the flush commit collides on the snapshot id and must retry;
+# the retry parses the concurrent snapshot's changes_made.  No rows may be
+# lost (issue #215).
+
+setup
+{
+  CALL ducklake.set_option('data_inlining_row_limit', 100);
+  CREATE TABLE iso_inline_flush_t (id int, val text) USING ducklake;
+  INSERT INTO iso_inline_flush_t VALUES (1, 'a'), (2, 'b');
+  INSERT INTO iso_inline_flush_t VALUES (3, 'c');
+}
+
+# separate block: the previous block is one implicit transaction, so the
+# ducklake metadata written at its commit is only visible from here on
+setup
+{
+  DO $$
+  DECLARE tname text;
+  BEGIN
+    SELECT it.table_name INTO STRICT tname
+    FROM ducklake.ducklake_inlined_data_tables it
+    JOIN ducklake.ducklake_table t ON t.table_id = it.table_id
+    WHERE t.table_name = 'iso_inline_flush_t' AND t.end_snapshot IS NULL
+    ORDER BY it.schema_version DESC LIMIT 1;
+    EXECUTE format('CREATE VIEW iso_inline_flush_inlined AS '
+                   'SELECT row_id, end_snapshot IS NULL AS live, id, '
+                   'convert_from(val, ''UTF8'') AS val FROM ducklake.%I', tname);
+  END $$;
+}
+
+session s1
+step s1_begin  { BEGIN; }
+step s1_pin    { SELECT count(*) FROM iso_inline_flush_t; }
+step s1_flush  { SELECT * FROM ducklake.flush_inlined_data('iso_inline_flush_t'::regclass); }
+step s1_commit { COMMIT; }
+step s1_count  { SELECT count(*) FROM iso_inline_flush_t; }
+# metadata state: raw inlined-data rows and data files (snapshot ids omitted,
+# they depend on the position in the schedule)
+step s1_inlined {
+  SELECT row_id, live, id, val FROM iso_inline_flush_inlined ORDER BY row_id;
+}
+step s1_files {
+  SELECT ddf.record_count, ddf.end_snapshot IS NULL AS live
+  FROM ducklake.ducklake_data_file ddf
+  JOIN ducklake.ducklake_table dt ON ddf.table_id = dt.table_id
+  WHERE dt.table_name = 'iso_inline_flush_t' AND dt.end_snapshot IS NULL
+  ORDER BY ddf.data_file_id;
+}
+
+session s2
+# autocommit: must not be in a transaction block so the direct-insert fast
+# path engages and commits its own snapshot
+step s2_insert { INSERT INTO iso_inline_flush_t VALUES (4, 'd'); }
+step s2_count  { SELECT count(*) FROM iso_inline_flush_t; }
+
+teardown
+{
+  DROP VIEW iso_inline_flush_inlined;
+  DROP TABLE iso_inline_flush_t;
+  CALL ducklake.set_option('data_inlining_row_limit', 0);
+}
+
+# Flush with no concurrency: sanity baseline -- all inlined rows move to one
+# data file, the inlined table drains
+permutation s1_begin s1_pin s1_flush s1_commit s1_count s1_inlined s1_files
+
+# A direct insert commits after the flush transaction pinned its snapshot:
+# the flush commit retries past the snapshot-id collision and both the
+# flushed rows and the concurrently inserted row survive -- the setup rows
+# land in a data file, the concurrent row stays inlined
+permutation s1_begin s1_pin s2_insert s1_flush s1_commit s1_count s2_count s1_inlined s1_files

--- a/pg_ducklake/test/regression/expected/snapshots.out
+++ b/pg_ducklake/test/regression/expected/snapshots.out
@@ -17,8 +17,41 @@ SELECT count(*) FROM ducklake.last_committed_snapshot();
      1
 (1 row)
 
--- Note: snapshots() is not tested in the full suite because it iterates all
--- catalog snapshots, including those from prior tests that may contain
--- inlined_data_insert changes (an upstream DuckLake limitation).
+-- 3. Direct-insert (fast path) snapshots record changes DuckLake can parse
+-- (issue #215: 'inlined_data_insert' broke flush commit retries and snapshots()).
+CALL ducklake.set_option('data_inlining_row_limit', 100);
+CREATE TABLE snap_inline (id int) USING ducklake;
+INSERT INTO snap_inline VALUES (1);  -- creates the inlined data table
+SELECT ducklake.reset_direct_insert_stats();
+ reset_direct_insert_stats 
+---------------------------
+ 
+(1 row)
+
+INSERT INTO snap_inline VALUES (2);
+-- confirm the fast path actually handled the insert above
+SELECT pattern, reason, count FROM ducklake.direct_insert_stats() WHERE count > 0;
+    pattern     | reason | count 
+----------------+--------+-------
+ matched_values | ok     |     1
+(1 row)
+
+SELECT changes_made ~ '^inlined_insert:\d+$' AS direct_insert_changes_parseable
+FROM ducklake.ducklake_snapshot_changes ORDER BY snapshot_id DESC LIMIT 1;
+ direct_insert_changes_parseable 
+---------------------------------
+ t
+(1 row)
+
+-- 4. snapshots() parses changes_made of every catalog snapshot, including
+-- the direct-insert ones just created
+SELECT count(*) > 0 AS has_snapshots FROM ducklake.snapshots();
+ has_snapshots 
+---------------
+ t
+(1 row)
+
+CALL ducklake.set_option('data_inlining_row_limit', 0);
 -- Cleanup
 DROP TABLE snap_test;
+DROP TABLE snap_inline;

--- a/pg_ducklake/test/regression/sql/snapshots.sql
+++ b/pg_ducklake/test/regression/sql/snapshots.sql
@@ -11,9 +11,24 @@ SELECT count(*) FROM ducklake.current_snapshot();
 -- 2. last_committed_snapshot() returns a single row
 SELECT count(*) FROM ducklake.last_committed_snapshot();
 
--- Note: snapshots() is not tested in the full suite because it iterates all
--- catalog snapshots, including those from prior tests that may contain
--- inlined_data_insert changes (an upstream DuckLake limitation).
+-- 3. Direct-insert (fast path) snapshots record changes DuckLake can parse
+-- (issue #215: 'inlined_data_insert' broke flush commit retries and snapshots()).
+CALL ducklake.set_option('data_inlining_row_limit', 100);
+CREATE TABLE snap_inline (id int) USING ducklake;
+INSERT INTO snap_inline VALUES (1);  -- creates the inlined data table
+SELECT ducklake.reset_direct_insert_stats();
+INSERT INTO snap_inline VALUES (2);
+-- confirm the fast path actually handled the insert above
+SELECT pattern, reason, count FROM ducklake.direct_insert_stats() WHERE count > 0;
+SELECT changes_made ~ '^inlined_insert:\d+$' AS direct_insert_changes_parseable
+FROM ducklake.ducklake_snapshot_changes ORDER BY snapshot_id DESC LIMIT 1;
+
+-- 4. snapshots() parses changes_made of every catalog snapshot, including
+-- the direct-insert ones just created
+SELECT count(*) > 0 AS has_snapshots FROM ducklake.snapshots();
+
+CALL ducklake.set_option('data_inlining_row_limit', 0);
 
 -- Cleanup
 DROP TABLE snap_test;
+DROP TABLE snap_inline;


### PR DESCRIPTION
## What happened

With data inlining enabled and continuous ingest through the direct-insert/COPY fast path, the maintenance worker's `flush_inlined_data` intermittently logged

```
WARNING: ducklake maintenance: flush_inlined_data failed ...: Failed to commit DuckLake transaction.
    Unsupported change type inlined_data_insert
```

and rows silently disappeared (the reporter lost ~90k of 316k rows; whole partition days vanished).

## Root cause

1. Ducklake spec drift. `CreateSnapshotForDirectInsert` recorded `changes_made = 'inlined_data_insert'`, but DuckLake 1.0 change to `inlined_insert:<table_id>`.

2. Worker committed after failure. The maintenance worker caught the commit failure, logged the WARNING, and committed the PG transaction anyway.

## Fix

- Align spec drift.
- Maintenance worker phase helpers report failure and the worker aborts its PG transaction instead of committing, so mid-operation SPI writes of a failed flush/expire/compaction can never outlive the failure.

Fixes #215.
