### PR TITLE
fix: guard postgres calls that unwind past C++ destructors

### DIFF
--- a/libpgduckdb/include/pgddb/scan/postgres_table_reader.hpp
+++ b/libpgduckdb/include/pgddb/scan/postgres_table_reader.hpp
@@ -14,7 +14,9 @@ public:
 	~PostgresTableReader();
 	void Init(const char *table_scan_query, bool count_tuples_only);
 	void Cleanup();
-	bool GetNextMinimalWorkerTuple(std::vector<uint8_t> &minimal_tuple_buffer);
+	// Parallel workers: each buffer owns a copy of the worker's minimal tuple; result < max means EOF. Caller holds
+	// GlobalProcessLock.
+	int GetNextMinimalWorkerTuples(std::vector<uint8_t> *minimal_tuple_buffers, int max);
 	// In-process (no workers): each slot owns its copy (freed on next store); result < max means EOF. Caller holds
 	// GlobalProcessLock.
 	int GetNextInProcessTuples(TupleTableSlot **slots, int max);
@@ -36,6 +38,7 @@ private:
 
 	TupleTableSlot *GetNextTuple();
 	int GetNextInProcessTuplesUnsafe(TupleTableSlot **slots, int max);
+	int GetNextMinimalWorkerTuplesUnsafe(std::vector<uint8_t> *minimal_tuple_buffers, int max);
 	TupleTableSlot *GetNextTupleUnsafe();
 	TupleTableSlot *ExecNextTupleUnsafe();
 	MinimalTuple GetNextWorkerTuple();

--- a/libpgduckdb/scan/order_pushdown_optimizer.cpp
+++ b/libpgduckdb/scan/order_pushdown_optimizer.cpp
@@ -1,6 +1,7 @@
 #include "pgddb/scan/order_pushdown_optimizer.hpp"
 
 #include "pgddb/logger.hpp"
