### PR TITLE
fix: order inlined flush read by (row_id, begin_snapshot)

### DIFF
--- a/pg_ducklake/src/pgducklake_metadata_manager.cpp
+++ b/pg_ducklake/src/pgducklake_metadata_manager.cpp
@@ -328,7 +328,13 @@ ORDER BY row_id;)",
 	return transaction.ExecuteRaw(query);
 }
 
-/* Same DuckDB routing as ReadInlinedData, but keeps deleted rows (no end_snapshot filter) for deletion vectors. */
+/* Same DuckDB routing as ReadInlinedData, but keeps deleted rows (no end_snapshot filter) for deletion vectors.
+ * Unlike ReadInlinedData (which filters to the single live version per row_id), this read keeps ALL versions,
+ * so a row_id can appear multiple times. The flush's delete-position query derives ordinals from
+ * ROW_NUMBER() OVER (ORDER BY row_id, begin_snapshot) - the physical read order MUST match that, or the
+ * positional delete file tombstones the wrong version and the latest value silently reverts. Over a Postgres
+ * heap scan, ORDER BY row_id alone leaves version ties to physical/TID order, not begin_snapshot - so the
+ * begin_snapshot tiebreaker is required here (mirrors upstream ducklake 8dd38ce0). */
 duckdb::unique_ptr<duckdb::QueryResult>
 PgDuckLakeMetadataManager::ReadAllInlinedDataForFlush(duckdb::DuckLakeSnapshot snapshot,
                                                       const duckdb::string &inlined_table_name,
@@ -338,7 +344,7 @@ PgDuckLakeMetadataManager::ReadAllInlinedDataForFlush(duckdb::DuckLakeSnapshot s
 SELECT %s
 FROM pgduckdb."%s".%s inlined_data
 WHERE %llu >= begin_snapshot
-ORDER BY row_id;)",
+ORDER BY row_id, begin_snapshot;)",
 	                                        projection, PGDUCKLAKE_PG_SCHEMA, duckdb::SQLIdentifier(inlined_table_name),
 	                                        (unsigned long long)snapshot.snapshot_id);
 	elog(DEBUG1, "ReadAllInlinedDataForFlush via DuckDB: %s", query.c_str());

