### PR TITLE
fix: break snapshot_time ties by snapshot_id in timestamp time travel

### DIFF
--- a/pg_ducklake/test/regression/expected/time_travel_creation.out
+++ b/pg_ducklake/test/regression/expected/time_travel_creation.out
@@ -1,0 +1,35 @@
+-- Regression test for issue #222: timestamp time travel at the creation
+-- snapshot of the first table in a brand-new schema.
+--
+-- CREATE TABLE ... USING ducklake auto-creates the DuckLake schema before
+-- the table, both committed via SPI inside the single wrapping PG
+-- transaction, so the two snapshots can share an identical snapshot_time.
+-- Without a snapshot_id tie-breaker, resolving a timestamp AT clause that
+-- lands on the tie could pick the earlier (schema-only) snapshot, where the
+-- table does not exist yet, and error.
+CREATE SCHEMA tt_new_schema;
+SET search_path = tt_new_schema;
+CREATE TABLE tt_new (id int, name text) USING ducklake;
+SELECT max(snapshot_id) AS v_create FROM ducklake.ducklake_snapshot \gset
+SELECT snapshot_time AS create_ts FROM ducklake.ducklake_snapshot WHERE snapshot_id = :v_create \gset
+-- Time travel to the creation timestamp must not error: the table exists
+-- and is empty. (Schema-qualified: the single-arg overload otherwise
+-- defaults unqualified names to "public".)
+SELECT * FROM ducklake.time_travel('tt_new_schema.tt_new', :'create_ts'::timestamptz);
+ id | name 
+----+------
+(0 rows)
+
+INSERT INTO tt_new VALUES (1, 'Alice');
+SELECT max(snapshot_id) AS v_insert FROM ducklake.ducklake_snapshot \gset
+SELECT snapshot_time AS insert_ts FROM ducklake.ducklake_snapshot WHERE snapshot_id = :v_insert \gset
+-- Time travel to the first-insert timestamp returns the inserted row.
+SELECT * FROM ducklake.time_travel('tt_new_schema.tt_new', :'insert_ts'::timestamptz);
+ id | name  
+----+-------
+  1 | Alice
+(1 row)
+
+-- Cleanup
+DROP TABLE tt_new;
+DROP SCHEMA tt_new_schema;

--- a/pg_ducklake/test/regression/schedule
+++ b/pg_ducklake/test/regression/schedule
@@ -36,6 +36,7 @@ test: partition
 test: sorted_table
 test: hybrid_scan
 test: time_travel
+test: time_travel_creation
 test: snapshots
 test: data_change_feed
 test: list_files

--- a/pg_ducklake/test/regression/sql/time_travel_creation.sql
+++ b/pg_ducklake/test/regression/sql/time_travel_creation.sql
@@ -1,0 +1,30 @@
+-- Regression test for issue #222: timestamp time travel at the creation
+-- snapshot of the first table in a brand-new schema.
+--
+-- CREATE TABLE ... USING ducklake auto-creates the DuckLake schema before
+-- the table, both committed via SPI inside the single wrapping PG
+-- transaction, so the two snapshots can share an identical snapshot_time.
+-- Without a snapshot_id tie-breaker, resolving a timestamp AT clause that
+-- lands on the tie could pick the earlier (schema-only) snapshot, where the
+-- table does not exist yet, and error.
+CREATE SCHEMA tt_new_schema;
+SET search_path = tt_new_schema;
+CREATE TABLE tt_new (id int, name text) USING ducklake;
+SELECT max(snapshot_id) AS v_create FROM ducklake.ducklake_snapshot \gset
+SELECT snapshot_time AS create_ts FROM ducklake.ducklake_snapshot WHERE snapshot_id = :v_create \gset
+
+-- Time travel to the creation timestamp must not error: the table exists
+-- and is empty. (Schema-qualified: the single-arg overload otherwise
+-- defaults unqualified names to "public".)
+SELECT * FROM ducklake.time_travel('tt_new_schema.tt_new', :'create_ts'::timestamptz);
+
+INSERT INTO tt_new VALUES (1, 'Alice');
+SELECT max(snapshot_id) AS v_insert FROM ducklake.ducklake_snapshot \gset
+SELECT snapshot_time AS insert_ts FROM ducklake.ducklake_snapshot WHERE snapshot_id = :v_insert \gset
+
+-- Time travel to the first-insert timestamp returns the inserted row.
+SELECT * FROM ducklake.time_travel('tt_new_schema.tt_new', :'insert_ts'::timestamptz);
+
+-- Cleanup
+DROP TABLE tt_new;
+DROP SCHEMA tt_new_schema;

--- a/pg_ducklake/third_party/ducklake-010-snapshot-timestamp-tiebreak.patch
+++ b/pg_ducklake/third_party/ducklake-010-snapshot-timestamp-tiebreak.patch
@@ -1,0 +1,17 @@
+diff --git a/src/storage/ducklake_metadata_manager.cpp b/src/storage/ducklake_metadata_manager.cpp
+index 2d9c0c59..b19f251a 100644
+--- a/src/storage/ducklake_metadata_manager.cpp
++++ b/src/storage/ducklake_metadata_manager.cpp
+@@ -4103,9 +4103,10 @@ SELECT snapshot_id, schema_version, next_catalog_id, next_file_id
+ 	SELECT snapshot_id
+ 	FROM {METADATA_CATALOG}.ducklake_snapshot
+ 	WHERE snapshot_time::TIMESTAMPTZ %s= %s
+-	ORDER BY snapshot_time::TIMESTAMPTZ %s
++	ORDER BY snapshot_time::TIMESTAMPTZ %s, snapshot_id %s
+ 	LIMIT 1);)",
+-		    timestamp_condition, val.DefaultCastAs(LogicalType::VARCHAR).ToSQLString(), timestamp_order));
++		    timestamp_condition, val.DefaultCastAs(LogicalType::VARCHAR).ToSQLString(), timestamp_order,
++		    timestamp_order));
+ 	} else {
+ 		throw InvalidInputException("Unsupported AT clause unit - %s", unit);
+ 	}


### PR DESCRIPTION
`ducklake.time_travel(tbl, <timestamp>)` errors with "Catalog Error: Table with name ... does not exist at timestamp ..." for every timestamp between the creation of the first table in a schema new to the DuckLake catalog and its next snapshot, while time travel by snapshot id works fine.

Root cause is two cooperating facts. Upstream DuckLake resolves a timestamp AT clause with `ORDER BY snapshot_time ... LIMIT 1` and no tie-breaker, so when two snapshots share a snapshot_time the choice is unordered (PostgreSQL happens to return the lower snapshot id). pg_ducklake makes that tie deterministic: the first table in a new schema issues an internal CREATE SCHEMA + CREATE TABLE as two DuckDB autocommits inside one wrapping PG transaction, so both snapshot rows are stamped with the same transaction-frozen NOW(). The resolver then picks the schema-only snapshot, where the table does not exist yet.

The fix (carried as vendored patch `ducklake-010-snapshot-timestamp-tiebreak.patch`) adds `snapshot_id` as a secondary ORDER BY key in the same direction as the bound (DESC for upper bound, ASC for lower), so ties resolve to "latest snapshot at or before ts", consistent with the snapshot-id path since snapshot_id is monotonic. Upstream ducklake main has the same latent hole, so this is worth proposing upstream as well.

Adds regression test `time_travel_creation`, which reproduces the tied snapshots deterministically and fails on unfixed code. Full regression suite passes 51/51.

Fixes #222. Note: this lands on v1.0 and needs a forward-port to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)