+#include "pgddb/pgddb_utils.hpp"
 #include "pgddb/scan/postgres_scan.hpp"
 
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
@@ -47,7 +48,12 @@ IndexSupportsOrder(Relation rel, const duckdb::vector<AttrNumber> &order_attrs,
 	if (order_attrs.empty()) {
 		return false;
 	}
-	List *index_list = RelationGetIndexList(rel);
+	/*
+	 * Guarded throughout: this runs as an OptimizerExtension callback under the
+	 * ClientContextLock held by ClientContext::Prepare. A longjmp past that frame leaves
+	 * the context mutex locked, deadlocking the backend on its next statement.
+	 */
+	List *index_list = PostgresFunctionGuard(RelationGetIndexList, rel);
 	if (index_list == NIL) {
 		return false;
 	}
@@ -55,14 +61,14 @@ IndexSupportsOrder(Relation rel, const duckdb::vector<AttrNumber> &order_attrs,
 	ListCell *lc;
 	foreach (lc, index_list) {
 		Oid index_oid = lfirst_oid(lc);
-		Relation index_rel = index_open(index_oid, AccessShareLock);
+		Relation index_rel = PostgresFunctionGuard(index_open, index_oid, AccessShareLock);
 		// Cheap structural rejects first: a valid btree covering all order keys, not partial.
 		// (A partial index can never satisfy a whole-table ORDER BY.)
 		if (!index_rel->rd_index || !index_rel->rd_index->indisvalid || index_rel->rd_rel->relam != BTREE_AM_OID ||
 		    static_cast<duckdb::idx_t>(index_rel->rd_index->indnkeyatts) < order_attrs.size() ||
 		    static_cast<duckdb::idx_t>(index_rel->rd_index->indkey.dim1) < order_attrs.size() ||
-		    RelationGetIndexPredicate(index_rel) != NIL) {
-			index_close(index_rel, AccessShareLock);
+		    PostgresFunctionGuard(RelationGetIndexPredicate, index_rel) != NIL) {
+			PostgresFunctionGuard(index_close, index_rel, AccessShareLock);
 			continue;
 		}
 		bool attr_match = true;
@@ -109,7 +115,7 @@ IndexSupportsOrder(Relation rel, const duckdb::vector<AttrNumber> &order_attrs,
 		if (attr_match && (matches_forward || matches_backward)) {
 			supported = true;
 		}
-		index_close(index_rel, AccessShareLock);
+		PostgresFunctionGuard(index_close, index_rel, AccessShareLock);
 		if (supported) {
 			break;
 		}

--- a/libpgduckdb/scan/postgres_scan.cpp
+++ b/libpgduckdb/scan/postgres_scan.cpp
@@ -606,13 +606,9 @@ PostgresScanTableFunction::PostgresScanFunction(duckdb::ClientContext &, duckdb:
 			size_t valid_slots = 0;
 			{
 				std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
-				for (size_t i = 0; i < LOCAL_STATE_SLOT_BATCH_SIZE; i++) {
-					if (!table_reader.GetNextMinimalWorkerTuple(local_state.minimal_tuple_buffer[i])) {
-						local_state.exhausted_scan = true;
-						break;
-					}
-					++valid_slots;
-				}
+				valid_slots = table_reader.GetNextMinimalWorkerTuples(local_state.minimal_tuple_buffer,
+				                                                      LOCAL_STATE_SLOT_BATCH_SIZE);
+				local_state.exhausted_scan = valid_slots < LOCAL_STATE_SLOT_BATCH_SIZE;
 			}
 			for (size_t i = 0; i < valid_slots; i++) {
 				MinimalTuple minimal_tuple = reinterpret_cast<MinimalTuple>(local_state.minimal_tuple_buffer[i].data());

--- a/libpgduckdb/scan/postgres_table_reader.cpp
+++ b/libpgduckdb/scan/postgres_table_reader.cpp
@@ -279,6 +279,12 @@ PostgresTableReader::MarkPlanParallelAware(Plan *plan) {
 /* GlobalProcessLock must be held before calling this. */
 TupleTableSlot *
 PostgresTableReader::GetNextTuple() {
+	/*
+	 * Above the guard, not below it: the guard's sigsetjmp lives in its own frame, so a longjmp
+	 * from the scan skips every frame deeper than that one. Here the guard's throw unwinds this
+	 * frame normally and restore_stack_base runs. Same reason as Init/Cleanup.
+	 */
+	PostgresScopedStackReset scoped_stack_reset;
 	return PostgresMemberGuard(PostgresTableReader::GetNextTupleUnsafe);
 }
 
@@ -297,7 +303,6 @@ PostgresTableReader::GetNextTupleUnsafe() {
 
 TupleTableSlot *
 PostgresTableReader::ExecNextTupleUnsafe() {
-	PostgresScopedStackReset scoped_stack_reset;
 	table_scan_query_desc->estate->es_query_dsa = parallel_executor_info ? parallel_executor_info->area : NULL;
 	TupleTableSlot *thread_scan_slot = ExecProcNode(table_scan_planstate);
 	table_scan_query_desc->estate->es_query_dsa = NULL;
@@ -311,24 +316,31 @@ CopyMinimalTuple(MinimalTuple src_minimal_tuple, std::vector<uint8_t> &dst_buffe
 	memcpy(dst_buffer.data(), src_minimal_tuple, tuple_size);
 }
 
-/*
- * Only valid when the scan runs with parallel workers; caller must hold GlobalProcessLock.
- * Returns false when the scan is complete.
- */
-bool
-PostgresTableReader::GetNextMinimalWorkerTuple(std::vector<uint8_t> &minimal_tuple_buffer) {
-	MinimalTuple worker_minmal_tuple = GetNextWorkerTuple();
-	if (HeapTupleIsValid(worker_minmal_tuple)) {
-		CopyMinimalTuple(worker_minmal_tuple, minimal_tuple_buffer);
-		return true;
-	}
+/* Only valid when the scan runs with parallel workers; caller must hold GlobalProcessLock. */
+int
+PostgresTableReader::GetNextMinimalWorkerTuples(std::vector<uint8_t> *minimal_tuple_buffers, int max) {
+	return PostgresMemberGuard(PostgresTableReader::GetNextMinimalWorkerTuplesUnsafe, minimal_tuple_buffers, max);
+}
 
-	minimal_tuple_buffer.resize(0);
-	return false;
+int
+PostgresTableReader::GetNextMinimalWorkerTuplesUnsafe(std::vector<uint8_t> *minimal_tuple_buffers, int max) {
+	/* One guard (from GetNextMinimalWorkerTuples) covers the whole batch, not one per tuple. */
+	int count = 0;
+	for (; count < max; count++) {
+		MinimalTuple worker_minmal_tuple = GetNextWorkerTuple();
+		if (!HeapTupleIsValid(worker_minmal_tuple)) {
+			minimal_tuple_buffers[count].resize(0);
+			break;
+		}
+		CopyMinimalTuple(worker_minmal_tuple, minimal_tuple_buffers[count]);
+	}
+	return count;
 }
 
 int
 PostgresTableReader::GetNextInProcessTuples(TupleTableSlot **slots, int max) {
+	/* Above the guard, for the reason in GetNextTuple. */
+	PostgresScopedStackReset scoped_stack_reset;
 	return PostgresMemberGuard(PostgresTableReader::GetNextInProcessTuplesUnsafe, slots, max);
 }
 

--- a/pg_ducklake/test/isolation/expected/optimizer_lock_error.out
+++ b/pg_ducklake/test/isolation/expected/optimizer_lock_error.out
@@ -1,0 +1,15 @@
+Parsed test spec with 2 sessions
+
+starting permutation: b_begin b_reindex s_query s_after b_commit
+step b_begin: BEGIN;
+step b_reindex: REINDEX INDEX iso_opt_heap_idx;
+step s_query: SELECT h.id FROM (SELECT id FROM iso_opt_heap ORDER BY id) h JOIN iso_opt_lake ON h.id = iso_opt_lake.x; <waiting ...>
+step s_query: <... completed>
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: Executor Error: (PGDuckDB/index_open) canceling statement due to lock timeout
+step s_after: SELECT count(*) FROM iso_opt_lake;
+count
+-----
+    3
+(1 row)
+
+step b_commit: COMMIT;

--- a/pg_ducklake/test/isolation/schedule
+++ b/pg_ducklake/test/isolation/schedule
@@ -2,3 +2,4 @@ test: explicit_transaction_commit
 test: concurrent_writes
 test: concurrent_cross_table_writes
 test: concurrent_inline_flush
+test: optimizer_lock_error

--- a/pg_ducklake/test/isolation/specs/optimizer_lock_error.spec
+++ b/pg_ducklake/test/isolation/specs/optimizer_lock_error.spec
@@ -1,0 +1,41 @@
+# The ORDER BY pushdown optimizer opens indexes from inside a DuckDB
+# OptimizerExtension callback, which runs under the ClientContextLock held by
+# ClientContext::Prepare. A Postgres error there must unwind as a C++ exception:
+# a longjmp skips that lock's destructor and deadlocks the backend's own DuckDB
+# connection, so s_after, not s_query, is the real assertion here.
+#
+# A regression does not show up as a diff. s_after never returns, isolationtester
+# cancels it after 360s, and the run takes ~10 minutes and leaves a backend that
+# ignores SIGTERM and needs SIGKILL.
+
+setup
+{
+  CREATE TABLE iso_opt_heap (id int, val text);
+  INSERT INTO iso_opt_heap SELECT g, 'v' || g FROM generate_series(1, 50) g;
+  CREATE INDEX iso_opt_heap_idx ON iso_opt_heap (id);
+  CREATE TABLE iso_opt_lake (x int) USING ducklake;
+  INSERT INTO iso_opt_lake VALUES (1), (2), (3);
+}
+
+teardown
+{
+  DROP TABLE iso_opt_lake;
+  DROP TABLE iso_opt_heap;
+}
+
+session blocker
+# REINDEX takes AccessExclusiveLock on the index but only ShareLock on the table,
+# so the scanner can still plan and reach index_open before it blocks.
+step b_begin   { BEGIN; }
+step b_reindex { REINDEX INDEX iso_opt_heap_idx; }
+step b_commit  { COMMIT; }
+
+session scanner
+# Without lock_timeout the scanner waits instead of erroring, and nothing unwinds.
+setup { SET lock_timeout = '500ms'; }
+# The DuckLake join routes this through DuckDB; the ORDER BY over the indexed heap
+# is what makes the optimizer open iso_opt_heap's indexes.
+step s_query { SELECT h.id FROM (SELECT id FROM iso_opt_heap ORDER BY id) h JOIN iso_opt_lake ON h.id = iso_opt_lake.x; }
+step s_after { SELECT count(*) FROM iso_opt_lake; }
+
+permutation b_begin b_reindex s_query s_after b_commit

--- a/pg_ducklake/test/regression/expected/scan_error_unwind.out
+++ b/pg_ducklake/test/regression/expected/scan_error_unwind.out
@@ -1,0 +1,63 @@
+-- A Postgres error raised while DuckDB reads a heap table through
+-- PostgresTableReader must unwind as a C++ exception, not a longjmp. The
+-- PostgresScopedStackReset sits above the guard so the guard's throw unwinds
+-- it; owned below the guard instead, a longjmp skips the destructor and PG's
+-- stack base keeps pointing at the scan's stack.
+--
+-- The error text is identical either way, so it proves nothing here. The
+-- max_stack_depth probes around the failed scan are the assertion. They run at
+-- 100kB because the abandoned base lands a variable distance away per run and
+-- is not always far enough off to trip the default limit.
+CREATE TABLE scan_err_heap(a int);
+INSERT INTO scan_err_heap VALUES (5), (2), (0);
+-- An RLS policy is a portable way to get an expression evaluated inside the
+-- scan itself; this one divides by zero on the last row.
+ALTER TABLE scan_err_heap ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scan_err_heap FORCE ROW LEVEL SECURITY;
+CREATE POLICY scan_err_policy ON scan_err_heap USING (10 / a > 0);
+CREATE TABLE scan_err_lake(x int) USING ducklake;
+INSERT INTO scan_err_lake VALUES (1);
+-- Superusers bypass RLS, so the scan runs as an unprivileged reader.
+CREATE USER scan_err_user IN ROLE ducklake_reader;
+GRANT ALL ON ALL TABLES IN SCHEMA ducklake TO scan_err_user;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA ducklake TO scan_err_user;
+GRANT SELECT ON scan_err_heap, scan_err_lake TO scan_err_user;
+\set VERBOSITY terse
+-- Baseline for the same two probes repeated after the failed scan.
+SET max_stack_depth = '100kB';
+SELECT 1 AS shallow;
+ shallow 
+---------
+       1
+(1 row)
+
+DO $$ BEGIN EXECUTE format('SELECT %s1%s', repeat('abs(', 2000), repeat(')', 2000)); END $$;
+ERROR:  stack depth limit exceeded
+RESET max_stack_depth;
+SET ROLE scan_err_user;
+-- Referencing the DuckLake table routes the whole query through DuckDB, which
+-- reads scan_err_heap back out of Postgres.
+SELECT a FROM scan_err_heap, scan_err_lake;
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: (PGDuckDB/GetNextInProcessTuples) division by zero
+-- count(*) reaches the same frame via GetNextCount/GetNextTuple rather than the
+-- batched GetNextInProcessTuples path, so a different caller guards it.
+SELECT count(*) FROM scan_err_heap, scan_err_lake;
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: (PGDuckDB/GetNextTuple) division by zero
+RESET ROLE;
+-- Must match the baseline above.
+SET max_stack_depth = '100kB';
+SELECT 1 AS shallow;
+ shallow 
+---------
+       1
+(1 row)
+
+DO $$ BEGIN EXECUTE format('SELECT %s1%s', repeat('abs(', 2000), repeat(')', 2000)); END $$;
+ERROR:  stack depth limit exceeded
+RESET max_stack_depth;
+\set VERBOSITY default
+DROP TABLE scan_err_lake;
+DROP TABLE scan_err_heap;
+REVOKE ALL ON ALL TABLES IN SCHEMA ducklake FROM scan_err_user;
+REVOKE ALL ON ALL SEQUENCES IN SCHEMA ducklake FROM scan_err_user;
+DROP USER scan_err_user;

--- a/pg_ducklake/test/regression/schedule
+++ b/pg_ducklake/test/regression/schedule
@@ -55,3 +55,4 @@ test: access_control
 test: quoted_names
 test: create_view_shapes
 test: parallel_mode_metadata
+test: scan_error_unwind

--- a/pg_ducklake/test/regression/sql/scan_error_unwind.sql
+++ b/pg_ducklake/test/regression/sql/scan_error_unwind.sql
@@ -1,0 +1,59 @@
+-- A Postgres error raised while DuckDB reads a heap table through
+-- PostgresTableReader must unwind as a C++ exception, not a longjmp. The
+-- PostgresScopedStackReset sits above the guard so the guard's throw unwinds
+-- it; owned below the guard instead, a longjmp skips the destructor and PG's
+-- stack base keeps pointing at the scan's stack.
+--
+-- The error text is identical either way, so it proves nothing here. The
+-- max_stack_depth probes around the failed scan are the assertion. They run at
+-- 100kB because the abandoned base lands a variable distance away per run and
+-- is not always far enough off to trip the default limit.
+
+CREATE TABLE scan_err_heap(a int);
+INSERT INTO scan_err_heap VALUES (5), (2), (0);
+
+-- An RLS policy is a portable way to get an expression evaluated inside the
+-- scan itself; this one divides by zero on the last row.
+ALTER TABLE scan_err_heap ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scan_err_heap FORCE ROW LEVEL SECURITY;
+CREATE POLICY scan_err_policy ON scan_err_heap USING (10 / a > 0);
+
+CREATE TABLE scan_err_lake(x int) USING ducklake;
+INSERT INTO scan_err_lake VALUES (1);
+
+-- Superusers bypass RLS, so the scan runs as an unprivileged reader.
+CREATE USER scan_err_user IN ROLE ducklake_reader;
+GRANT ALL ON ALL TABLES IN SCHEMA ducklake TO scan_err_user;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA ducklake TO scan_err_user;
+GRANT SELECT ON scan_err_heap, scan_err_lake TO scan_err_user;
+
+\set VERBOSITY terse
+
+-- Baseline for the same two probes repeated after the failed scan.
+SET max_stack_depth = '100kB';
+SELECT 1 AS shallow;
+DO $$ BEGIN EXECUTE format('SELECT %s1%s', repeat('abs(', 2000), repeat(')', 2000)); END $$;
+RESET max_stack_depth;
+
+SET ROLE scan_err_user;
+-- Referencing the DuckLake table routes the whole query through DuckDB, which
+-- reads scan_err_heap back out of Postgres.
+SELECT a FROM scan_err_heap, scan_err_lake;
+-- count(*) reaches the same frame via GetNextCount/GetNextTuple rather than the
+-- batched GetNextInProcessTuples path, so a different caller guards it.
+SELECT count(*) FROM scan_err_heap, scan_err_lake;
+RESET ROLE;
+
+-- Must match the baseline above.
+SET max_stack_depth = '100kB';
+SELECT 1 AS shallow;
+DO $$ BEGIN EXECUTE format('SELECT %s1%s', repeat('abs(', 2000), repeat(')', 2000)); END $$;
+RESET max_stack_depth;
+
+\set VERBOSITY default
+
+DROP TABLE scan_err_lake;
+DROP TABLE scan_err_heap;
+REVOKE ALL ON ALL TABLES IN SCHEMA ducklake FROM scan_err_user;
+REVOKE ALL ON ALL SEQUENCES IN SCHEMA ducklake FROM scan_err_user;
+DROP USER scan_err_user;


### PR DESCRIPTION
Closes #248.

### Problem

PostgreSQL propagates errors with `siglongjmp`, which does not run C++ destructors. `PostgresFunctionGuard` / `PostgresMemberGuard` turn an `ereport` into a C++ throw so unwinding is normal, but a guard's `sigsetjmp` lives in its own frame: RAII objects in frames *between* the guard and the throw site are still skipped. Three sites in `libpgduckdb/scan/` relied on a caller's guard and so held state across an unguarded PG call: `ExecProcNode`, the tuple-queue reads, and `index_open` in the ORDER BY pushdown optimizer. The held objects, symptoms and frames are in the issue.

### Fix

Guard a batch, not a tuple. Two of the three sites are per-tuple, and the obvious fix there -- guarding the throwing call itself -- measured as a 27% regression on an in-process 10M-row scan: a guard costs a `sigsetjmp` and, for `PostgresFunctionGuard`, a recursive re-acquire of `GlobalProcessLock` that the scan function already holds. So the RAII object moves above the caller's existing per-batch guard instead -- where `Init` and `Cleanup` already put it. Site 3 runs once per plan, not per tuple, and is guarded directly.

One API change: `GetNextMinimalWorkerTuple` becomes `GetNextMinimalWorkerTuples` -- a public method on `PostgresTableReader`, with one caller. The EOF contract moves with it, from the callee signalling per tuple to the caller deriving `exhausted_scan` from `count < max`.

### Behaviour change

None visible. The reporting guard is still the caller's, so error text is unchanged and no existing expected output moves.

### Verification

`scan_error_unwind` covers site 1 through both of its callers (batched, and `count(*)` via `GetNextCount`), and is red on an unpatched build, where the session is poisoned badly enough that even teardown fails at the default `max_stack_depth`. It asserts on those probes and not on error text, which is byte-identical between a fixed and a broken build -- pinning the message would remove the only signal.

`optimizer_lock_error` covers site 3. A regression there does not produce a diff -- it hangs for ~10 minutes and leaves a backend that needs SIGKILL.

Site 2 has no test: `regression.conf` disables parallel workers for the macOS hang. Verified by hand instead -- two workers, and 1000003 rows through a partial final batch returning count/sum/min/max that match the Postgres-side values.

Batched guards land inside run-to-run noise (medians, 10M-row scan: in-process 725ms unpatched vs 712ms batched; parallel 913 vs 935).

### Not in this PR

- A test for site 2: blocked on the macOS parallel-worker hang, and no SQL-reachable trigger exists for that site anyway. It is hardening, not a live defect; the issue says why.
- The parallel scan path's behaviour *after* an error: with `max_parallel_workers > 0` the leader hangs in `ExecParallelFinish`, and cancelling that hang aborts the backend out of `~PostgresTableReader`. Both predate this change and reproduce identically on `main`, and `regression.conf` sets `max_parallel_workers = 0`, so the suite sees neither.
- The upstream half. Sites 1 and 2 exist in `duckdb/pg_duckdb`; tracked separately.

- [x] This PR has been reviewed by human.
- [x] This PR description has been reviewed by human.