--- a/pg_ducklake/test/regression/expected/inlined_flush_lost_update.out
+++ b/pg_ducklake/test/regression/expected/inlined_flush_lost_update.out
@@ -1,0 +1,65 @@
+-- Regression: flush_inlined_data must not revert a row to an older version.
+--
+-- On the Postgres backend, PgDuckLakeMetadataManager::ReadAllInlinedDataForFlush
+-- read the inline versions ORDER BY row_id only. When a row_id has several versions
+-- (two or more updates before one flush), the tie fell to Postgres heap/scan order,
+-- which the end_snapshot-stamping UPDATEs scramble away from begin_snapshot order.
+-- The flush's delete-position query derives ordinals from
+-- ROW_NUMBER() OVER (ORDER BY [sort,] row_id, begin_snapshot), so the physical read
+-- order must match it; when it did not, the delete file tombstoned the live version
+-- and the committed value silently reverted after the flush.
+--
+-- Fix: order the read by (row_id, begin_snapshot), matching the delete-position query
+-- and upstream DuckLake commit 8dd38ce0. This test reverts (all values correct) with
+-- the fix and fails (older values resurface) without it.
+CALL ducklake.set_option('data_inlining_row_limit', 1000);  -- keep everything inline until the explicit flush
+CREATE TABLE flr_fact (part int, id int, v int) USING ducklake;
+CALL ducklake.set_partition('flr_fact'::regclass, 'part');
+INSERT INTO flr_fact VALUES (0,1,100),(0,2,200),(0,3,300),(0,4,400);
+-- Interleaved updates: several versions chained under one row_id. The UPDATEs that
+-- stamp end_snapshot relocate heap tuples, so physical order != begin_snapshot order.
+UPDATE flr_fact SET v=101 WHERE id=1;
+UPDATE flr_fact SET v=201 WHERE id=2;
+UPDATE flr_fact SET v=102 WHERE id=1;
+UPDATE flr_fact SET v=301 WHERE id=3;
+UPDATE flr_fact SET v=103 WHERE id=1;
+UPDATE flr_fact SET v=202 WHERE id=2;
+UPDATE flr_fact SET v=999 WHERE id=1;
+-- Latest committed values, before the flush.
+SELECT id, v FROM flr_fact ORDER BY id;
+ id |  v  
+----+-----
+  1 | 999
+  2 | 202
+  3 | 301
+  4 | 400
+(4 rows)
+
+-- The flush that mis-tombstoned the live version pre-fix.
+SELECT * FROM ducklake.flush_inlined_data('flr_fact'::regclass);
+ schema_name | table_name | rows_flushed 
+-------------+------------+--------------
+ public      | flr_fact   |           11
+(1 row)
+
+-- Post-flush values must be identical to the pre-flush values above.
+SELECT id, v FROM flr_fact ORDER BY id;
+ id |  v  
+----+-----
+  1 | 999
+  2 | 202
+  3 | 301
+  4 | 400
+(4 rows)
+
+-- Explicit verdict: 0 == no row reverted (GREEN); pre-fix this was 3.
+SELECT count(*) AS reverted_rows
+FROM flr_fact f JOIN (VALUES (1,999),(2,202),(3,301),(4,400)) e(id,ev) ON e.id = f.id
+WHERE f.v <> e.ev;
+ reverted_rows 
+---------------
+             0
+(1 row)
+
+DROP TABLE flr_fact;
+CALL ducklake.set_option('data_inlining_row_limit', 0);

--- a/pg_ducklake/test/regression/schedule
+++ b/pg_ducklake/test/regression/schedule
@@ -22,6 +22,7 @@ test: create_with_options
 test: direct_insert_stats
 test: inlined_data_schema_change
 test: alter_partition_inlining
+test: inlined_flush_lost_update
 test: types
 test: unresolved_type_ops
 test: decimal_precision

--- a/pg_ducklake/test/regression/sql/inlined_flush_lost_update.sql
+++ b/pg_ducklake/test/regression/sql/inlined_flush_lost_update.sql
@@ -1,0 +1,48 @@
+-- Regression: flush_inlined_data must not revert a row to an older version.
+--
+-- On the Postgres backend, PgDuckLakeMetadataManager::ReadAllInlinedDataForFlush
+-- read the inline versions ORDER BY row_id only. When a row_id has several versions
+-- (two or more updates before one flush), the tie fell to Postgres heap/scan order,
+-- which the end_snapshot-stamping UPDATEs scramble away from begin_snapshot order.
+-- The flush's delete-position query derives ordinals from
+-- ROW_NUMBER() OVER (ORDER BY [sort,] row_id, begin_snapshot), so the physical read
+-- order must match it; when it did not, the delete file tombstoned the live version
+-- and the committed value silently reverted after the flush.
+--
+-- Fix: order the read by (row_id, begin_snapshot), matching the delete-position query
+-- and upstream DuckLake commit 8dd38ce0. This test reverts (all values correct) with
+-- the fix and fails (older values resurface) without it.
+
+CALL ducklake.set_option('data_inlining_row_limit', 1000);  -- keep everything inline until the explicit flush
+
+CREATE TABLE flr_fact (part int, id int, v int) USING ducklake;
+CALL ducklake.set_partition('flr_fact'::regclass, 'part');
+
+INSERT INTO flr_fact VALUES (0,1,100),(0,2,200),(0,3,300),(0,4,400);
+
+-- Interleaved updates: several versions chained under one row_id. The UPDATEs that
+-- stamp end_snapshot relocate heap tuples, so physical order != begin_snapshot order.
+UPDATE flr_fact SET v=101 WHERE id=1;
+UPDATE flr_fact SET v=201 WHERE id=2;
+UPDATE flr_fact SET v=102 WHERE id=1;
+UPDATE flr_fact SET v=301 WHERE id=3;
+UPDATE flr_fact SET v=103 WHERE id=1;
+UPDATE flr_fact SET v=202 WHERE id=2;
+UPDATE flr_fact SET v=999 WHERE id=1;
+
+-- Latest committed values, before the flush.
+SELECT id, v FROM flr_fact ORDER BY id;
+
+-- The flush that mis-tombstoned the live version pre-fix.
+SELECT * FROM ducklake.flush_inlined_data('flr_fact'::regclass);
+
+-- Post-flush values must be identical to the pre-flush values above.
+SELECT id, v FROM flr_fact ORDER BY id;
+
+-- Explicit verdict: 0 == no row reverted (GREEN); pre-fix this was 3.
+SELECT count(*) AS reverted_rows
+FROM flr_fact f JOIN (VALUES (1,999),(2,202),(3,301),(4,400)) e(id,ev) ON e.id = f.id
+WHERE f.v <> e.ev;
+
+DROP TABLE flr_fact;
+CALL ducklake.set_option('data_inlining_row_limit', 0);


