### PR TITLE
fix: guard metadata SPI calls against PG longjmp

### DIFF
--- a/pg_ducklake/src/pgducklake_metadata_manager.cpp
+++ b/pg_ducklake/src/pgducklake_metadata_manager.cpp
@@ -85,6 +85,36 @@ CreateEmptyResult(duckdb::StatementType type) {
 }
 
 /*
+ * SPI_finish() and PopActiveSnapshot() cannot ereport (spi.c, snapmgr.c), so these destructors
+ * are safe to run while a C++ exception unwinds. Acquisition goes through PostgresFunctionGuard
+ * because SPI_connect() and GetTransactionSnapshot() can.
+ * Two objects rather than one: a destructor runs only for a fully constructed object, so a
+ * failed snapshot push still releases the SPI connection.
+ */
+struct SpiConnectionScope {
+	SpiConnectionScope() {
+		PostgresFunctionGuard(SPI_connect);
+	}
+	~SpiConnectionScope() {
+		SPI_finish();
+	}
+	SpiConnectionScope(const SpiConnectionScope &) = delete;
+	SpiConnectionScope &operator=(const SpiConnectionScope &) = delete;
+};
+
+struct ActiveSnapshotScope {
+	ActiveSnapshotScope() {
+		Snapshot snapshot = PostgresFunctionGuard(GetTransactionSnapshot);
+		PostgresFunctionGuard(PushActiveSnapshot, snapshot);
+	}
+	~ActiveSnapshotScope() {
+		PopActiveSnapshot();
+	}
+	ActiveSnapshotScope(const ActiveSnapshotScope &) = delete;
+	ActiveSnapshotScope &operator=(const ActiveSnapshotScope &) = delete;
+};
+
+/*
  * Catch PG ERRORs in a subtransaction: a bare longjmp catch leaks
  * ActiveSnapshot/executor resources. CurrentResourceOwner must be restored by
  * hand after release/rollback; the GUC nest level stays outside the subxact.
@@ -132,30 +162,25 @@ SPIExecuteInSubtransaction(const duckdb::string &query, bool &had_error, duckdb:
 	return ret;
 }
 
+/*
+ * Every PG call that can ereport(ERROR) belongs here, not in the caller: the guard's sigsetjmp is
+ * in its own frame, so a longjmp out of this function skips this frame entirely. Nothing here may
+ * rely on a local destructor, and hoisting a PG call into the caller reopens the leak this split
+ * exists to close.
+ * Query passed by pointer: __PostgresFunctionGuard__ takes its arguments by value.
+ */
 static duckdb::unique_ptr<duckdb::QueryResult>
