### PR TITLE
fix: preserve catalog data path on attach

### DIFF
--- a/pg_ducklake/src/duckdb_manager.cpp
+++ b/pg_ducklake/src/duckdb_manager.cpp
@@ -55,15 +55,17 @@ ducklake_attach_catalog() {
 	duckdb::string query =
 	    "ATTACH 'ducklake:" PGDUCKLAKE_DUCKDB_CATALOG ":' AS " PGDUCKLAKE_DUCKDB_CATALOG
 	    "(METADATA_SCHEMA " PGDUCKLAKE_PG_SCHEMA_QUOTED ", METADATA_CATALOG " PGDUCKLAKE_DUCKDB_CATALOG;
-	/* First-time init: pass DATA_PATH so DuckLake stores it in catalog metadata. */
-	auto data_path = duckdb::StringUtil::Format("%s/pg_ducklake", DataDir);
-	try {
-		std::filesystem::create_directory(data_path);
-	} catch (const std::filesystem::filesystem_error &e) {
-		ereport(ERROR, (errcode(ERRCODE_IO_ERROR),
-		                errmsg("failed to create DuckLake data directory \"%s\": %s", data_path.c_str(), e.what())));
+	if (creating_extension) {
+		/* First-time init: pass DATA_PATH so DuckLake stores it in catalog metadata. */
+		auto data_path = duckdb::StringUtil::Format("%s/pg_ducklake", DataDir);
+		try {
+			std::filesystem::create_directory(data_path);
+		} catch (const std::filesystem::filesystem_error &e) {
+			ereport(ERROR, (errcode(ERRCODE_IO_ERROR), errmsg("failed to create DuckLake data directory \"%s\": %s",
+			                                                  data_path.c_str(), e.what())));
+		}
+		query += ", DATA_PATH '" + data_path + "'";
 	}
-	query += ", DATA_PATH '" + data_path + "'";
 	/* Subsequent ATTACHes omit DATA_PATH so DuckLake reads it from stored
 	 * metadata, avoiding mismatch if the path was changed (e.g. to an S3 bucket). */
 	query += ")";

--- a/pg_ducklake/test/regression/expected/recycle_ddb.out
+++ b/pg_ducklake/test/regression/expected/recycle_ddb.out
@@ -26,3 +26,34 @@ SELECT * FROM t ORDER BY a;
 (2 rows)
 
 DROP TABLE t;
+-- A catalog can store a non-default data path, for example after migration to
+-- S3. Reattaching must read that path instead of forcing the local default.
+CREATE TEMP TABLE original_ducklake_data_path AS
+SELECT value FROM ducklake.ducklake_metadata WHERE key = 'data_path';
+UPDATE ducklake.ducklake_metadata
+SET value = '/tmp/pg_ducklake_relocated/'
+WHERE key = 'data_path';
+-- Recycling exercises the same attach path as a fresh backend.
+CALL ducklake.recycle_ddb();
+SELECT value = '/tmp/pg_ducklake_relocated/' AS relocated_data_path
+FROM ducklake.options()
+WHERE option_name = 'data_path';
+ relocated_data_path 
+---------------------
+ t
+(1 row)
+
+UPDATE ducklake.ducklake_metadata
+SET value = (SELECT value FROM original_ducklake_data_path)
+WHERE key = 'data_path';
+CALL ducklake.recycle_ddb();
+SELECT options.value = original.value AS restored_data_path
+FROM ducklake.options() AS options
+CROSS JOIN original_ducklake_data_path AS original
+WHERE options.option_name = 'data_path';
+ restored_data_path 
+--------------------
+ t
+(1 row)
+
+DROP TABLE original_ducklake_data_path;

--- a/pg_ducklake/test/regression/sql/recycle_ddb.sql
+++ b/pg_ducklake/test/regression/sql/recycle_ddb.sql
@@ -14,3 +14,30 @@ INSERT INTO t VALUES (2, 'after');
 SELECT * FROM t ORDER BY a;
 
 DROP TABLE t;
+
+-- A catalog can store a non-default data path, for example after migration to
+-- S3. Reattaching must read that path instead of forcing the local default.
+CREATE TEMP TABLE original_ducklake_data_path AS
+SELECT value FROM ducklake.ducklake_metadata WHERE key = 'data_path';
+
+UPDATE ducklake.ducklake_metadata
+SET value = '/tmp/pg_ducklake_relocated/'
+WHERE key = 'data_path';
+
+-- Recycling exercises the same attach path as a fresh backend.
+CALL ducklake.recycle_ddb();
+SELECT value = '/tmp/pg_ducklake_relocated/' AS relocated_data_path
+FROM ducklake.options()
+WHERE option_name = 'data_path';
+
+UPDATE ducklake.ducklake_metadata
+SET value = (SELECT value FROM original_ducklake_data_path)
+WHERE key = 'data_path';
+CALL ducklake.recycle_ddb();
+
+SELECT options.value = original.value AS restored_data_path
+FROM ducklake.options() AS options
+CROSS JOIN original_ducklake_data_path AS original
+WHERE options.option_name = 'data_path';
+
+DROP TABLE original_ducklake_data_path;


### PR DESCRIPTION
DuckLake catalogs can store a data path that differs from the PostgreSQL-local default, such as after moving data to S3. Subsequent backend initialization currently passes the local `DATA_PATH` again, causing DuckLake to reject the attach because it conflicts with the catalog metadata.

Only pass `DATA_PATH` during `CREATE EXTENSION`; later attaches defer to the stored catalog value. The regression case changes the stored path, recycles DuckDB to exercise reattachment, verifies the relocated path, and restores the original value.

Fixes #258.

- [x] This PR has been reviewed by human.
- [x] This PR description has been reviewed by human.