### PR TITLE
fix: direct-insert fast path metadata commit protocol drift

### DIFF
--- a/pg_ducklake/src/copy_from.cpp
+++ b/pg_ducklake/src/copy_from.cpp
@@ -209,7 +209,29 @@ DucklakeCopyFromStdin(CopyStmt *stmt, const char *query_string) {
 
 	if (rows_inserted > 0) {
 		SkipSnapshotSyncGuard sync_guard;
-		CreateSnapshotForDirectInsert(begin_snapshot, table_id, rows_inserted);
+		/* Concurrent commits race on MAX(snapshot_id)+1; the loser hits 23505.
+		 * Translate to 40001 so client retry adapters retry transparently
+		 * (mirrors DirectInsert_ExecCustomScan). */
+		MemoryContext old_ctx = CurrentMemoryContext;
+		PG_TRY();
+		{
+			CreateSnapshotForDirectInsert(begin_snapshot, table_id, rows_inserted);
+		}
+		PG_CATCH();
+		{
+			MemoryContextSwitchTo(old_ctx);
+			ErrorData *edata = CopyErrorData();
+			if (edata->sqlerrcode == ERRCODE_UNIQUE_VIOLATION) {
+				FreeErrorData(edata);
+				FlushErrorState();
+				ereport(ERROR,
+				        (errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+				         errmsg("ducklake COPY: snapshot_id allocation lost the race"), errhint("Retry the COPY.")));
+			}
+			FreeErrorData(edata);
+			PG_RE_THROW();
+		}
+		PG_END_TRY();
 		CommandCounterIncrement();
 	}
 

--- a/pg_ducklake/src/pgducklake_metadata_manager.cpp
+++ b/pg_ducklake/src/pgducklake_metadata_manager.cpp
@@ -732,6 +732,10 @@ CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int64_t r
 		}
 	}
 
+	/* next_file_id + 1 mirrors upstream's inlined-only commits: DuckLake keys
+	 * its table-stats cache on (next_file_id, schema_version, table_id), so a
+	 * data change that does not advance it leaves stale cached stats (and a
+	 * later normal-path commit would reuse row ids from the stale next_row_id). */
 	StringInfoData snapshot_insert;
 	initStringInfo(&snapshot_insert);
 	appendStringInfo(&snapshot_insert,
@@ -740,7 +744,7 @@ CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int64_t r
 	                 "next_file_id) "
 	                 "VALUES (%llu, NOW(), %llu, %llu, %llu)",
 	                 (unsigned long long)snapshot_id, (unsigned long long)schema_version,
-	                 (unsigned long long)next_catalog_id, (unsigned long long)next_file_id);
+	                 (unsigned long long)next_catalog_id, (unsigned long long)(next_file_id + 1));
 
 	elog(DEBUG1, "CreateSnapshotForDirectInsert: executing %s", snapshot_insert.data);
 	ret = SPI_execute(snapshot_insert.data, false, 0);
@@ -810,6 +814,23 @@ CreateSnapshotForDirectInsert(uint64_t snapshot_id, uint64_t table_id, int64_t r
 
 		elog(DEBUG1, "CreateSnapshotForDirectInsert: created new stats row for table %llu",
 		     (unsigned long long)table_id);
+	} else {
+		/* Degrade column stats to unknown: the fast path does not compute
+		 * min/max/null flags, and stale claims would let DuckLake readers
+		 * prune rows this insert just added. */
+		StringInfoData col_stats_degrade;
+		initStringInfo(&col_stats_degrade);
+		appendStringInfo(&col_stats_degrade,
+		                 "UPDATE ducklake.ducklake_table_column_stats "
+		                 "SET contains_null = NULL, contains_nan = NULL, "
+		                 "min_value = NULL, max_value = NULL, extra_stats = NULL "
+		                 "WHERE table_id = %llu",
+		                 (unsigned long long)table_id);
+
+		ret = SPI_execute(col_stats_degrade.data, false, 0);
+		if (ret != SPI_OK_UPDATE) {
+			elog(ERROR, "CreateSnapshotForDirectInsert: failed to degrade column stats: %d", ret);
+		}
 	}
 
 	SPI_finish();

