### PR TITLE
fix: make TRUNCATE work on ducklake tables

### DIFF
--- a/pg_ducklake/src/ducklake_table.cpp
+++ b/pg_ducklake/src/ducklake_table.cpp
@@ -255,26 +255,53 @@ duckdb_finish_bulk_insert(Relation /*relation*/, int /*options*/) {
 	/* No-op */
 }
 
+/* Truncates via a DuckDB TRUNCATE, tied to the current transaction. */
+static void
+TruncateDuckLakeTable_Cpp(Oid relid) {
+	std::string truncate_ddl = std::string("TRUNCATE ") + pgddb_relation_name(relid);
+	elog(DEBUG1, "Truncating DuckLake table: %s", truncate_ddl.c_str());
+	pgducklake::DuckDBQueryOrThrow(truncate_ddl);
+}
+
+/* Table AM callbacks are plain PG frames; convert DuckDB exceptions to PG ERRORs. */
+static void
+TruncateDuckLakeTable(Oid relid) {
+	InvokeCPPFunc(TruncateDuckLakeTable_Cpp, relid);
+}
+
 #if PG_VERSION_NUM >= 160000
 
 static void
-duckdb_relation_set_new_filelocator(Relation /*rel*/, const RelFileLocator * /*newrnode*/, char /*persistence*/,
+duckdb_relation_set_new_filelocator(Relation rel, const RelFileLocator * /*newrnode*/, char /*persistence*/,
                                     TransactionId * /*freezeXid*/, MultiXactId * /*minmulti*/) {
-	/* No-op: the table is created in DuckDB later by duckdb_create_table_trigger. */
+	HeapTuple tp = SearchSysCache1(RELOID, ObjectIdGetDatum(rel->rd_id));
+	if (!HeapTupleIsValid(tp)) {
+		/* No-op: the table is created in DuckDB later by duckdb_create_table_trigger. */
+		return;
+	}
+	ReleaseSysCache(tp);
+	TruncateDuckLakeTable(rel->rd_id);
 }
 
 #else
 
 static void
-duckdb_relation_set_new_filenode(Relation /*rel*/, const RelFileNode * /*newrnode*/, char /*persistence*/,
+duckdb_relation_set_new_filenode(Relation rel, const RelFileNode * /*newrnode*/, char /*persistence*/,
                                  TransactionId * /*freezeXid*/, MultiXactId * /*minmulti*/) {
-	/* No-op: the table is created in DuckDB later by duckdb_create_table_trigger. */
+	HeapTuple tp = SearchSysCache1(RELOID, ObjectIdGetDatum(rel->rd_id));
+	if (!HeapTupleIsValid(tp)) {
+		/* No-op: the table is created in DuckDB later by duckdb_create_table_trigger. */
+		return;
+	}
+	ReleaseSysCache(tp);
+	TruncateDuckLakeTable(rel->rd_id);
 }
 
 #endif
 
 static void
 duckdb_relation_nontransactional_truncate(Relation rel) {
+	TruncateDuckLakeTable(rel->rd_id);
 }
 
 #if PG_VERSION_NUM >= 160000

--- a/pg_ducklake/test/e2e/test_crud.py
+++ b/pg_ducklake/test/e2e/test_crud.py
@@ -66,13 +66,12 @@ async def test_delete(conn):
     assert tag == "DELETE 5"
     assert await conn.fetchval("SELECT count(*) FROM t") == 5
 
-    # TRUNCATE is documented as a no-op on ducklake tables (use DELETE);
-    # pin that behavior so a change shows up here.
     await conn.execute("TRUNCATE t")
-    assert await conn.fetchval("SELECT count(*) FROM t") == 5
+    assert await conn.fetchval("SELECT count(*) FROM t") == 0
 
+    await conn.execute("INSERT INTO t VALUES (1), (2), (3)")
     tag = await conn.execute("DELETE FROM t")
-    assert tag == "DELETE 5"
+    assert tag == "DELETE 3"
     assert await conn.fetchval("SELECT count(*) FROM t") == 0
 
 

--- a/pg_ducklake/test/regression/expected/merge.out
+++ b/pg_ducklake/test/regression/expected/merge.out
@@ -28,9 +28,9 @@ SELECT * FROM merge_target ORDER BY id;
   4 | four  |  40
 (4 rows)
 
--- Reset (TRUNCATE is a no-op on ducklake tables, use DELETE)
-DELETE FROM merge_target;
-DELETE 4
+-- Reset
+TRUNCATE merge_target;
+TRUNCATE TABLE
 INSERT INTO merge_target VALUES (1, 'one', 10), (2, 'two', 20), (3, 'three', 30);
 INSERT 0 3
 -- MERGE with DELETE action

--- a/pg_ducklake/test/regression/expected/truncate.out
+++ b/pg_ducklake/test/regression/expected/truncate.out
@@ -1,0 +1,97 @@
+-- TRUNCATE on ducklake tables (issue #224).
+\set QUIET off
+CREATE TABLE trunc_t (id int, val text) USING ducklake;
+CREATE TABLE
+INSERT INTO trunc_t VALUES (1, 'one'), (2, 'two'), (3, 'three');
+INSERT 0 3
+-- Plain TRUNCATE: rows gone, a delete snapshot is recorded
+TRUNCATE trunc_t;
+TRUNCATE TABLE
+SELECT count(*) FROM trunc_t;
+ count 
+-------
+     0
+(1 row)
+
+SELECT changes_made ~ '^(deleted_from_table|inlined_delete):\d+$' AS truncate_recorded
+FROM ducklake.ducklake_snapshot_changes ORDER BY snapshot_id DESC LIMIT 1;
+ truncate_recorded 
+-------------------
+ t
+(1 row)
+
+-- TRUNCATE then INSERT
+INSERT INTO trunc_t VALUES (4, 'four');
+INSERT 0 1
+SELECT * FROM trunc_t ORDER BY id;
+ id | val  
+----+------
+  4 | four
+(1 row)
+
+-- TRUNCATE inside a rolled-back transaction: rows restored
+BEGIN;
+BEGIN
+TRUNCATE trunc_t;
+TRUNCATE TABLE
+SELECT count(*) FROM trunc_t;
+ count 
+-------
+     0
+(1 row)
+
+ROLLBACK;
+ROLLBACK
+SELECT * FROM trunc_t ORDER BY id;
+ id | val  
+----+------
+  4 | four
+(1 row)
+
+-- Mixed-list TRUNCATE of a heap table and a ducklake table
+CREATE TABLE trunc_heap (id int);
+CREATE TABLE
+INSERT INTO trunc_heap VALUES (1), (2);
+INSERT 0 2
+TRUNCATE trunc_heap, trunc_t;
+TRUNCATE TABLE
+SELECT count(*) FROM trunc_heap;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM trunc_t;
+ count 
+-------
+     0
+(1 row)
+
+-- TRUNCATE of a table created in the same transaction (nontransactional path)
+BEGIN;
+BEGIN
+CREATE TABLE trunc_same_txn (id int) USING ducklake;
+CREATE TABLE
+INSERT INTO trunc_same_txn VALUES (1), (2);
+INSERT 0 2
+TRUNCATE trunc_same_txn;
+TRUNCATE TABLE
+SELECT count(*) FROM trunc_same_txn;
+ count 
+-------
+     0
+(1 row)
+
+COMMIT;
+COMMIT
+SELECT count(*) FROM trunc_same_txn;
+ count 
+-------
+     0
+(1 row)
+
+\set QUIET on
+-- Cleanup
+DROP TABLE trunc_t;
+DROP TABLE trunc_heap;
+DROP TABLE trunc_same_txn;

--- a/pg_ducklake/test/regression/schedule
+++ b/pg_ducklake/test/regression/schedule
@@ -5,6 +5,7 @@ test: basic
 test: virtual_columns
 test: dml_row_count
 test: merge
+test: truncate
 test: transaction
 test: non_ducklake_commit
 test: temp_table

--- a/pg_ducklake/test/regression/sql/merge.sql
+++ b/pg_ducklake/test/regression/sql/merge.sql
@@ -22,8 +22,8 @@ WHEN NOT MATCHED THEN INSERT VALUES (s.id, s.val, s.n);
 
 SELECT * FROM merge_target ORDER BY id;
 
--- Reset (TRUNCATE is a no-op on ducklake tables, use DELETE)
-DELETE FROM merge_target;
+-- Reset
+TRUNCATE merge_target;
 INSERT INTO merge_target VALUES (1, 'one', 10), (2, 'two', 20), (3, 'three', 30);
 
 -- MERGE with DELETE action

--- a/pg_ducklake/test/regression/sql/truncate.sql
+++ b/pg_ducklake/test/regression/sql/truncate.sql
@@ -1,0 +1,45 @@
+-- TRUNCATE on ducklake tables (issue #224).
+\set QUIET off
+
+CREATE TABLE trunc_t (id int, val text) USING ducklake;
+INSERT INTO trunc_t VALUES (1, 'one'), (2, 'two'), (3, 'three');
+
+-- Plain TRUNCATE: rows gone, a delete snapshot is recorded
+TRUNCATE trunc_t;
+SELECT count(*) FROM trunc_t;
+SELECT changes_made ~ '^(deleted_from_table|inlined_delete):\d+$' AS truncate_recorded
+FROM ducklake.ducklake_snapshot_changes ORDER BY snapshot_id DESC LIMIT 1;
+
+-- TRUNCATE then INSERT
+INSERT INTO trunc_t VALUES (4, 'four');
+SELECT * FROM trunc_t ORDER BY id;
+
+-- TRUNCATE inside a rolled-back transaction: rows restored
+BEGIN;
+TRUNCATE trunc_t;
+SELECT count(*) FROM trunc_t;
+ROLLBACK;
+SELECT * FROM trunc_t ORDER BY id;
+
+-- Mixed-list TRUNCATE of a heap table and a ducklake table
+CREATE TABLE trunc_heap (id int);
+INSERT INTO trunc_heap VALUES (1), (2);
+TRUNCATE trunc_heap, trunc_t;
+SELECT count(*) FROM trunc_heap;
+SELECT count(*) FROM trunc_t;
+
+-- TRUNCATE of a table created in the same transaction (nontransactional path)
+BEGIN;
+CREATE TABLE trunc_same_txn (id int) USING ducklake;
+INSERT INTO trunc_same_txn VALUES (1), (2);
+TRUNCATE trunc_same_txn;
+SELECT count(*) FROM trunc_same_txn;
+COMMIT;
+SELECT count(*) FROM trunc_same_txn;
+
+\set QUIET on
+
+-- Cleanup
+DROP TABLE trunc_t;
+DROP TABLE trunc_heap;
+DROP TABLE trunc_same_txn;


### PR DESCRIPTION
TRUNCATE on a `USING ducklake` table has always been a silent no-op: it reports success, creates no snapshot, and leaves all rows in place -- including when a ducklake table appears in a mixed TRUNCATE list alongside heap tables. In the v1.0 line that stays as the documented, intended behavior; starting with the next release, this PR makes TRUNCATE perform a real truncate.

The no-op comes from the table access method: `relation_set_new_filelocator`/`filenode` and `relation_nontransactional_truncate` were written for the CREATE TABLE code path (where the DuckDB-side table doesn't exist yet and is created later by the event trigger). But PostgreSQL's `ExecuteTruncateGuts` invokes the same callback for TRUNCATE, so the operation was swallowed.

The change mirrors pg_duckdb's approach: a pg_class syscache miss on the relation means CREATE (row not yet visible) and stays a no-op; a hit means TRUNCATE, which is now routed to DuckDB as `TRUNCATE <table>`. DuckLake executes it as an unconditional DELETE and records a proper delete snapshot. Since the DuckDB transaction is tied to the PG transaction, TRUNCATE inside BEGIN/ROLLBACK behaves correctly for free. The DuckDB call goes through InvokeCPPFunc so a DuckDB error becomes a regular PG ERROR instead of an unhandled C++ exception in a PG C frame.

Adds a `truncate` regression test (plain TRUNCATE + snapshot bookkeeping, ROLLBACK, TRUNCATE-then-INSERT, mixed heap/ducklake list, same-transaction TRUNCATE), switches merge.sql's stale "TRUNCATE is a no-op" DELETE workaround back to a real TRUNCATE, and updates the e2e test that pinned the no-op. Full regression suite passes (51/51 on PG 18).

Fixes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)