-CreateSPIResult(const duckdb::string &query) {
-	elog(DEBUG1, "Creating SPI result for query: %s", query.c_str());
-
-	std::lock_guard<std::recursive_mutex> lock(pgddb::GlobalProcessLock::GetLock());
-	pgddb::PostgresScopedStackReset scoped_stack_reset;
-
-	SPI_connect();
-	PushActiveSnapshot(GetTransactionSnapshot());
-
+CreateSPIResultBody(const duckdb::string *query_ptr) {
 	duckdb::string error_message;
 	bool had_error = false;
-	int ret = SPIExecuteInSubtransaction(query, had_error, error_message);
+	int ret = SPIExecuteInSubtransaction(*query_ptr, had_error, error_message);
 
 	if (had_error) {
-		PopActiveSnapshot();
-		SPI_finish();
 		duckdb::ErrorData error(duckdb::ExceptionType::IO, "SPI execution failed: " + error_message);
 		return duckdb::make_uniq<duckdb::MaterializedQueryResult>(std::move(error));
 	}
 
 	if (ret < 0) {
-		PopActiveSnapshot();
-		SPI_finish();
 		duckdb::ErrorData error(duckdb::ExceptionType::IO,
 		                        "SPI execution failed: " + duckdb::string(SPI_result_code_string(ret)));
 		return duckdb::make_uniq<duckdb::MaterializedQueryResult>(std::move(error));
@@ -163,8 +188,6 @@ CreateSPIResult(const duckdb::string &query) {
 
 	SPITupleTable *tuptable = SPI_tuptable;
 	if (!tuptable) {
-		PopActiveSnapshot();
-		SPI_finish();
 		return CreateEmptyResult(ConvertSPIResultToDuckStatementType(ret));
 	}
 
@@ -221,12 +244,27 @@ CreateSPIResult(const duckdb::string &query) {
 		collection_p->Append(append_state, chunk);
 	}
 
-	PopActiveSnapshot();
-	SPI_finish();
-
 	duckdb::StatementProperties properties;
 	return duckdb::make_uniq<duckdb::MaterializedQueryResult>(duckdb::StatementType::SELECT_STATEMENT, properties,
 	                                                          names, std::move(collection_p), client_properties);
+}
+
+static duckdb::unique_ptr<duckdb::QueryResult>
+CreateSPIResult(const duckdb::string &query) {
+	elog(DEBUG1, "Creating SPI result for query: %s", query.c_str());
+
+	std::lock_guard<std::recursive_mutex> lock(pgddb::GlobalProcessLock::GetLock());
+	pgddb::PostgresScopedStackReset scoped_stack_reset;
+
+	try {
+		SpiConnectionScope spi;
+		ActiveSnapshotScope snapshot;
+		return PostgresFunctionGuard(CreateSPIResultBody, &query);
+	} catch (const std::exception &ex) {
+		/* Repackage rather than propagate: DuckLake's metadata manager treats an error-carrying
+		 * QueryResult as a value and branches on it. */
+		return duckdb::make_uniq<duckdb::MaterializedQueryResult>(duckdb::ErrorData(ex));
+	}
 }
 
 /* Avoids transaction.GetCatalog(): during init the AttachedDatabase is not yet reachable via db_manager. */
@@ -241,10 +279,29 @@ SubstitutePgCatalogPlaceholders(duckdb::string &query) {
 }
 
 /*
- * Convert PG ERRORs into duckdb::TransactionException so DuckLake's
- * FlushChanges() retry loop can intercept unique-violations from concurrent
- * commits instead of a PG longjmp bypassing the C++ catch.
+ * Below the guard frame -- see CreateSPIResultBody.
+ * Failures become duckdb::TransactionException so DuckLake's FlushChanges() retry loop can
+ * intercept unique-violations from concurrent commits; a C++ throw from here propagates through
+ * the guard unchanged.
  */
+static duckdb::unique_ptr<duckdb::QueryResult>
+CreateSPIExecuteInSubtransactionBody(const duckdb::string *query_ptr) {
+	duckdb::string error_message;
+	bool had_error = false;
+	int ret = SPIExecuteInSubtransaction(*query_ptr, had_error, error_message);
+
+	if (!had_error && ret < 0) {
+		error_message = duckdb::string("SPI execute failed: ") + SPI_result_code_string(ret);
+		had_error = true;
+	}
+
+	if (had_error) {
+		throw duckdb::TransactionException("%s", error_message.c_str());
+	}
+
+	return CreateEmptyResult(duckdb::StatementType::EXECUTE_STATEMENT);
+}
+
 static duckdb::unique_ptr<duckdb::QueryResult>
 CreateSPIExecuteInSubtransaction(const duckdb::string &query) {
 	elog(DEBUG1, "CreateSPIExecuteInSubtransaction: %s", query.c_str());
@@ -252,28 +309,11 @@ CreateSPIExecuteInSubtransaction(const duckdb::string &query) {
 	std::lock_guard<std::recursive_mutex> lock(pgddb::GlobalProcessLock::GetLock());
 	pgddb::PostgresScopedStackReset scoped_stack_reset;
 
-	SPI_connect();
+	SpiConnectionScope spi;
 	// PRE_COMMIT of a pipelined implicit txn (extended protocol) has no active snapshot; SPI needs one pushed.
-	PushActiveSnapshot(GetTransactionSnapshot());
+	ActiveSnapshotScope snapshot;
 
-	duckdb::string error_message;
-	bool had_error = false;
-	int ret = SPIExecuteInSubtransaction(query, had_error, error_message);
-
-	PopActiveSnapshot();
-
-	if (!had_error && ret < 0) {
-		error_message = duckdb::string("SPI execute failed: ") + SPI_result_code_string(ret);
-		had_error = true;
-	}
-
-	SPI_finish();
-
-	if (had_error) {
-		throw duckdb::TransactionException("%s", error_message.c_str());
-	}
-
-	return CreateEmptyResult(duckdb::StatementType::EXECUTE_STATEMENT);
+	return PostgresFunctionGuard(CreateSPIExecuteInSubtransactionBody, &query);
 }
 
 PgDuckLakeMetadataManager::PgDuckLakeMetadataManager(duckdb::DuckLakeTransaction &transaction_)
@@ -471,19 +511,12 @@ PgDuckLakeMetadataManager::IsInitialized() {
 	return found;
 }
 
-/* Raw SPI: runs inside DuckDB's ATTACH path, where re-entering DuckDB would recurse infinitely. */
-void
-PgDuckLakeMetadataManager::EnsureSnapshotTrigger() {
-	std::lock_guard<std::recursive_mutex> lock(pgddb::GlobalProcessLock::GetLock());
-	pgddb::PostgresScopedStackReset scoped_stack_reset;
-
-	SPI_connect();
-	PushActiveSnapshot(GetTransactionSnapshot());
-
+/* Below the guard frame -- see CreateSPIResultBody. */
+static void
+EnsureSnapshotTriggerBody() {
 	auto save_nestlevel = NewGUCNestLevel();
 	::SetConfigOption("duckdb.force_execution", "false", PGC_USERSET, PGC_S_SESSION);
 
-	// SPIExecuteInSubtransaction keeps a PG ERROR from longjmp-ing past the held lock_guard (skips C++ dtors).
 	duckdb::string error_message;
 	bool had_error = false;
 	int ret = SPIExecuteInSubtransaction(R"(
@@ -508,8 +541,6 @@ PgDuckLakeMetadataManager::EnsureSnapshotTrigger() {
 	}
 
 	AtEOXact_GUC(false, save_nestlevel);
-	PopActiveSnapshot();
-	SPI_finish();
 
 	if (had_error || ret < 0) {
 		if (!had_error) {
@@ -517,6 +548,20 @@ PgDuckLakeMetadataManager::EnsureSnapshotTrigger() {
 		}
 		throw duckdb::IOException("EnsureSnapshotTrigger failed: %s", error_message.c_str());
 	}
+}
+
+/* Raw SPI: runs inside DuckDB's ATTACH path, where re-entering DuckDB would recurse infinitely. */
+void
+PgDuckLakeMetadataManager::EnsureSnapshotTrigger() {
+	std::lock_guard<std::recursive_mutex> lock(pgddb::GlobalProcessLock::GetLock());
+	pgddb::PostgresScopedStackReset scoped_stack_reset;
+
+	SpiConnectionScope spi;
+	ActiveSnapshotScope snapshot;
+
+	/* No repackaging: this function already reports failure by throwing, so the guard's exception
+	 * can propagate as-is. */
+	PostgresFunctionGuard(EnsureSnapshotTriggerBody);
 }
 
 bool


### PR DESCRIPTION

Closes #239.

### Problem

PostgreSQL propagates errors with `siglongjmp`, which does not run C++ destructors. `CreateSPIResult` took a `std::lock_guard` on `GlobalProcessLock` and a `PostgresScopedStackReset`, then called `SPI_connect()`, `PushActiveSnapshot()` and `SPIExecuteInSubtransaction()` with none of them guarded and no `PG_TRY` of its own. A PG ERROR in that window jumps straight out to `PortalRun`, roughly 27 frames up. `__CPPFunctionGuard__` at the extension's C++/C boundary does not stop it: that is a `try`/`catch` for C++ exceptions and contains no `sigsetjmp`.

Every RAII object in between is skipped, and not only ours. The outermost is `unique_ptr<ClientContextLock>` in DuckDB's `PendingQueryResult::ExecuteTask`. `ClientContext::context_lock` is **non-recursive** and is left owned by the backend's own thread, so the next DuckDB operation in that session blocks on a lock it already holds, and neither `pg_cancel_backend` nor `pg_terminate_backend` ends it. `GlobalProcessLock` leaks as well, but it is a `std::recursive_mutex` held by the same thread, so it never blocks. That is why the visible symptom points away from the actual cause.

`CreateSPIExecuteInSubtransaction` and `EnsureSnapshotTrigger` have the identical shape.

### Fix

Split all three, so that every PG call that can `ereport` runs below a `PostgresFunctionGuard`. The guard does its `sigsetjmp` in a frame of its own, which is the point: the longjmp stops there and comes back out as a C++ exception that unwinds the callers normally. The bulk of each function moves into a `*Body` helper invoked through it.

SPI and snapshot lifetime move into two scope objects held above the guard, replacing the manual acquisition and (in `CreateSPIResult`) the `PopActiveSnapshot(); SPI_finish();` pair repeated on four exit paths. Two objects rather than one so that a failed snapshot push still releases the SPI connection, since a destructor only runs for a fully constructed object. Both destructors are safe to run during unwind: `SPI_finish()` returns an error code rather than raising, and `PopActiveSnapshot()` is pointer manipulation plus a `pfree`. Their acquisition is guarded in turn, since `SPI_connect()`, `GetTransactionSnapshot()` and `PushActiveSnapshot()` can all raise.

`CreateSPIResult` catches at its own frame and repackages into an error-carrying `MaterializedQueryResult`, keeping the existing contract: DuckLake's metadata manager branches on  such a result rather than expecting a throw. `ErrorData(ex)` also preserves the real exception type, where the old code hardcoded `ExceptionType::IO`. The other two already signal failure by throwing, so the guard's exception propagates untouched.

One comment is deleted rather than corrected. It claimed `SPIExecuteInSubtransaction` stopped a PG ERROR from escaping the caller's held `lock_guard`, but that function's `PG_TRY` opens only after `NewGUCNestLevel`, both `SetConfigOption` calls, `SetAllowSubtransaction` and `BeginInternalSubTransaction` have already run.

### Behaviour change

Error text on this path is now wrapped by the guard:

```
before: ERROR: parameter "..." cannot be set during a parallel operation
after:  ERROR: (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: Failed to get data file
        list from DuckLake: (PGDuckDB/CreateSPIResultBody) parameter "..." ...
```

No expected-output file in the suite matches on it.

### Verification

Reproducer from the issue on a fresh cluster (PG 18.4): `rc=124` (hang) before, `rc=0` after. Same at the default thread count, where the alternate `stack depth limit exceeded` cascade also clears. Under gdb after the error, `GlobalProcessLock` shows `__count == 0` and `ClientContext::context_lock` is unowned. A fresh `ATTACH` on a virgin database exercises `EnsureSnapshotTrigger()` under the new shape and succeeds.

- Regression suite: 52/52 on a pre-fix baseline, 52/52 on three consecutive post-fix runs.
- Fresh `ATTACH` on a virgin database exercises `EnsureSnapshotTrigger()` under the new shape and succeeds, with `ducklake_snapshot_sync_trigger` present.

### Not in this PR

- The parallel-mode GUC bug that supplies today's ERROR on this path. Different defect; this change is about what happens once an ERROR is raised, whichever one it is.
- `SPIExecuteInSubtransaction`'s own prologue, which now sits below the guard and so is no longer catastrophic, but still leaves the GUC nest level unpopped and possibly an open subtransaction if it raises. Covering it needs a flag tracking whether `BeginInternalSubTransaction` actually ran. `EnsureSnapshotTriggerBody` has the same exposure on its own nest level. Neither is a regression, since the same calls were skipped before, and Postgres reclaims nest levels at transaction end.
- The `elog(DEBUG1)` above the lock in the same function, which runs on DuckDB task threads and segfaults at `log_min_messages = debug1`. Separate one-line fix, tracked separately; folding it in here would make two issues share one review.
- The same shape in `libpgduckdb/`, which is shared with pg_duckdb and wants its own change.