--- a/pg_ducklake/test/regression/expected/direct_insert_metadata.out
+++ b/pg_ducklake/test/regression/expected/direct_insert_metadata.out
@@ -1,0 +1,144 @@
+-- Direct-insert (fast path) metadata commit protocol.
+-- The fast path hand-writes the DuckLake commit; these tests pin the parts of
+-- the protocol other DuckLake machinery relies on.
+CALL ducklake.set_option('data_inlining_row_limit', 100);
+-- ============================================================
+-- 1. next_file_id must advance on a fast-path commit
+-- ============================================================
+-- DuckLake keys its table-stats cache on (next_file_id, schema_version,
+-- table_id) and bumps next_file_id on inlined-only commits to signal a data
+-- change. A fast-path commit that carries it forward leaves stale cached
+-- stats (next_row_id, record_count, min/max) in every open DuckDB instance.
+CREATE TABLE dim_t (id int, val text) USING ducklake;
+INSERT INTO dim_t VALUES (0, 'seed');  -- normal path: creates the inlined data table
+SELECT next_file_id AS file_id_before
+FROM ducklake.ducklake_snapshot ORDER BY snapshot_id DESC LIMIT 1 \gset
+SELECT ducklake.reset_direct_insert_stats();
+ reset_direct_insert_stats 
+---------------------------
+ 
+(1 row)
+
+INSERT INTO dim_t VALUES (1, 'fast');
+-- fast path handled the insert above
+SELECT pattern, reason, count FROM ducklake.direct_insert_stats() WHERE count > 0;
+    pattern     | reason | count 
+----------------+--------+-------
+ matched_values | ok     |     1
+(1 row)
+
+SELECT next_file_id > :file_id_before AS file_id_advanced
+FROM ducklake.ducklake_snapshot ORDER BY snapshot_id DESC LIMIT 1;
+ file_id_advanced 
+------------------
+ t
+(1 row)
+
+-- ============================================================
+-- 2. row ids must stay unique when fast-path and normal-path
+--    inserts interleave
+-- ============================================================
+-- Load this backend's DuckDB table-stats cache, then advance next_row_id
+-- through the fast path (PG metadata only). The normal-path insert below
+-- must not seed its row ids from the stale cache entry.
+SELECT count(*) FROM dim_t WHERE id >= 0;
+ count 
+-------
+     2
+(1 row)
+
+INSERT INTO dim_t VALUES (2, 'fast2');
+BEGIN;  -- transaction block: fast path disengages, normal DuckLake path
+INSERT INTO dim_t VALUES (3, 'slow');
+COMMIT;
+SELECT it.table_name AS dim_inl
+FROM ducklake.ducklake_inlined_data_tables it
+JOIN ducklake.ducklake_table t USING (table_id)
+WHERE t.table_name = 'dim_t' AND t.end_snapshot IS NULL
+ORDER BY it.schema_version DESC LIMIT 1 \gset
+SELECT row_id, count(*) AS dup_count
+FROM ducklake.:dim_inl GROUP BY row_id HAVING count(*) > 1;
+ row_id | dup_count 
+--------+-----------
+(0 rows)
+
+SELECT count(*) AS inlined_rows, count(DISTINCT row_id) AS distinct_row_ids
+FROM ducklake.:dim_inl;
+ inlined_rows | distinct_row_ids 
+--------------+------------------
+            4 |                4
+(1 row)
+
+-- deleting one row must not take an unrelated row with it
+DELETE FROM dim_t WHERE id = 3;
+SELECT * FROM dim_t ORDER BY id;
+ id |  val  
+----+-------
+  0 | seed
+  1 | fast
+  2 | fast2
+(3 rows)
+
+-- ============================================================
+-- 3. global column stats must not claim ranges that exclude
+--    fast-path rows
+-- ============================================================
+-- The fast path cannot maintain min/max/contains_null, so it must degrade
+-- them to NULL (= unknown). Stale claims are trusted by DuckLake readers of
+-- this catalog (global stats feed DuckDB optimizer statistics, which fold
+-- provably-false filters) and are perpetuated by later stats merges.
+CREATE TABLE stats_t (id int) USING ducklake;
+INSERT INTO stats_t SELECT i FROM generate_series(1, 200) i;  -- normal path, real stats
+-- cache the (accurate, soon stale) stats in this backend
+SELECT count(*) FROM stats_t WHERE id = 150;
+ count 
+-------
+     1
+(1 row)
+
+SELECT ducklake.reset_direct_insert_stats();
+ reset_direct_insert_stats 
+---------------------------
+ 
+(1 row)
+
+INSERT INTO stats_t VALUES (1000);  -- outside the recorded min/max
+INSERT INTO stats_t VALUES (NULL);  -- violates contains_null = false
+SELECT pattern, reason, count FROM ducklake.direct_insert_stats() WHERE count > 0;
+    pattern     | reason | count 
+----------------+--------+-------
+ matched_values | ok     |     2
+(1 row)
+
+-- stats must no longer claim [1,200] / no-nulls
+SELECT s.min_value, s.max_value, s.contains_null
+FROM ducklake.ducklake_table_column_stats s
+JOIN ducklake.ducklake_table t ON t.table_id = s.table_id AND t.end_snapshot IS NULL
+WHERE t.table_name = 'stats_t';
+ min_value | max_value | contains_null 
+-----------+-----------+---------------
+           |           | 
+(1 row)
+
+SELECT count(*) FROM stats_t WHERE id = 1000;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM stats_t WHERE id IS NULL;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM stats_t;
+ count 
+-------
+   202
+(1 row)
+
+-- Cleanup
+DROP TABLE dim_t;
+DROP TABLE stats_t;
+CALL ducklake.set_option('data_inlining_row_limit', 0);

