### PR TITLE
v1.0.2

### DIFF
--- a/pg_ducklake/pg_ducklake.control
+++ b/pg_ducklake/pg_ducklake.control
@@ -1,4 +1,4 @@
 comment = 'DuckLake lakehouse extension built on libpgddb'
-default_version = '1.0.1'
+default_version = '1.0.2'
 module_pathname = '$libdir/pg_ducklake'
 relocatable = false

--- a/pg_ducklake/sql/pg_ducklake--1.0.1--1.0.2.sql
+++ b/pg_ducklake/sql/pg_ducklake--1.0.1--1.0.2.sql
@@ -1,0 +1,1 @@
+-- 1.0.2 is a bug-fix release with no SQL object changes.

--- a/pg_ducklake/test/regression/expected/initialization.out
+++ b/pg_ducklake/test/regression/expected/initialization.out
@@ -6,7 +6,7 @@ FROM pg_extension WHERE extname IN ('plpgsql', 'pg_ducklake') ORDER BY extname =
    extname   | extowner | extnamespace | extrelocatable | extversion | extconfig | extcondition 
 -------------+----------+--------------+----------------+------------+-----------+--------------
  plpgsql     |       10 |           11 | f              | 1.0        |           | 
- pg_ducklake |       10 |         2200 | f              | 1.0.1      |           | 
+ pg_ducklake |       10 |         2200 | f              | 1.0.2      |           | 
 (2 rows)
 
 SELECT amname FROM pg_am WHERE amname = 'ducklake';


### PR DESCRIPTION
## Summary

- bump the default extension version to 1.0.2
- add the 1.0.1 to 1.0.2 no-op upgrade script
- update the initialization regression expectation

## Tests

- `make check-format`
- `make installcheck` (PostgreSQL 18.3; 53 regression and 4 isolation tests passed)