### PR TITLE
[v1.0] fix: set metadata SPI GUCs with GUC_ACTION_SAVE

### DIFF
--- a/pg_ducklake/src/pgducklake_metadata_manager.cpp
+++ b/pg_ducklake/src/pgducklake_metadata_manager.cpp
@@ -93,9 +93,13 @@ SPIExecuteInSubtransaction(const duckdb::string &query, bool &had_error, duckdb:
 	int ret = -1;
 	had_error = false;
 
+	/* GUC_ACTION_SAVE, not SetConfigOption()'s GUC_ACTION_SET: a metadata query can be issued while a
+	 * libpgduckdb PostgresTableReader has put the backend in PG parallel mode, and guc.c rejects
+	 * GUC_ACTION_SET there. SAVE is exempt because a parallel worker pops it too; PG itself relies on
+	 * that in execute_extension_script(). */
 	/* Suppress NOTICEs: DuckLake re-runs CREATE TABLE IF NOT EXISTS, whose NOTICE would leak to the client. */
 	int save_nestlevel = NewGUCNestLevel();
-	::SetConfigOption("client_min_messages", "warning", PGC_USERSET, PGC_S_SESSION);
+	::set_config_option("client_min_messages", "warning", PGC_USERSET, PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	SetAllowSubtransaction(true);
 	BeginInternalSubTransaction(NULL);

--- a/pg_ducklake/test/regression/expected/parallel_mode_metadata.out
+++ b/pg_ducklake/test/regression/expected/parallel_mode_metadata.out
@@ -1,0 +1,48 @@
+-- Regression test for: parameter "client_min_messages" cannot be set during a
+-- parallel operation.
+--
+-- libpgduckdb's PostgresTableReader calls EnterParallelMode() for every
+-- non-temp heap relation whose scan plan is parallel-safe, and the backend then
+-- stays in PG parallel mode for the rest of that DuckDB query.  The call does
+-- not consult max_parallel_workers, so regression.conf's max_parallel_workers =
+-- 0 does not prevent it; raising it does not either, since a worker then really
+-- launches and the window is just as open.  This test therefore covers the
+-- suite's configuration, not the only affected one.
+--
+-- A DuckLake metadata query issued inside that window runs over
+-- SPI, which sets client_min_messages -- and guc.c rejects GUC_ACTION_SET in
+-- parallel mode.  The ereport then longjmps out of
+-- CreateSPIResult past its std::lock_guard on GlobalProcessLock, so the lock is
+-- never released and every later DuckDB operation in the backend blocks
+-- forever.
+--
+-- Both halves have to land in one DuckDB query, in this order:
+--   * count(*) over a plain heap table, written first so its
+--     PostgresTableReader (count_tuples_only) enters parallel mode first;
+--   * count(*) over a DuckLake table WITH a filter -- filter pushdown builds a
+--     fresh DuckLakeMultiFileList whose file list is only expanded, by a
+--     metadata query, during execution.  Drop the filter and the file list is
+--     already resolved at bind time, so nothing reaches SPI.
+--
+-- ducklake.threads = 1 pins that ordering.  At DuckDB's default thread count
+-- the two pipelines can start on different threads and the failure turns
+-- intermittent, which is why CI only ever lost this race on one job.
+--
+-- The tables are deliberately left behind: before the fix the SELECT leaks
+-- GlobalProcessLock, so a following DROP TABLE on the ducklake table would
+-- block until the CI job's timeout instead of producing a diff.  Keeping the
+-- SELECT last is what makes the regression bounded, and is why this test is
+-- scheduled last.
+SET ducklake.threads = 1;
+CALL ducklake.recycle_ddb();
+CREATE TABLE pm_heap(id int);
+INSERT INTO pm_heap VALUES (1), (2), (3);
+CREATE TABLE pm_lake(id int, val text) USING ducklake;
+INSERT INTO pm_lake VALUES (1, 'x'), (2, 'y');
+SELECT (SELECT count(*) FROM pm_heap) AS heap_count,
+       (SELECT count(*) FROM pm_lake WHERE id = 2) AS lake_count;
+ heap_count | lake_count 
+------------+------------
+          3 |          1
+(1 row)
+

--- a/pg_ducklake/test/regression/schedule
+++ b/pg_ducklake/test/regression/schedule
@@ -50,3 +50,4 @@ test: secrets
 test: access_control
 test: quoted_names
 test: create_view_shapes
+test: parallel_mode_metadata

--- a/pg_ducklake/test/regression/sql/parallel_mode_metadata.sql
+++ b/pg_ducklake/test/regression/sql/parallel_mode_metadata.sql
@@ -1,0 +1,47 @@
+-- Regression test for: parameter "client_min_messages" cannot be set during a
+-- parallel operation.
+--
+-- libpgduckdb's PostgresTableReader calls EnterParallelMode() for every
+-- non-temp heap relation whose scan plan is parallel-safe, and the backend then
+-- stays in PG parallel mode for the rest of that DuckDB query.  The call does
+-- not consult max_parallel_workers, so regression.conf's max_parallel_workers =
+-- 0 does not prevent it; raising it does not either, since a worker then really
+-- launches and the window is just as open.  This test therefore covers the
+-- suite's configuration, not the only affected one.
+--
+-- A DuckLake metadata query issued inside that window runs over
+-- SPI, which sets client_min_messages -- and guc.c rejects GUC_ACTION_SET in
+-- parallel mode.  The ereport then longjmps out of
+-- CreateSPIResult past its std::lock_guard on GlobalProcessLock, so the lock is
+-- never released and every later DuckDB operation in the backend blocks
+-- forever.
+--
+-- Both halves have to land in one DuckDB query, in this order:
+--   * count(*) over a plain heap table, written first so its
+--     PostgresTableReader (count_tuples_only) enters parallel mode first;
+--   * count(*) over a DuckLake table WITH a filter -- filter pushdown builds a
+--     fresh DuckLakeMultiFileList whose file list is only expanded, by a
+--     metadata query, during execution.  Drop the filter and the file list is
+--     already resolved at bind time, so nothing reaches SPI.
+--
+-- ducklake.threads = 1 pins that ordering.  At DuckDB's default thread count
+-- the two pipelines can start on different threads and the failure turns
+-- intermittent, which is why CI only ever lost this race on one job.
+--
+-- The tables are deliberately left behind: before the fix the SELECT leaks
+-- GlobalProcessLock, so a following DROP TABLE on the ducklake table would
+-- block until the CI job's timeout instead of producing a diff.  Keeping the
+-- SELECT last is what makes the regression bounded, and is why this test is
+-- scheduled last.
+
+SET ducklake.threads = 1;
+CALL ducklake.recycle_ddb();
+
+CREATE TABLE pm_heap(id int);
+INSERT INTO pm_heap VALUES (1), (2), (3);
+
+CREATE TABLE pm_lake(id int, val text) USING ducklake;
+INSERT INTO pm_lake VALUES (1, 'x'), (2, 'y');
+
+SELECT (SELECT count(*) FROM pm_heap) AS heap_count,
+       (SELECT count(*) FROM pm_lake WHERE id = 2) AS lake_count;


### PR DESCRIPTION
Backport of #242 to `v1.0`.

`SPIExecuteInSubtransaction` currently sets `client_min_messages` with `GUC_ACTION_SET`, which PostgreSQL rejects while libpgduckdb's `PostgresTableReader` has the backend in parallel mode. Use `GUC_ACTION_SAVE`, matching the existing GUC nest-level restoration and PostgreSQL's own extension-script handling.

Includes the deterministic `parallel_mode_metadata` regression from #242. The test is kept last because, without the fix, the final query reports the expected parallel-operation error and later DuckDB operations can block.

Backport notes:
- Resolved the schedule conflict by retaining `create_view_shapes` and appending `parallel_mode_metadata`.
- The `v1.0` branch only changes `client_min_messages` in this path, so the backport does not introduce main's later `search_path` behavior.
- Original commit author is preserved as Gavin Brand.

Verification (PostgreSQL 18.3):

```text
ok 1 - parallel_mode_metadata
1..1
# All 1 tests passed.
```
