### PR TITLE
refactor: read the nulls_allowed column via SPI_getbinval

### DIFF
--- a/pg_ducklake/src/ducklake_table.cpp
+++ b/pg_ducklake/src/ducklake_table.cpp
@@ -978,8 +978,10 @@ SyncNewTables(const char *sid) {
 		ci.col_name = v ? v : "";
 		v = SPI_getvalue(tup, td, 4);
 		ci.col_type = v ? v : "";
-		v = SPI_getvalue(tup, td, 5);
-		ci.not_null = (v && strcmp(v, "f") == 0);
+
+		bool isnull;
+		Datum nulls_allowed_datum = SPI_getbinval(tup, td, 5, &isnull);
+		ci.not_null = !isnull && !DatumGetBool(nulls_allowed_datum);
 		cols.push_back(std::move(ci));
 	}
 


### PR DESCRIPTION
Follow-up to the review comment on #254 -- `SyncNewTables` was the last site reading a `BOOLEAN` (`ducklake_column.nulls_allowed`) with `SPI_getvalue` and recovering the value by comparing the rendered text against `"f"`.

No behavior change; `boolout` only ever emits `t/f`. The improvement is that the polarity becomes visible -- `not_null` is the negation of `nulls_allowed` -- and drops the dependency on a type's output format.

No new test: `metadata_sync` already asserts `attnotnull` for both a nullable and a `NOT NULL` column, and inverting the polarity locally turns it red.

- [x] This PR has been reviewed by human.
- [x] This PR description has been reviewed by human.