### PR DESCRIPTION
Closes #220.

### Problem

On an inlining-enabled table, when a row accumulates two or more updates before a single
`flush_inlined_data`, the flush could materialize an **older** version and drop the latest —
the committed value silently reverts. No error is raised.

The flush writes all inline versions of a row to Parquet and then a positional delete file
tombstones the dead ones. The delete positions are computed by
`ROW_NUMBER() OVER (ORDER BY [sort,] row_id, begin_snapshot)`, so the physical order of the
rows fed to the flush **must** match that ordering. On the Postgres backend the read is
`PgDuckLakeMetadataManager::ReadAllInlinedDataForFlush`, which ordered only by `row_id`.
With several versions sharing one `row_id`, the tie was broken by the Postgres heap/scan
order — and the row-versioning UPDATEs (which stamp `end_snapshot`) relocate tuples, so heap
order diverges from `begin_snapshot` order. The delete file then tombstones the live version
instead of the dead one.

This only affects the Postgres backend. On the DuckDB metadata backend the inline scan
returns rows in insertion order (≈ `begin_snapshot` order), so `row_id`-only ties happen to
line up. Upstream DuckLake already orders the equivalent base read by
`row_id, begin_snapshot` (commit `8dd38ce0`); the pg-specific override was copied from the
older `row_id`-only form and never picked up that change.

### Fix

Add the `begin_snapshot` tiebreaker to the override's read, matching the ordering the
delete-position query assumes and mirroring upstream:

```diff
-ORDER BY row_id;
+ORDER BY row_id, begin_snapshot;
```

in `PgDuckLakeMetadataManager::ReadAllInlinedDataForFlush`. One line, plus a comment
explaining the ordering contract.

The sibling `ReadInlinedData` (live-rows-only) is intentionally left `ORDER BY row_id`: it
filters to a single live version per `row_id`, so there are no ties and no tiebreaker is
needed — this matches the upstream base method.

### Verification

Reproduced red→green on a real pg_ducklake build (PostgreSQL 18). Same build, same workload,
only the one-line ordering differs:

| row (versions) | before fix | after fix |
| --- | --- | --- |
| id=1 (5) | 999 → **103** ❌ | 999 ✅ |
| id=2 (3) | 202 → **201** ❌ | 202 ✅ |
| id=3 (2) | 301 → **300** ❌ | 301 ✅ |
| id=4 (1) | 400 ✅ | 400 ✅ |
| **reverted rows** | **3** | **0** |

Adds a regression test `test/regression/inlined_flush_lost_update` that asserts all four
post-flush values survive; it fails (older versions resurface) without the fix. Full suite
green with the fix: regression 50/50, isolation 3/3 (PG 18).

