### PR TITLE
fix: set metadata SPI GUCs with GUC_ACTION_SAVE

### DIFF
--- a/pg_ducklake/src/pgducklake_metadata_manager.cpp
+++ b/pg_ducklake/src/pgducklake_metadata_manager.cpp
@@ -96,12 +96,16 @@ SPIExecuteInSubtransaction(const duckdb::string &query, bool &had_error, duckdb:
 	int ret = -1;
 	had_error = false;
 
+	/* GUC_ACTION_SAVE, not SetConfigOption()'s GUC_ACTION_SET: a metadata query can be issued while a
+	 * libpgduckdb PostgresTableReader has put the backend in PG parallel mode, and guc.c rejects
+	 * GUC_ACTION_SET there. SAVE is exempt because a parallel worker pops it too; PG itself relies on
+	 * that in execute_extension_script(). */
 	/* Suppress NOTICEs: DuckLake re-runs CREATE TABLE IF NOT EXISTS, whose NOTICE would leak to the client. */
 	int save_nestlevel = NewGUCNestLevel();
-	::SetConfigOption("client_min_messages", "warning", PGC_USERSET, PGC_S_SESSION);
+	::set_config_option("client_min_messages", "warning", PGC_USERSET, PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	/* DuckLake-generated SQL calls DuckDB-dialect functions (month(), murmur3_32(), ...) unqualified;
 	 * resolve them to the ducklake-schema UDFs deterministically, independent of the caller's search_path. */
-	::SetConfigOption("search_path", "ducklake", PGC_USERSET, PGC_S_SESSION);
+	::set_config_option("search_path", "ducklake", PGC_USERSET, PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	SetAllowSubtransaction(true);
 	BeginInternalSubTransaction(NULL);

--- a/pg_ducklake/test/regression/expected/parallel_mode_metadata.out
+++ b/pg_ducklake/test/regression/expected/parallel_mode_metadata.out
@@ -1,0 +1,48 @@
+-- Regression test for: parameter "client_min_messages" cannot be set during a
+-- parallel operation.
+--
+-- libpgduckdb's PostgresTableReader calls EnterParallelMode() for every
+-- non-temp heap relation whose scan plan is parallel-safe, and the backend then
+-- stays in PG parallel mode for the rest of that DuckDB query.  The call does
+-- not consult max_parallel_workers, so regression.conf's max_parallel_workers =
+-- 0 does not prevent it; raising it does not either, since a worker then really
+-- launches and the window is just as open.  This test therefore covers the
+-- suite's configuration, not the only affected one.
+--
+-- A DuckLake metadata query issued inside that window runs over
+-- SPI, which sets client_min_messages and search_path -- and guc.c rejects
+-- GUC_ACTION_SET in parallel mode.  The ereport then longjmps out of
+-- CreateSPIResult past its std::lock_guard on GlobalProcessLock, so the lock is
+-- never released and every later DuckDB operation in the backend blocks
+-- forever.
+--
+-- Both halves have to land in one DuckDB query, in this order:
+--   * count(*) over a plain heap table, written first so its
+--     PostgresTableReader (count_tuples_only) enters parallel mode first;
+--   * count(*) over a DuckLake table WITH a filter -- filter pushdown builds a
+--     fresh DuckLakeMultiFileList whose file list is only expanded, by a
+--     metadata query, during execution.  Drop the filter and the file list is
+--     already resolved at bind time, so nothing reaches SPI.
+--
+-- ducklake.threads = 1 pins that ordering.  At DuckDB's default thread count
+-- the two pipelines can start on different threads and the failure turns
+-- intermittent, which is why CI only ever lost this race on one job.
+--
+-- The tables are deliberately left behind: before the fix the SELECT leaks
+-- GlobalProcessLock, so a following DROP TABLE on the ducklake table would
+-- block until the CI job's timeout instead of producing a diff.  Keeping the
+-- SELECT last is what makes the regression bounded, and is why this test is
+-- scheduled last.
+SET ducklake.threads = 1;
+CALL ducklake.recycle_ddb();
+CREATE TABLE pm_heap(id int);
+INSERT INTO pm_heap VALUES (1), (2), (3);
+CREATE TABLE pm_lake(id int, val text) USING ducklake;
+INSERT INTO pm_lake VALUES (1, 'x'), (2, 'y');
+SELECT (SELECT count(*) FROM pm_heap) AS heap_count,
+       (SELECT count(*) FROM pm_lake WHERE id = 2) AS lake_count;
+ heap_count | lake_count 
+------------+------------
+          3 |          1
+(1 row)
+

--- a/pg_ducklake/test/regression/schedule
+++ b/pg_ducklake/test/regression/schedule
@@ -55,3 +55,4 @@ test: import_foreign_schema
 test: secrets
 test: access_control
 test: quoted_names
+test: parallel_mode_metadata

--- a/pg_ducklake/test/regression/sql/parallel_mode_metadata.sql
+++ b/pg_ducklake/test/regression/sql/parallel_mode_metadata.sql
@@ -1,0 +1,47 @@
+-- Regression test for: parameter "client_min_messages" cannot be set during a
+-- parallel operation.
+--
+-- libpgduckdb's PostgresTableReader calls EnterParallelMode() for every
+-- non-temp heap relation whose scan plan is parallel-safe, and the backend then
+-- stays in PG parallel mode for the rest of that DuckDB query.  The call does
+-- not consult max_parallel_workers, so regression.conf's max_parallel_workers =
+-- 0 does not prevent it; raising it does not either, since a worker then really
+-- launches and the window is just as open.  This test therefore covers the
+-- suite's configuration, not the only affected one.
+--
+-- A DuckLake metadata query issued inside that window runs over
+-- SPI, which sets client_min_messages and search_path -- and guc.c rejects
+-- GUC_ACTION_SET in parallel mode.  The ereport then longjmps out of
+-- CreateSPIResult past its std::lock_guard on GlobalProcessLock, so the lock is
+-- never released and every later DuckDB operation in the backend blocks
+-- forever.
+--
+-- Both halves have to land in one DuckDB query, in this order:
+--   * count(*) over a plain heap table, written first so its
+--     PostgresTableReader (count_tuples_only) enters parallel mode first;
+--   * count(*) over a DuckLake table WITH a filter -- filter pushdown builds a
+--     fresh DuckLakeMultiFileList whose file list is only expanded, by a
+--     metadata query, during execution.  Drop the filter and the file list is
+--     already resolved at bind time, so nothing reaches SPI.
+--
+-- ducklake.threads = 1 pins that ordering.  At DuckDB's default thread count
+-- the two pipelines can start on different threads and the failure turns
+-- intermittent, which is why CI only ever lost this race on one job.
+--
+-- The tables are deliberately left behind: before the fix the SELECT leaks
+-- GlobalProcessLock, so a following DROP TABLE on the ducklake table would
+-- block until the CI job's timeout instead of producing a diff.  Keeping the
+-- SELECT last is what makes the regression bounded, and is why this test is
+-- scheduled last.
+
+SET ducklake.threads = 1;
+CALL ducklake.recycle_ddb();
+
+CREATE TABLE pm_heap(id int);
+INSERT INTO pm_heap VALUES (1), (2), (3);
+
+CREATE TABLE pm_lake(id int, val text) USING ducklake;
+INSERT INTO pm_lake VALUES (1, 'x'), (2, 'y');
+
+SELECT (SELECT count(*) FROM pm_heap) AS heap_count,
+       (SELECT count(*) FROM pm_lake WHERE id = 2) AS lake_count;


### PR DESCRIPTION
Mitigates #241. Does not close it -- the parallel-mode window that issue describes stays open.

Please land after #240 as its only reproducer is the ERROR this change removes, so merging this first leaves that fix unverifiable.

### Problem

`SPIExecuteInSubtransaction` sets `client_min_messages` and `search_path` through `SetConfigOption`, which uses `GUC_ACTION_SET`. `guc.c` rejects that while the backend is in PostgreSQL parallel mode, and libpgduckdb's `PostgresTableReader` enters parallel mode for any non-temp relation whose plan `CanTableScanRunInParallel` accepts, holding it until that scan is drained -- long enough to cover metadata queries issued by other pipelines, or by other DuckDB task threads, since parallel mode is backend-wide state. A DuckLake metadata query issued inside that window fails:

```
ERROR:  parameter "client_min_messages" cannot be set during a parallel operation
```

Ordinary query shapes hit it -- a `count(*)` over a heap table plus a filtered ducklake scan in one statement does it every time. `max_parallel_workers` does not gate it either way.

### Fix

Set both GUCs with `set_config_option(..., GUC_ACTION_SAVE, ...)` instead. The parallel-mode check in `set_config_with_handle()` exempts `GUC_ACTION_SAVE` by construction -- its own comment says such changes "are acceptable during a parallel operation, because the current worker will also pop the change" -- the function's existing `NewGUCNestLevel()`/`AtEOXact_GUC()` bracket already restores values set that way, and PostgreSQL does the same thing in `execute_extension_script()`, the `CREATE EXTENSION` script path (`extension.c:1321-1364` on PG 19).

### Verification

New regression test `parallel_mode_metadata`, deterministic in both directions on this branch: reverting the source change alone turns it red with the ERROR above, restoring it turns it green. Full suite 53/53. Also verified by hand at `max_parallel_workers = 8`, where a worker really launches: 3/3 fail without the change, 5/5 pass with it.

The suite runs `max_parallel_workers = 0` (a Mac-only-hang workaround in `regression.conf`), so CI covers one of the two configurations. The other is the manual result above.

PG 18.4 only; PG 17, PG 19 and the coexist configuration were not run locally.

The test is scheduled last and deliberately leaves its two tables behind. Until #239 (fixed by #240) lands, a `DROP TABLE` after the failing `SELECT` wedges the session rather than producing a diff, so adding cleanup would turn any future regression into a CI timeout instead of a test failure. Both can be undone then.

### Not in this PR

**The window itself.** `PostgresTableReader` enters parallel mode unconditionally once its gate passes, and holds it until the scan is drained. That is the underlying defect and it lives in `libpgduckdb/`. This change makes the read path survive the window; it does not close it.