--- a/pg_ducklake/test/regression/schedule
+++ b/pg_ducklake/test/regression/schedule
@@ -20,6 +20,7 @@ test: options
 test: data_inlining_row_limit
 test: create_with_options
 test: direct_insert_stats
+test: direct_insert_metadata
 test: inlined_data_schema_change
 test: alter_partition_inlining
 test: types

--- a/pg_ducklake/test/regression/sql/direct_insert_metadata.sql
+++ b/pg_ducklake/test/regression/sql/direct_insert_metadata.sql
@@ -1,0 +1,91 @@
+-- Direct-insert (fast path) metadata commit protocol.
+-- The fast path hand-writes the DuckLake commit; these tests pin the parts of
+-- the protocol other DuckLake machinery relies on.
+
+CALL ducklake.set_option('data_inlining_row_limit', 100);
+
+-- ============================================================
+-- 1. next_file_id must advance on a fast-path commit
+-- ============================================================
+-- DuckLake keys its table-stats cache on (next_file_id, schema_version,
+-- table_id) and bumps next_file_id on inlined-only commits to signal a data
+-- change. A fast-path commit that carries it forward leaves stale cached
+-- stats (next_row_id, record_count, min/max) in every open DuckDB instance.
+
+CREATE TABLE dim_t (id int, val text) USING ducklake;
+INSERT INTO dim_t VALUES (0, 'seed');  -- normal path: creates the inlined data table
+
+SELECT next_file_id AS file_id_before
+FROM ducklake.ducklake_snapshot ORDER BY snapshot_id DESC LIMIT 1 \gset
+
+SELECT ducklake.reset_direct_insert_stats();
+INSERT INTO dim_t VALUES (1, 'fast');
+-- fast path handled the insert above
+SELECT pattern, reason, count FROM ducklake.direct_insert_stats() WHERE count > 0;
+
+SELECT next_file_id > :file_id_before AS file_id_advanced
+FROM ducklake.ducklake_snapshot ORDER BY snapshot_id DESC LIMIT 1;
+
+-- ============================================================
+-- 2. row ids must stay unique when fast-path and normal-path
+--    inserts interleave
+-- ============================================================
+-- Load this backend's DuckDB table-stats cache, then advance next_row_id
+-- through the fast path (PG metadata only). The normal-path insert below
+-- must not seed its row ids from the stale cache entry.
+SELECT count(*) FROM dim_t WHERE id >= 0;
+INSERT INTO dim_t VALUES (2, 'fast2');
+BEGIN;  -- transaction block: fast path disengages, normal DuckLake path
+INSERT INTO dim_t VALUES (3, 'slow');
+COMMIT;
+
+SELECT it.table_name AS dim_inl
+FROM ducklake.ducklake_inlined_data_tables it
+JOIN ducklake.ducklake_table t USING (table_id)
+WHERE t.table_name = 'dim_t' AND t.end_snapshot IS NULL
+ORDER BY it.schema_version DESC LIMIT 1 \gset
+
+SELECT row_id, count(*) AS dup_count
+FROM ducklake.:dim_inl GROUP BY row_id HAVING count(*) > 1;
+
+SELECT count(*) AS inlined_rows, count(DISTINCT row_id) AS distinct_row_ids
+FROM ducklake.:dim_inl;
+
+-- deleting one row must not take an unrelated row with it
+DELETE FROM dim_t WHERE id = 3;
+SELECT * FROM dim_t ORDER BY id;
+
+-- ============================================================
+-- 3. global column stats must not claim ranges that exclude
+--    fast-path rows
+-- ============================================================
+-- The fast path cannot maintain min/max/contains_null, so it must degrade
+-- them to NULL (= unknown). Stale claims are trusted by DuckLake readers of
+-- this catalog (global stats feed DuckDB optimizer statistics, which fold
+-- provably-false filters) and are perpetuated by later stats merges.
+
+CREATE TABLE stats_t (id int) USING ducklake;
+INSERT INTO stats_t SELECT i FROM generate_series(1, 200) i;  -- normal path, real stats
+
+-- cache the (accurate, soon stale) stats in this backend
+SELECT count(*) FROM stats_t WHERE id = 150;
+
+SELECT ducklake.reset_direct_insert_stats();
+INSERT INTO stats_t VALUES (1000);  -- outside the recorded min/max
+INSERT INTO stats_t VALUES (NULL);  -- violates contains_null = false
+SELECT pattern, reason, count FROM ducklake.direct_insert_stats() WHERE count > 0;
+
+-- stats must no longer claim [1,200] / no-nulls
+SELECT s.min_value, s.max_value, s.contains_null
+FROM ducklake.ducklake_table_column_stats s
+JOIN ducklake.ducklake_table t ON t.table_id = s.table_id AND t.end_snapshot IS NULL
+WHERE t.table_name = 'stats_t';
+
+SELECT count(*) FROM stats_t WHERE id = 1000;
+SELECT count(*) FROM stats_t WHERE id IS NULL;
+SELECT count(*) FROM stats_t;
+
+-- Cleanup
+DROP TABLE dim_t;
+DROP TABLE stats_t;
+CALL ducklake.set_option('data_inlining_row_limit', 0);


