### PR TITLE
fix: forward same-transaction DROP to DuckDB

### DIFF
--- a/pg_ducklake/src/ducklake_table.cpp
+++ b/pg_ducklake/src/ducklake_table.cpp
@@ -16,6 +16,10 @@
 #include "pgddb/pgddb_table_am.hpp"
 
 #include <common/ducklake_types.hpp>
+#include <duckdb/catalog/catalog.hpp>
+#include <duckdb/catalog/catalog_entry.hpp>
+#include <duckdb/catalog/catalog_entry/schema_catalog_entry.hpp>
+#include <duckdb/catalog/entry_lookup_info.hpp>
 #include <duckdb/common/string_util.hpp>
 #include <duckdb/parser/keyword_helper.hpp>
 
@@ -633,6 +637,35 @@ DECLARE_PG_FUNCTION(ducklake_create_table_trigger) {
 	PG_RETURN_NULL();
 }
 
+/*
+ * ducklake_table rows are only written at PRE_COMMIT, so a table created
+ * earlier in this transaction is invisible to the metadata lookup. DuckDB's
+ * catalog does see it, but throws rather than returning null unless a DuckDB
+ * transaction is open.
+ */
+static bool
+DropTargetLivesInDuckDBCatalog(const char *schema_name, const char *table_name) {
+	if (!pgducklake::DuckDBManager::IsInitialized())
+		return false;
+
+	auto *connection = pgducklake::DuckDBManager::Get().GetConnectionUnsafe();
+	if (!connection || !connection->context->transaction.HasActiveTransaction())
+		return false;
+
+	auto &context = *connection->context;
+	std::string schema_str(schema_name);
+	std::string table_str(table_name);
+
+	duckdb::EntryLookupInfo lookup(duckdb::CatalogType::TABLE_ENTRY, table_str, duckdb::QueryErrorContext());
+	auto entry = duckdb::Catalog::GetEntry(context, PGDUCKLAKE_DUCKDB_CATALOG, schema_str, lookup,
+	                                       duckdb::OnEntryNotFound::RETURN_NULL);
+
+	/* DuckDB matches names case-insensitively, the metadata lookup does not --
+	 * without this, dropping heap table "FOO" or "PUBLIC".foo destroys DuckLake
+	 * table public.foo. */
+	return entry && entry->name == table_str && entry->ParentSchema().name == schema_str;
+}
+
 DECLARE_PG_FUNCTION(ducklake_drop_table_trigger) {
 	if (pgducklake::syncing_from_metadata)
 		PG_RETURN_NULL();
@@ -645,16 +678,19 @@ DECLARE_PG_FUNCTION(ducklake_drop_table_trigger) {
 
 	/* Can't use pg_class here: the tables are already dropped. */
 	int ret = SPI_exec(R"(
-		SELECT cmds.schema_name, cmds.object_name
+		SELECT cmds.schema_name, cmds.object_name,
+		       EXISTS (
+		         SELECT 1
+		         FROM ducklake.ducklake_table AS tbl
+		         JOIN ducklake.ducklake_schema AS schema
+		           ON tbl.schema_id = schema.schema_id
+		         WHERE tbl.table_name = cmds.object_name
+		           AND schema.schema_name = cmds.schema_name
+		           AND tbl.end_snapshot IS NULL
+		           AND schema.end_snapshot IS NULL
+		       ) AS in_metadata
 		FROM pg_catalog.pg_event_trigger_dropped_objects() cmds
-		JOIN ducklake.ducklake_table AS tbl
-		  ON cmds.object_name = tbl.table_name
-		JOIN ducklake.ducklake_schema AS schema
-		  ON cmds.schema_name = schema.schema_name
-		  AND tbl.schema_id = schema.schema_id
 		WHERE cmds.object_type = 'table'
-		  AND tbl.end_snapshot IS NULL
-		  AND schema.end_snapshot IS NULL
 		)",
 	                   0);
 
@@ -667,6 +703,11 @@ DECLARE_PG_FUNCTION(ducklake_drop_table_trigger) {
 
 		char *schema_name = SPI_getvalue(tuple, SPI_tuptable->tupdesc, 1);
 		char *table_name = SPI_getvalue(tuple, SPI_tuptable->tupdesc, 2);
+		char *in_metadata = SPI_getvalue(tuple, SPI_tuptable->tupdesc, 3);
+
+		bool is_ducklake_table = in_metadata != nullptr && in_metadata[0] == 't';
+		if (!is_ducklake_table && !DropTargetLivesInDuckDBCatalog(schema_name, table_name))
+			continue;
 
 		std::string drop_ddl =
 		    duckdb::StringUtil::Format("DROP TABLE IF EXISTS " PGDUCKLAKE_DUCKDB_CATALOG ".%s.%s",

--- a/pg_ducklake/src/ducklake_table.cpp
+++ b/pg_ducklake/src/ducklake_table.cpp
@@ -703,9 +703,11 @@ DECLARE_PG_FUNCTION(ducklake_drop_table_trigger) {
 
 		char *schema_name = SPI_getvalue(tuple, SPI_tuptable->tupdesc, 1);
 		char *table_name = SPI_getvalue(tuple, SPI_tuptable->tupdesc, 2);
-		char *in_metadata = SPI_getvalue(tuple, SPI_tuptable->tupdesc, 3);
 
-		bool is_ducklake_table = in_metadata != nullptr && in_metadata[0] == 't';
+		bool isnull;
+		Datum in_metadata_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 3, &isnull);
+
+		bool is_ducklake_table = !isnull && DatumGetBool(in_metadata_datum);
 		if (!is_ducklake_table && !DropTargetLivesInDuckDBCatalog(schema_name, table_name))
 			continue;
 

--- a/pg_ducklake/test/regression/expected/same_txn_create_drop.out
+++ b/pg_ducklake/test/regression/expected/same_txn_create_drop.out
@@ -1,0 +1,226 @@
+-- Scheduled last: until the drop is forwarded this test strands DuckLake
+-- tables, which fails unrelated tests from any earlier slot.
+BEGIN;
+CREATE TABLE sx_t (a int) USING ducklake;
+INSERT INTO sx_t VALUES (7), (8);
+DROP TABLE sx_t;
+COMMIT;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_t' AND end_snapshot IS NULL;
+ live_rows 
+-----------
+         0
+(1 row)
+
+CREATE TABLE sx_t (a int) USING ducklake;
+INSERT INTO sx_t VALUES (99);
+SELECT * FROM sx_t ORDER BY a;
+ a  
+----
+ 99
+(1 row)
+
+DROP TABLE sx_t;
+-- CTAS creates through the direct-insert writer, not the plain CREATE path.
+BEGIN;
+CREATE TABLE sx_ctas USING ducklake AS SELECT g AS a FROM generate_series(1, 3) g;
+DROP TABLE sx_ctas;
+COMMIT;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_ctas' AND end_snapshot IS NULL;
+ live_rows 
+-----------
+         0
+(1 row)
+
+-- The second CREATE only succeeds if the DROP actually reached DuckDB.
+BEGIN;
+CREATE TABLE sx_again (a int) USING ducklake;
+INSERT INTO sx_again VALUES (1);
+DROP TABLE sx_again;
+CREATE TABLE sx_again (b text) USING ducklake;
+INSERT INTO sx_again VALUES ('x');
+COMMIT;
+SELECT * FROM sx_again;
+ b 
+---
+ x
+(1 row)
+
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_again' AND end_snapshot IS NULL;
+ live_rows 
+-----------
+         1
+(1 row)
+
+DROP TABLE sx_again;
+CREATE TABLE sx_later (a int) USING ducklake;
+DROP TABLE sx_later;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_later' AND end_snapshot IS NULL;
+ live_rows 
+-----------
+         0
+(1 row)
+
+CREATE TABLE sx_heap (a int);
+DROP TABLE sx_heap;
+SELECT count(*) AS dl_rows FROM ducklake.ducklake_table WHERE table_name = 'sx_heap';
+ dl_rows 
+---------
+       0
+(1 row)
+
+-- recycle_ddb reproduces a fresh backend: DuckDB uninitialized, so only the
+-- metadata lookup can carry this drop.
+CREATE TABLE sx_fresh (a int) USING ducklake;
+CALL ducklake.recycle_ddb();
+DROP TABLE sx_fresh;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_fresh' AND end_snapshot IS NULL;
+ live_rows 
+-----------
+         0
+(1 row)
+
+-- DuckDB matches names case-insensitively, the metadata lookup does not.
+BEGIN;
+CREATE TABLE sx_case (a int) USING ducklake;
+INSERT INTO sx_case VALUES (1), (2);
+CREATE TABLE "SX_CASE" (a int);
+DROP TABLE "SX_CASE";
+COMMIT;
+SELECT * FROM sx_case ORDER BY a;
+ a 
+---
+ 1
+ 2
+(2 rows)
+
+DROP TABLE sx_case;
+-- Same hole one level up: the schema name is resolved case-insensitively too.
+CREATE TABLE sx_sch (a int) USING ducklake;
+INSERT INTO sx_sch VALUES (1), (2);
+CREATE SCHEMA "PUBLIC";
+CREATE TABLE "PUBLIC".sx_sch (a int);
+BEGIN;
+INSERT INTO sx_sch VALUES (3);
+DROP TABLE "PUBLIC".sx_sch;
+COMMIT;
+SELECT * FROM sx_sch ORDER BY a;
+ a 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+DROP TABLE sx_sch;
+DROP SCHEMA "PUBLIC";
+BEGIN;
+CREATE TABLE sx_rb (a int) USING ducklake;
+DROP TABLE sx_rb;
+ROLLBACK;
+SELECT count(*) AS rows_left FROM ducklake.ducklake_table WHERE table_name = 'sx_rb';
+ rows_left 
+-----------
+         0
+(1 row)
+
+BEGIN;
+CREATE TABLE sx_m1 (a int) USING ducklake;
+CREATE TABLE sx_m2 (a int) USING ducklake;
+DROP TABLE sx_m1, sx_m2;
+COMMIT;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name IN ('sx_m1', 'sx_m2') AND end_snapshot IS NULL;
+ live_rows 
+-----------
+         0
+(1 row)
+
+BEGIN;
+CREATE SCHEMA sx_s;
+CREATE TABLE sx_s.sx_c (a int) USING ducklake;
+DROP SCHEMA sx_s CASCADE;
+NOTICE:  drop cascades to table sx_s.sx_c
+COMMIT;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_c' AND end_snapshot IS NULL;
+ live_rows 
+-----------
+         0
+(1 row)
+
+-- Rows under the inlining limit never reach parquet, so the file-backed drop
+-- needs a table large enough to flush.
+BEGIN;
+CREATE TABLE sx_files (a int) USING ducklake;
+INSERT INTO sx_files SELECT g FROM generate_series(1, 50) g;
+DROP TABLE sx_files;
+COMMIT;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_files' AND end_snapshot IS NULL;
+ live_rows 
+-----------
+         0
+(1 row)
+
+SELECT count(*) AS live_files FROM ducklake.ducklake_data_file f
+JOIN ducklake.ducklake_table t ON f.table_id = t.table_id
+WHERE t.table_name = 'sx_files' AND f.end_snapshot IS NULL;
+ live_files 
+------------
+          0
+(1 row)
+
+-- The fallback resolves whatever name the DROP used, so a same-transaction
+-- rename has to have reached DuckDB first.
+BEGIN;
+CREATE TABLE sx_ren (a int) USING ducklake;
+INSERT INTO sx_ren VALUES (1);
+ALTER TABLE sx_ren RENAME TO sx_ren2;
+DROP TABLE sx_ren2;
+COMMIT;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name IN ('sx_ren', 'sx_ren2') AND end_snapshot IS NULL;
+ live_rows 
+-----------
+         0
+(1 row)
+
+CREATE SCHEMA sx_other;
+CREATE TABLE sx_other.sx_dup (a int) USING ducklake;
+INSERT INTO sx_other.sx_dup VALUES (1), (2);
+BEGIN;
+CREATE TABLE sx_dup (a int) USING ducklake;
+INSERT INTO sx_dup VALUES (9);
+DROP TABLE sx_dup;
+COMMIT;
+SELECT * FROM sx_other.sx_dup ORDER BY a;
+ a 
+---
+ 1
+ 2
+(2 rows)
+
+DROP TABLE sx_other.sx_dup;
+DROP SCHEMA sx_other;
+-- An unqualified DROP resolves to pg_temp ahead of public.
+CREATE TABLE sx_tmp (a int) USING ducklake;
+INSERT INTO sx_tmp VALUES (1), (2);
+BEGIN;
+INSERT INTO sx_tmp VALUES (3);
+CREATE TEMP TABLE sx_tmp (a int);
+DROP TABLE sx_tmp;
+COMMIT;
+SELECT * FROM public.sx_tmp ORDER BY a;
+ a 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+DROP TABLE public.sx_tmp;

--- a/pg_ducklake/test/regression/schedule
+++ b/pg_ducklake/test/regression/schedule
@@ -59,3 +59,4 @@ test: quoted_names
 test: create_view_shapes
 test: parallel_mode_metadata
 test: scan_error_unwind
+test: same_txn_create_drop

--- a/pg_ducklake/test/regression/sql/same_txn_create_drop.sql
+++ b/pg_ducklake/test/regression/sql/same_txn_create_drop.sql
@@ -1,0 +1,145 @@
+-- Scheduled last: until the drop is forwarded this test strands DuckLake
+-- tables, which fails unrelated tests from any earlier slot.
+BEGIN;
+CREATE TABLE sx_t (a int) USING ducklake;
+INSERT INTO sx_t VALUES (7), (8);
+DROP TABLE sx_t;
+COMMIT;
+
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_t' AND end_snapshot IS NULL;
+
+CREATE TABLE sx_t (a int) USING ducklake;
+INSERT INTO sx_t VALUES (99);
+SELECT * FROM sx_t ORDER BY a;
+DROP TABLE sx_t;
+
+-- CTAS creates through the direct-insert writer, not the plain CREATE path.
+BEGIN;
+CREATE TABLE sx_ctas USING ducklake AS SELECT g AS a FROM generate_series(1, 3) g;
+DROP TABLE sx_ctas;
+COMMIT;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_ctas' AND end_snapshot IS NULL;
+
+-- The second CREATE only succeeds if the DROP actually reached DuckDB.
+BEGIN;
+CREATE TABLE sx_again (a int) USING ducklake;
+INSERT INTO sx_again VALUES (1);
+DROP TABLE sx_again;
+CREATE TABLE sx_again (b text) USING ducklake;
+INSERT INTO sx_again VALUES ('x');
+COMMIT;
+SELECT * FROM sx_again;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_again' AND end_snapshot IS NULL;
+DROP TABLE sx_again;
+
+CREATE TABLE sx_later (a int) USING ducklake;
+DROP TABLE sx_later;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_later' AND end_snapshot IS NULL;
+
+CREATE TABLE sx_heap (a int);
+DROP TABLE sx_heap;
+SELECT count(*) AS dl_rows FROM ducklake.ducklake_table WHERE table_name = 'sx_heap';
+
+-- recycle_ddb reproduces a fresh backend: DuckDB uninitialized, so only the
+-- metadata lookup can carry this drop.
+CREATE TABLE sx_fresh (a int) USING ducklake;
+CALL ducklake.recycle_ddb();
+DROP TABLE sx_fresh;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_fresh' AND end_snapshot IS NULL;
+
+-- DuckDB matches names case-insensitively, the metadata lookup does not.
+BEGIN;
+CREATE TABLE sx_case (a int) USING ducklake;
+INSERT INTO sx_case VALUES (1), (2);
+CREATE TABLE "SX_CASE" (a int);
+DROP TABLE "SX_CASE";
+COMMIT;
+SELECT * FROM sx_case ORDER BY a;
+DROP TABLE sx_case;
+
+-- Same hole one level up: the schema name is resolved case-insensitively too.
+CREATE TABLE sx_sch (a int) USING ducklake;
+INSERT INTO sx_sch VALUES (1), (2);
+CREATE SCHEMA "PUBLIC";
+CREATE TABLE "PUBLIC".sx_sch (a int);
+BEGIN;
+INSERT INTO sx_sch VALUES (3);
+DROP TABLE "PUBLIC".sx_sch;
+COMMIT;
+SELECT * FROM sx_sch ORDER BY a;
+DROP TABLE sx_sch;
+DROP SCHEMA "PUBLIC";
+
+BEGIN;
+CREATE TABLE sx_rb (a int) USING ducklake;
+DROP TABLE sx_rb;
+ROLLBACK;
+SELECT count(*) AS rows_left FROM ducklake.ducklake_table WHERE table_name = 'sx_rb';
+
+BEGIN;
+CREATE TABLE sx_m1 (a int) USING ducklake;
+CREATE TABLE sx_m2 (a int) USING ducklake;
+DROP TABLE sx_m1, sx_m2;
+COMMIT;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name IN ('sx_m1', 'sx_m2') AND end_snapshot IS NULL;
+
+BEGIN;
+CREATE SCHEMA sx_s;
+CREATE TABLE sx_s.sx_c (a int) USING ducklake;
+DROP SCHEMA sx_s CASCADE;
+COMMIT;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_c' AND end_snapshot IS NULL;
+
+-- Rows under the inlining limit never reach parquet, so the file-backed drop
+-- needs a table large enough to flush.
+BEGIN;
+CREATE TABLE sx_files (a int) USING ducklake;
+INSERT INTO sx_files SELECT g FROM generate_series(1, 50) g;
+DROP TABLE sx_files;
+COMMIT;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name = 'sx_files' AND end_snapshot IS NULL;
+SELECT count(*) AS live_files FROM ducklake.ducklake_data_file f
+JOIN ducklake.ducklake_table t ON f.table_id = t.table_id
+WHERE t.table_name = 'sx_files' AND f.end_snapshot IS NULL;
+
+-- The fallback resolves whatever name the DROP used, so a same-transaction
+-- rename has to have reached DuckDB first.
+BEGIN;
+CREATE TABLE sx_ren (a int) USING ducklake;
+INSERT INTO sx_ren VALUES (1);
+ALTER TABLE sx_ren RENAME TO sx_ren2;
+DROP TABLE sx_ren2;
+COMMIT;
+SELECT count(*) AS live_rows FROM ducklake.ducklake_table
+WHERE table_name IN ('sx_ren', 'sx_ren2') AND end_snapshot IS NULL;
+
+CREATE SCHEMA sx_other;
+CREATE TABLE sx_other.sx_dup (a int) USING ducklake;
+INSERT INTO sx_other.sx_dup VALUES (1), (2);
+BEGIN;
+CREATE TABLE sx_dup (a int) USING ducklake;
+INSERT INTO sx_dup VALUES (9);
+DROP TABLE sx_dup;
+COMMIT;
+SELECT * FROM sx_other.sx_dup ORDER BY a;
+DROP TABLE sx_other.sx_dup;
+DROP SCHEMA sx_other;
+
+-- An unqualified DROP resolves to pg_temp ahead of public.
+CREATE TABLE sx_tmp (a int) USING ducklake;
+INSERT INTO sx_tmp VALUES (1), (2);
+BEGIN;
+INSERT INTO sx_tmp VALUES (3);
+CREATE TEMP TABLE sx_tmp (a int);
+DROP TABLE sx_tmp;
+COMMIT;
+SELECT * FROM public.sx_tmp ORDER BY a;
+DROP TABLE public.sx_tmp;


### PR DESCRIPTION
Closes #253 .

### Problem

Creating a DuckLake table and dropping it in one transaction commits the `CREATE` and silently loses the `DROP`. What is left behind is a live `ducklake_table` row with no PostgreSQL relation: the name can be neither reused nor dropped, the rows are still served to every DuckLake reader of the catalog, and `ducklake.flush_inlined_data()` will write fresh parquet for a table nobody can see.

`BEGIN; CREATE; ...; DROP; COMMIT` is an ordinary migration shape, and a multi-statement `psql -c` hits it too since that is one implicit transaction.

The `sql_drop` trigger decides whether a dropped relation was a DuckLake table from `ducklake.ducklake_table`, which is not written until `PRE_COMMIT` -- so mid-transaction there is no row to match.

### Why this shape

Three decisions that are not visible in the diff:

- **The metadata lookup stays the primary decision.** Replacing it outright with the catalog lookup regresses the committed case, because a fresh backend dropping an already-committed DuckLake table relies on the drop itself to initialize DuckDB.
- **The fallback is gated on an active DuckDB transaction.** Without one `GetEntry` throws rather than returning null, so that gate is load-bearing rather than defensive.
- **It compares the resolved entry's schema *and* table name.** DuckDB's catalog folds case and the metadata lookup does not, so an unguarded fallback lets `DROP TABLE "FOO"` -- or `DROP TABLE "PUBLIC".foo` -- destroy DuckLake table `public.foo`.

### Cost

DDL only. A dropped relation the metadata lookup does not match costs one in-process catalog lookup, and only when a DuckDB transaction is already open. Measured: neither `DROP TABLE heap_t;` nor `BEGIN; DROP TABLE ducklake_t; COMMIT;` has an active DuckDB transaction at `sql_drop` time, so neither pays anything.

### Notes for reviewers

The new test is scheduled last deliberately. While the bug is present it strands DuckLake tables, and from an earlier slot that cascades into four unrelated failures.

Reproducing by hand: a `DROP TABLE` in autocommit does not exercise the new path at all. Only a drop inside a transaction that has already touched a DuckLake table reaches the fallback.

This stops new orphans; it does not clean up catalogs that already have them.

- [x] This PR has been reviewed by human.
- [x] This PR description has been reviewed by human.