### PR TITLE
fix: track PG19 node changes in vendored ruleutils

### DIFF
--- a/libpgduckdb/vendor/pg_ruleutils_19.c
+++ b/libpgduckdb/vendor/pg_ruleutils_19.c
@@ -531,6 +531,7 @@ static void get_rte_alias(RangeTblEntry *rte, int varno, bool use_as,
 static void get_column_alias_list(deparse_columns *colinfo,
 								  deparse_context *context);
 static void get_for_portion_of(ForPortionOfExpr *forPortionOf,
+							   RangeTblEntry *rte,
 							   deparse_context *context);
 static void get_from_clause_coldeflist(RangeTblFunction *rtfunc,
 									   deparse_columns *colinfo,
@@ -6562,9 +6563,7 @@ get_basic_select_query(Query *query, deparse_context *context)
 		save_ingroupby = context->inGroupBy;
 		context->inGroupBy = true;
 
-		if (query->groupByAll)
-			appendStringInfoString(buf, "ALL");
-		else if (query->groupingSets == NIL)
+		if (query->groupingSets == NIL)
 		{
 			sep = "";
 			foreach(l, query->groupClause)
@@ -7613,7 +7612,7 @@ get_update_query_def(Query *query, deparse_context *context)
 					 generate_relation_name(rte->relid, NIL));
 
 	/* Print the FOR PORTION OF, if needed */
-	get_for_portion_of(query->forPortionOf, context);
+	get_for_portion_of(query->forPortionOf, rte, context);
 
 	/* Print the relation alias, if needed */
 	get_rte_alias(rte, query->resultRelation, false, context);
@@ -7820,7 +7819,7 @@ get_delete_query_def(Query *query, deparse_context *context)
 					 generate_relation_name(rte->relid, NIL));
 
 	/* Print the FOR PORTION OF, if needed */
-	get_for_portion_of(query->forPortionOf, context);
+	get_for_portion_of(query->forPortionOf, rte, context);
 
 	/* Print the relation alias, if needed */
 	get_rte_alias(rte, query->resultRelation, false, context);
@@ -13436,12 +13435,18 @@ get_rte_alias(RangeTblEntry *rte, int varno, bool use_as,
  * alias and SET will be on their own line with a leading space.
  */
 static void
-get_for_portion_of(ForPortionOfExpr *forPortionOf, deparse_context *context)
+get_for_portion_of(ForPortionOfExpr *forPortionOf, RangeTblEntry *rte,
+				   deparse_context *context)
 {
 	if (forPortionOf)
 	{
+		char	   *range_name;
+
+		range_name = get_attname(rte->relid,
+								 forPortionOf->rangeVar->varattno,
+								 false);
 		appendStringInfo(context->buf, " FOR PORTION OF %s",
-						 quote_identifier(forPortionOf->range_name));
+						 quote_identifier(range_name));
 
 		/*
 		 * Try to write it as FROM ... TO ... if we received it that way,


### PR DESCRIPTION
```
libpgduckdb/vendor/pg_ruleutils_19.c:6565:26: error: 'Query' has no member named 'groupByAll'
libpgduckdb/vendor/pg_ruleutils_19.c:13444:81: error: 'ForPortionOfExpr' has no member named 'range_name'; did you mean 'rangeVar'?
```

That file is a vendored copy of PostgreSQL's `ruleutils.c`, and the matrix tracks REL_19_STABLE tip. Two upstream commits changed nodes it reads: `372b8d1adb` reverted "Add GROUP BY ALL" and removed `Query.groupByAll`, and `2a9541ddfd` replaced `ForPortionOfExpr.range_name` with a `Var *rangeVar` whose column name is resolved from the catalogs at deparse time.

Both hunks are taken from `ruleutils.c` at REL_19_STABLE rather than written here: the GROUP BY ALL branch goes away, and `get_for_portion_of()` grows a `RangeTblEntry *` so it can call `get_attname()` on the range column. Only the `_19` file changes, so PG14 through PG18 are untouched.

No PG19 server on hand, so this was checked by compiling the one translation unit against REL_19_STABLE headers (`9f6fb11`): both errors reproduce before the change, and it compiles clean under `-Wall` after. Not exercised at runtime.