### PR TITLE
test: terminate expected-to-fail COPY FROM STDIN cases

### DIFF
--- a/pg_ducklake/test/regression/expected/copy_from_1.out
+++ b/pg_ducklake/test/regression/expected/copy_from_1.out
@@ -78,6 +78,8 @@ DROP TABLE copy_defaults;
 -- skipped COPY data. Older psql rejects it instead, hence copy_from_1.out.
 COPY copy_stdin FROM STDIN WITH (FREEZE true);
 ERROR:  COPY FROM STDIN with FREEZE is not supported for DuckLake tables
+\.
+invalid command \.
 SELECT count(*) FROM copy_stdin;
  count 
 -------
@@ -86,6 +88,8 @@ SELECT count(*) FROM copy_stdin;
 
 COPY copy_stdin FROM STDIN WITH (ON_ERROR ignore);
 ERROR:  COPY FROM STDIN with ON_ERROR is not supported for DuckLake tables
+\.
+invalid command \.
 SELECT count(*) FROM copy_stdin;
  count 
 -------

--- a/pg_ducklake/test/regression/sql/copy_from.sql
+++ b/pg_ducklake/test/regression/sql/copy_from.sql
@@ -59,9 +59,13 @@ SELECT * FROM copy_defaults ORDER BY id;
 DROP TABLE copy_defaults;
 
 -- Unsupported COPY semantics must fail before COPY enters streaming mode.
+-- \. is required: without it newer psql consumes the rest of the file as
+-- skipped COPY data. Older psql rejects it instead, hence copy_from_1.out.
 COPY copy_stdin FROM STDIN WITH (FREEZE true);
+\.
 SELECT count(*) FROM copy_stdin;
 COPY copy_stdin FROM STDIN WITH (ON_ERROR ignore);
+\.
 SELECT count(*) FROM copy_stdin;
 
 DROP TABLE copy_stdin;


### PR DESCRIPTION
CI is red on every open PR since 2026-08-10. PostgreSQL backpatched `29921259` ("Teach psql to skip in-line COPY ... FROM STDIN data after a failure") to all stable branches, and CI builds PG from the branch tip.

Our two expected-to-fail COPYs have no in-line data and no `\.`, so psql now skips forward and eats the next ~20 lines, including a DROP TABLE. The leaked table then fails `frozen_fdw` and `import_foreign_schema`, which enumerate I`MPORT FOREIGN SCHEMA public` -- three red tests, one cause.

Adding `\.` keeps the rest of the file executing on both psql generations. Pre-fix psql reports it as an invalid command, so that output is kept as `copy_from_1.out`.


- [x] This PR has been reviewed by human.
- [x] This PR description has been reviewed by human.