### PR TITLE
fix: added ducklake.azure_transport_option_type as option

### DIFF
--- a/pg_ducklake/docs/settings.md
+++ b/pg_ducklake/docs/settings.md
@@ -11,6 +11,7 @@ Use `SELECT * FROM ducklake.options()` to list all DuckLake catalog options and 
 
 | Name | Default | Access |
 | :--- | :------ | :----- |
+| [`ducklake.azure_transport_option_type`](#ducklakeazure_transport_option_type) | `""` | Superuser-only |
 | [`ducklake.default_table_path`](#ducklakedefault_table_path) | `""` | Per-session |
 | [`ducklake.enable_direct_insert`](#ducklakeenable_direct_insert) | `true` | Per-session |
 | [`ducklake.enable_metadata_sync`](#ducklakeenable_metadata_sync) | `true` | Per-session |
@@ -61,6 +62,13 @@ Every option can be scoped global, schema, or table (most specific wins).
 ## Detailed Descriptions
 
 ### PostgreSQL GUCs
+
+### `ducklake.azure_transport_option_type`
+
+Sets the `azure_transport_option_type` setting for the DuckDB Azure extension. Set it to `'curl'` to work around [issue #882](https://github.com/duckdb/pg_duckdb/issues/882). The setting only affects connections when the Azure extension is loaded.
+
+- **Default**: `""` (empty string)
+- **Access**: Superuser-only
 
 ### `ducklake.default_table_path`
 

--- a/pg_ducklake/include/pgducklake/guc.hpp
+++ b/pg_ducklake/include/pgducklake/guc.hpp
@@ -3,6 +3,7 @@
 namespace pgducklake {
 
 extern char *default_table_path;
+extern char *azure_transport_option_type;
 extern double vacuum_delete_threshold;
 extern bool enable_direct_insert;
 extern bool ctas_skip_data;

--- a/pg_ducklake/src/duckdb_manager.cpp
+++ b/pg_ducklake/src/duckdb_manager.cpp
@@ -139,6 +139,11 @@ DuckDBManager::RefreshConnectionState(duckdb::ClientContext &context) {
 		}
 	}
 
+	if (azure_transport_option_type && azure_transport_option_type[0] != '\0' && database->ExtensionIsLoaded("azure")) {
+		DuckDBQueryOrThrow(context, "SET azure_transport_option_type = " +
+		                                duckdb::KeywordHelper::WriteQuoted(azure_transport_option_type));
+	}
+
 	// Re-emit S3/Azure secrets from the catalog when a SERVER/USER MAPPING changed.
 	if (!secrets_valid_) {
 		DropSecrets(context);

--- a/pg_ducklake/src/guc.cpp
+++ b/pg_ducklake/src/guc.cpp
@@ -10,6 +10,7 @@ extern "C" {
 namespace pgducklake {
 
 char *default_table_path = strdup("");
+char *azure_transport_option_type = strdup("");
 double vacuum_delete_threshold = 0.1;
 bool enable_direct_insert = true;
 bool ctas_skip_data = false;
@@ -55,6 +56,11 @@ InitGUCs() {
 	                           "Default directory path for DuckLake tables. If set, tables will be "
 	                           "created under this path.",
 	                           NULL, &default_table_path, "", PGC_USERSET, 0, NULL, NULL, NULL);
+
+	DefineCustomStringVariable("ducklake.azure_transport_option_type",
+	                           "Set the azure_transport_option_type for DuckDB Azure extension. Can be used to "
+	                           "work around issue #882: https://github.com/duckdb/pg_duckdb/issues/882",
+	                           NULL, &azure_transport_option_type, "", PGC_SUSET, 0, NULL, NULL, NULL);
 
 	DefineCustomRealVariable("ducklake.vacuum_delete_threshold",
 	                         "Minimum fraction of deleted rows (0.0-1.0) before VACUUM rewrites a "

--- a/pg_ducklake/test/regression/expected/gucs.out
+++ b/pg_ducklake/test/regression/expected/gucs.out
@@ -1,4 +1,10 @@
 -- Test DuckLake GUCs
+SHOW ducklake.azure_transport_option_type;
+ ducklake.azure_transport_option_type 
+--------------------------------------
+ 
+(1 row)
+
 SHOW ducklake.default_table_path;
  ducklake.default_table_path 
 -----------------------------
@@ -60,6 +66,20 @@ SHOW ducklake.threads;
 (1 row)
 
 -- Test setting GUCs
+SET ducklake.azure_transport_option_type = 'curl';
+SHOW ducklake.azure_transport_option_type;
+ ducklake.azure_transport_option_type 
+--------------------------------------
+ curl
+(1 row)
+
+RESET ducklake.azure_transport_option_type;
+SHOW ducklake.azure_transport_option_type;
+ ducklake.azure_transport_option_type 
+--------------------------------------
+ 
+(1 row)
+
 SET ducklake.default_table_path = '/tmp/test_path';
 SHOW ducklake.default_table_path;
  ducklake.default_table_path 

--- a/pg_ducklake/test/regression/sql/gucs.sql
+++ b/pg_ducklake/test/regression/sql/gucs.sql
@@ -1,4 +1,5 @@
 -- Test DuckLake GUCs
+SHOW ducklake.azure_transport_option_type;
 SHOW ducklake.default_table_path;
 SHOW ducklake.vacuum_delete_threshold;
 SHOW ducklake.enable_direct_insert;
@@ -11,6 +12,11 @@ SHOW ducklake.native_writer_retry_backoff;
 SHOW ducklake.threads;
 
 -- Test setting GUCs
+SET ducklake.azure_transport_option_type = 'curl';
+SHOW ducklake.azure_transport_option_type;
+RESET ducklake.azure_transport_option_type;
+SHOW ducklake.azure_transport_option_type;
+
 SET ducklake.default_table_path = '/tmp/test_path';
 SHOW ducklake.default_table_path;
 RESET ducklake.default_table_path;


### PR DESCRIPTION
fixes: https://github.com/relytcloud/pg_ducklake/issues/261

This was all done by whatever model gh copilot picked. I looked at what it did but, honestly, I really don't know c++ enough to be a good judge of it. What I did do was compile and test it on pg18 locally.

I was able to

```sql
SELECT ducklake.raw_query('INSTALL azure');
SELECT ducklake.raw_query('LOAD azure');
SELECT ducklake.create_azure_secret('secret');
SET ducklake.default_table_path = 'azure://ducklake/';
SELECT ducklake.raw_query($$SET azure_transport_option_type = 'curl'$$);
CREATE TABLE my_table (
    id INT,
    name TEXT,
    age INT
)
USING ducklake;

INSERT INTO my_table VALUES (5, 'AliceRgg', 25550), (6, 'BggobR', 31100);
SELECT * FROM ducklake.flush_inlined_data('my_table'::regclass);
```

exit out of psql, modify postgresql.conf with 
```text
ducklake.azure_transport_option_type='curl'
```
```bash
sudo systemctl restart postgresql
```
then back into psql and successfully did
```sql
SELECT * FROM ducklake.flush_inlined_data('my_table'::regclass);
```
without manually having to redo`SELECT ducklake.raw_query($$SET azure_transport_option_type = 'curl'$$);`


- [x] This PR has been reviewed by human.
- [x] This PR description has been reviewed by human.