### PR DESCRIPTION
Follow-up to #216. Auditing the hand-written DuckLake metadata writes in the direct-insert/COPY fast path against upstream DuckLake's commit protocol (the same class of drift that caused #215) surfaced three more divergences. All hand-written metadata DML lives in this one path (`CreateSnapshotForDirectInsert` + the fast-path row writers); nothing else in pg_ducklake hand-writes `ducklake.*` rows.

## Drift 1: `next_file_id` not bumped (row-id corruption)

Upstream advances `next_file_id` by 1 on inlined-only commits, explicitly to "signal a data change": DuckLake's table-stats cache is keyed by `(next_file_id, schema_version, table_id)` (`ducklake_catalog.cpp`). The fast path carried it forward unchanged, so its snapshots reused the old cache key and every open DuckDB instance kept serving stale stats -- including `next_row_id`. A later normal-path insert in the same backend seeded `row_id_start` from the stale cache and wrote rows with **duplicate row ids**.

The new `direct_insert_metadata` regression test reproduces the consequence deterministically on unfixed code:

```
DELETE FROM dim_t WHERE id = 3;   -- 'slow' row, duplicated row_id
SELECT * FROM dim_t ORDER BY id;  -- id = 2 ('fast2') is gone too
```

Fix: write `next_file_id + 1`, mirroring upstream.

## Drift 2: global column stats never maintained (stale validity claims)

Real min/max/`contains_null` recorded by an earlier normal-path (parquet) write kept claiming validity while fast-path rows fell outside the range (`max=200` while a row with 1000 and a NULL exist). pg_ducklake's own scan does not prune on global stats today, but DuckLake readers of the same catalog trust them for optimizer filter folding, and later upstream stats merges perpetuate the wrong values. The fast path now degrades the table's column stats to NULL -- "unknown", which every reader treats as non-pruning (safe but pessimistic). The test pins the metadata contract: after a fast-path insert the stats may not claim a range that excludes the inserted values.

## Drift 3: COPY surfaced the snapshot-id race as a raw duplicate-key error

The direct INSERT path translates the `MAX(snapshot_id)+1` allocation race (23505) to `serialization_failure` (40001) so client retry adapters retry transparently; COPY FROM STDIN lacked the translation and leaked the raw unique-violation. COPY now uses the same translation. (No deterministic reproduction is possible in the regression/isolation harnesses -- the collision needs a commit landing mid-COPY -- so this one is covered by the shared code shape rather than a test.)

## Tests

`direct_insert_metadata.sql` (new): asserts `next_file_id` advances on a fast-path commit, that interleaved fast-path/normal-path inserts keep row ids unique (with the delete-side-effect reproduction above), and that column stats degrade instead of claiming stale ranges. Regression 49/49, isolation 3/3 locally (PG 18, macOS).

Note: restoring *precise* column stats (instead of degrading to NULL) and eliminating this hand-written SQL entirely by reusing upstream's static SQL builders is planned as a refactor targeting `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)